### PR TITLE
Quickfix: Todo task order

### DIFF
--- a/components/actions/TaskList.js
+++ b/components/actions/TaskList.js
@@ -50,15 +50,14 @@ function TaskList(props) {
       return moment(adate).diff(moment(bdate));
     });
 
-  const doneTasks = sortedTasks
-    .reverse()
-    .filter((item) => item.completedAt !== null)
+  const undoneTasks = sortedTasks
+    .filter((item) => item.completedAt === null)
     .map((item) => (
       <ListGroupItem key={item.id} className={`state--${item.state}`}>
         <TaskWrapper>
           <TaskMeta>
-            <Icon name="check" className="text-black-50 mr-2" alt={t('action-task-done')} />
-            <Date>{parseTimestamp(item.completedAt)}</Date>
+            <Icon name="calendar" className="text-black-50 mr-2" alt={t('action-task-todo')} />
+            <Date>{parseTimestamp(item.dueAt)}</Date>
           </TaskMeta>
           <TaskContent>
             <h6>{item.name}</h6>
@@ -72,14 +71,15 @@ function TaskList(props) {
       </ListGroupItem>
     ));
 
-  const undoneTasks = sortedTasks
-    .filter((item) => item.completedAt === null)
+  const doneTasks = sortedTasks
+    .reverse()
+    .filter((item) => item.completedAt !== null)
     .map((item) => (
       <ListGroupItem key={item.id} className={`state--${item.state}`}>
         <TaskWrapper>
           <TaskMeta>
-            <Icon name="calendar" className="text-black-50 mr-2" alt={t('action-task-todo')} />
-            <Date>{parseTimestamp(item.dueAt)}</Date>
+            <Icon name="check" className="text-black-50 mr-2" alt={t('action-task-done')} />
+            <Date>{parseTimestamp(item.completedAt)}</Date>
           </TaskMeta>
           <TaskContent>
             <h6>{item.name}</h6>


### PR DESCRIPTION
Todo task order ends up wrong due to reverse() being in-place method. Switch the order of generating the arrays.