### PR TITLE
Change queries to fetch Wagtail images instead of removed legacy images

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -5,15 +5,15 @@
 export function getActionImageURL(plan, action) {
   let url;
 
-  if (action.imageUrl) {
-    url = action.imageUrl;
+  if (action.image?.rendition.src) {
+    url = action.image.rendition.src;
   } else {
     action.categories.forEach((cat) => {
       if (url) return;
       let parent = cat;
       while (parent) {
-        if (parent.imageUrl) {
-          url = parent.imageUrl;
+        if (parent.image?.rendition.src) {
+          url = parent.image.rendition.src;
           return;
         }
         parent = parent.parent;
@@ -21,7 +21,7 @@ export function getActionImageURL(plan, action) {
     });
   }
   if (!url) {
-    url = plan.mainImage?.smallRendition?.src || plan.imageUrl;
+    url = plan.image?.smallRendition?.src || plan.image?.rendition.src;
   }
   return url;
 }

--- a/components/actions/ActionContent.js
+++ b/components/actions/ActionContent.js
@@ -42,7 +42,11 @@ query ActionDetails($plan: ID!, $id: ID!, $bgImageSize: String = "1200x630") {
     officialName
     description
     completion
-    imageUrl(size: $bgImageSize)
+    image {
+      rendition(size: $bgImageSize) {
+        src
+      }
+    }
     updatedAt
     mergedActions {
       id
@@ -52,11 +56,19 @@ query ActionDetails($plan: ID!, $id: ID!, $bgImageSize: String = "1200x630") {
     categories(categoryType: "action") {
       id
       name
-      imageUrl(size: $bgImageSize)
+      image {
+        rendition(size: $bgImageSize) {
+          src
+        }
+      }
       parent {
         id
         name
-        imageUrl(size: $bgImageSize)
+        image {
+          rendition(size: $bgImageSize) {
+            src
+          }
+        }
       }
     }
     emissionScopes: categories(categoryType: "emission_scope") {

--- a/components/actions/ActionHighlightsList.js
+++ b/components/actions/ActionHighlightsList.js
@@ -26,7 +26,11 @@ export const GET_ACTION_LIST = gql`
       officialName
       completion
       updatedAt
-      imageUrl(size: $bgImageSize)
+      image {
+        rendition(size: $bgImageSize) {
+          src
+        }
+      }
       plan {
         id
       }
@@ -41,13 +45,25 @@ export const GET_ACTION_LIST = gql`
       }
       categories {
         id
-        imageUrl(size: $bgImageSize)
+        image {
+          rendition(size: $bgImageSize) {
+            src
+          }
+        }
         parent {
           id
-          imageUrl(size: $bgImageSize)
+          image {
+            rendition(size: $bgImageSize) {
+              src
+            }
+          }
           parent {
             id
-            imageUrl(size: $bgImageSize)
+            image {
+              rendition(size: $bgImageSize) {
+                src
+              }
+            }
           }
         }
       }

--- a/components/actions/ActionsTable.js
+++ b/components/actions/ActionsTable.js
@@ -30,7 +30,11 @@ const ACTION_ROW_FRAGMENT = gql`
       id
       identifier
       name
-      imageUrl
+      image {
+        rendition {
+          src
+        }
+      }
     }
     impact {
       id

--- a/components/common/StreamField.js
+++ b/components/common/StreamField.js
@@ -108,7 +108,9 @@ function StreamFieldBlock(props) {
     case 'CategoryListBlock': {
       const { color } = props;
       const { category } = page;
-      const fallbackImage = category?.imageUrl || plan.mainImage?.smallRendition?.src || plan.imageUrl;
+      const fallbackImage = (category?.image?.rendition.src
+                             || plan.image?.smallRendition?.src
+                             || plan.image?.rendition.src);
       return <CategoryListBlock categories={category.children} color={color} fallbackImageUrl={fallbackImage} />;
     }
     default:

--- a/components/layout.js
+++ b/components/layout.js
@@ -69,7 +69,7 @@ export function Meta(props) {
   // In ogTitle we don't want to repeat the site name.
   const ogTitle = title || siteTitle;
   const ogDescription = description || generalContent.siteDescription;
-  const ogImage = shareImageUrl || plan.mainImage?.smallRendition?.src || plan.imageUrl;
+  const ogImage = shareImageUrl || plan.image?.smallRendition?.src || plan.image?.rendition.src;
 
   return (
     <Head>

--- a/pages/[...slug].js
+++ b/pages/[...slug].js
@@ -33,7 +33,11 @@ query GetPlanPage($plan: ID!, $path: String!) {
       category {
         id
         identifier
-        imageUrl
+        image {
+          rendition {
+            src
+          }
+        }
         shortDescription
         color
         type {
@@ -43,7 +47,11 @@ query GetPlanPage($plan: ID!, $path: String!) {
           id
           identifier
           name
-          imageUrl
+          image {
+            rendition {
+              src
+            }
+          }
           color
           categoryPage {
             title
@@ -53,7 +61,11 @@ query GetPlanPage($plan: ID!, $path: String!) {
         parent {
           id
           identifier
-          imageUrl
+          image {
+            rendition {
+              src
+            }
+          }
           color
           categoryPage {
             title
@@ -111,7 +123,7 @@ const PageHeaderBlock = (props) => {
           title={page.title}
           identifier={page.category.identifier}
           lead={page.category.shortDescription}
-          headerImage={page.category.imageUrl || page.category?.parent.imageUrl }
+          headerImage={page.category.image?.rendition.src || page.category.parent?.image?.rendition.src}
           parentTitle={parentTitle}
           parentUrl={parentUrl}
           color={color}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -41,7 +41,11 @@ const GET_PLAN = gql`
       id
       identifier
       name
-      imageUrl(size: "1500x500")
+      image {
+        rendition(size: "1500x500") {
+          src
+        }
+      }
       primaryLanguage
       otherLanguages
       domain(hostname: $hostname) {
@@ -49,7 +53,7 @@ const GET_PLAN = gql`
         googleSiteVerificationTag
         matomoAnalyticsUrl
       }
-      mainImage {
+      image {
         largeRendition: rendition(size: "1600x900") {
           src
           width

--- a/pages/index.js
+++ b/pages/index.js
@@ -43,7 +43,7 @@ function HomePage() {
   // Use default hero component
   let heroComponent = (
     <HeroFullImage
-      bgImage={plan.mainImage?.largeRendition?.src || plan.imageUrl}
+      bgImage={plan.image?.largeRendition?.src}
       title={generalContent.siteTitle}
       siteDescription={generalContent.siteDescription}
       actionsDescription={generalContent.actionShortDescription}


### PR DESCRIPTION
This should adapt image-fetching queries to use the new Wagtail images instead of instances of the old model, which are removed in [the respective backend PR](https://github.com/kausaltech/kausal-watch-private/pull/23). Hopefully I found everything. I'm not really sure where we should request which rendition (size).