### PR TITLE
Add support for Node.js 15.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "url": ""
   },
   "engines": {
-    "node": "14.x"
+    "node": "14.x || 15.x"
   },
   "browserslist": [
     "> 1%",


### PR DESCRIPTION
Currently Node.js is required to be version 14.x. I added 15.x.