### PR TITLE
Migrate to new static page model

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -21,10 +21,10 @@ function Footer(props) {
   navLinks.push({ id: '2', name: t('actions'), slug: 'actions' });
   navLinks.push({ id: '3', name: t('indicators'), slug: 'indicators' });
 
-  if (plan.staticPages) {
-    const topMenuPages = plan.staticPages.filter((page) => page.footer);
-    staticPages = topMenuPages.map((page, index) => (
-      { id: `s${index}`, name: page.name, slug: page.slug }
+  if (plan.pages) {
+    const footerPages = plan.pages.filter((page) => page.showInFooter);
+    staticPages = footerPages.map((page, index) => (
+      { id: `s${index}`, name: page.seoTitle, slug: page.slug }
     ));
     navLinks = navLinks.concat(staticPages);
   }

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -21,10 +21,9 @@ function Footer(props) {
   navLinks.push({ id: '2', name: t('actions'), slug: 'actions' });
   navLinks.push({ id: '3', name: t('indicators'), slug: 'indicators' });
 
-  if (plan.pages) {
-    const footerPages = plan.pages.filter((page) => page.showInFooter);
-    staticPages = footerPages.map((page, index) => (
-      { id: `s${index}`, name: page.seoTitle, slug: page.slug }
+  if (plan.footer.items.length > 0) {
+    staticPages = plan.footer.items.map(({ linkText, page }, index) => (
+      { id: `s${index}`, name: linkText, slug: page.slug }
     ));
     navLinks = navLinks.concat(staticPages);
   }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -90,6 +90,25 @@ const GET_PLAN = gql`
       impactGroups {
         id
       }
+      pages {
+        id
+        slug
+        seoTitle
+        title
+        showInMenus
+        ... on CategoryPage {
+          showInFooter
+        }
+        ... on EmptyPage {
+          showInFooter
+        }
+        ... on PlanRootPage {
+          showInFooter
+        }
+        ... on StaticPage {
+          showInFooter
+        }
+      }
       generalContent {
         id
         siteTitle

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -90,25 +90,6 @@ const GET_PLAN = gql`
       impactGroups {
         id
       }
-      pages {
-        id
-        slug
-        seoTitle
-        title
-        showInMenus
-        ... on CategoryPage {
-          showInFooter
-        }
-        ... on EmptyPage {
-          showInFooter
-        }
-        ... on PlanRootPage {
-          showInFooter
-        }
-        ... on StaticPage {
-          showInFooter
-        }
-      }
       generalContent {
         id
         siteTitle
@@ -134,6 +115,15 @@ const GET_PLAN = gql`
             page {
               __typename
             }
+          }
+        }
+      }
+      footer {
+        items {
+          id
+          linkText
+          page {
+            slug
           }
         }
       }


### PR DESCRIPTION
These are the changes that should be done to the UI after migrating the static pages as described in [the corresponding backend PR](https://github.com/kausaltech/kausal-watch-private/pull/17)