### PR TITLE
Display action attributes

### DIFF
--- a/components/actions/ActionContent.js
+++ b/components/actions/ActionContent.js
@@ -19,6 +19,7 @@ import images, { getBgImageAlignment, getActionImage } from 'common/images';
 import IndicatorCausal from 'components/indicators/IndicatorCausal';
 import Timeline from 'components/graphs/Timeline';
 import ScheduleTimeline from 'components/graphs/ScheduleTimeline';
+import AttributesBlock from 'components/common/AttributesBlock';
 import ContentLoader from 'components/common/ContentLoader';
 import ErrorMessage from 'components/common/ErrorMessage';
 import RichText from 'components/common/RichText';
@@ -189,6 +190,44 @@ query ActionDetails($plan: ID!, $id: ID!) {
       id
       identifier
     }
+    attributes {
+      __typename
+      id
+      key
+      keyIdentifier
+      ...on AttributeChoice {
+        value
+        valueIdentifier
+        type {
+          identifier
+          name
+        }
+      }
+      ...on AttributeRichText {
+        value
+        type {
+          identifier
+          name
+        }
+      }
+      ...on AttributeNumericValue {
+        numericValue: value
+        type {
+          identifier
+          name
+        }
+      }
+    }
+  }
+  plan(id: $plan) {
+    actionAttributeTypes {
+      __typename
+      format
+      identifier
+      choiceOptions {
+        identifier
+      }
+    }
   }
 }
 ${images.fragments.multiUseImage}
@@ -296,6 +335,7 @@ function ActionContent({ id }) {
     },
   });
   const { action } = data || {};
+  const attributeTypes = data?.plan.actionAttributeTypes;
 
   useHotkeys('ctrl+left, ctrl+right', (ev) => {
     const next = (ev.code == 'ArrowLeft' ? action.previousAction : action.nextAction);
@@ -513,6 +553,11 @@ function ActionContent({ id }) {
                 <CategoryTags data={action.categories} />
               </ActionSection>
             ) : null}
+            { action.attributes.length > 0 && (
+              <ActionSection>
+                <AttributesBlock attributes={action.attributes} types={attributeTypes} />
+              </ActionSection>
+            )}
             { action?.contactPersons.length > 0 && (
               <ActionSection>
                 <ContactPersons persons={action.contactPersons.map((item) => item.person)} />

--- a/components/common/AttributesBlock.js
+++ b/components/common/AttributesBlock.js
@@ -1,9 +1,8 @@
 import React, { useContext } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 import RichText from 'components/common/RichText';
 import PlanContext from 'context/plan';
-import ActionGroupStatus from 'components/actions/ActionGroupStatus';
 import Icon from 'components/common/Icon';
 import CategoryMetaBar from '../actions/CategoryMetaBar';
 
@@ -30,21 +29,25 @@ const ScaleIcon = styled(Icon)`
 `;
 
 const AttributesList = styled.dl`
-  display: flex;
-  flex-flow: row wrap;
+  ${props => props.vertical && css`
+    display: flex;
+    flex-flow: row wrap;
+  `}
   max-width: 720px;
   margin: ${(props) => props.theme.spaces.s200} auto 0;
 
+  h3 {
+    font-size: ${(props) => props.theme.fontSizeBase};
+  }
+
   dt {
     flex: 0 0 100%;
-    text-align: center;
     margin-bottom: .5rem;
   }
 
   dd {
     flex: 0 1 100%;
     margin-bottom: 1rem;
-    text-align: center;
 
     .text-content {
       text-align: left;
@@ -84,92 +87,95 @@ const formatEmissionSharePercent = (share, total) => {
 };
 
 function AttributeContent(props) {
-  const { contentData, contentType, title, color } = props;
+  const { contentData, contentType, title, vertical } = props;
 
+  let dataElement;
   switch (contentData.__typename) {
     case 'AttributeChoice':
       if (contentType) {
         // const choiceCount = contentType.choiceOptions.length;
-        return (
-          <>
-            <dt>{title}</dt>
-            <dd>
-              <div>
-                { contentType.choiceOptions.map((choice) => (
-                  <ScaleIcon
-                    name="circleFull"
-                    className={choice.identifier <= contentData.valueIdentifier ? 'icon-on' : 'icon-off'}
-                    size="md"
-                    key={choice.identifier}
-                  />
-                ))}
-                <AttributeChoiceLabel>{ contentData.value }</AttributeChoiceLabel>
-              </div>
-            </dd>
-          </>
+        dataElement = (
+          <div>
+            { contentType.choiceOptions.map((choice) => (
+              <ScaleIcon
+                name="circleFull"
+                className={choice.identifier <= contentData.valueIdentifier ? 'icon-on' : 'icon-off'}
+                size="md"
+                key={choice.identifier}
+              />
+            ))}
+            <AttributeChoiceLabel>{ contentData.value }</AttributeChoiceLabel>
+          </div>
         );
       }
+      break;
+    case 'AttributeChoiceAndText':
+      // TODO
       return null;
     case 'AttributeRichText':
-      return (
-        <>
-          <dt>{title}</dt>
-          <dd>
-            <RichText html={contentData.value} />
-          </dd>
-        </>
+      dataElement = (
+        <RichText html={contentData.value} />
       );
+      break;
     case 'AttributeNumericValue':
-      // KPR specific hack
-      if (contentData.keyIdentifier === 'impact') {
-        const totalEmissions = 50.921;
-        const segments = [{
-          id: 'emissions',
-          label: '',
-          value: formatEmissionSharePercent(contentData.numericValue, totalEmissions),
-          portion: contentData.numericValue / totalEmissions,
-          color,
-        }];
-        return <CategoryMetaBar segments={segments} title={contentData.key} />;
-      }
-      return null;
+      dataElement = (
+        <span>
+          {contentData.numericValue}
+        </span>
+      );
+      break;
     default: return <div />;
   }
+  if (vertical) {
+    return (
+      <>
+        <dt>{title}</dt>
+        <dd>{dataElement}</dd>
+      </>
+    );
+  }
+  // Render horizontal layout
+  return (
+    <div className="mb-4">
+      <h3>{title}</h3>
+      {dataElement}
+    </div>
+  );
 }
 
-function CategoryAttributesBlock(props) {
+function AttributesBlock(props) {
   const plan = useContext(PlanContext);
   const {
-    color,
     attributes,
-    id,
+    children,  // extra children that can be passed by nesting in the JSX tag
     types,
+    vertical,
   } = props;
 
   return (
-    <AttributesList>
+    <AttributesList vertical={vertical}>
       {attributes.map((item) => (
         <React.Fragment key={item.id}>
           <AttributeContent
             title={item.key}
             contentData={item}
             contentType={types?.find((type) => type.identifier === item.keyIdentifier)}
-            color={color}
+            vertical={vertical}
           />
         </React.Fragment>
       ))}
-      {plan.actionStatuses.length ? <ActionGroupStatus category={id} /> : null}
+      {children}
     </AttributesList>
   );
 }
 
 // TODO: prop types and defaults
-CategoryAttributesBlock.defaultProps = {
+AttributesBlock.defaultProps = {
 
 };
 
-CategoryAttributesBlock.propTypes = {
+AttributesBlock.propTypes = {
 
 };
 
-export default CategoryAttributesBlock;
+export default AttributesBlock;

--- a/components/contentblocks/CategoryPageHeaderBlock.js
+++ b/components/contentblocks/CategoryPageHeaderBlock.js
@@ -5,10 +5,11 @@ import { Container, Row, Col } from 'reactstrap';
 import styled from 'styled-components';
 import PlanContext from 'context/plan';
 import { Link } from 'common/links';
-import CategoryAttributesBlock from './CategoryAttributesBlock';
+import ActionGroupStatus from 'components/actions/ActionGroupStatus';
+import AttributesBlock from 'components/common/AttributesBlock';
 
 export const GET_CATEGORY_ATTRIBUTE_TYPES = gql`
-  query GetAttributeTypes($plan: ID!) {
+  query GetCategoryAttributeTypes($plan: ID!) {
     plan(id: $plan) {
       id
       categoryTypes {
@@ -104,11 +105,10 @@ function CategoryPageHeaderBlock(props) {
     typeId,
     level,
   } = props;
+  const plan = useContext(PlanContext);
 
   let attributeTypes = [];
-
   if (attributes?.length) {
-    const plan = useContext(PlanContext);
     const { loading, error, data } = useQuery(GET_CATEGORY_ATTRIBUTE_TYPES, {
       variables: {
         plan: plan.identifier,
@@ -150,8 +150,11 @@ function CategoryPageHeaderBlock(props) {
               </h1>
               {level}
               <p>{ lead }</p>
-              { attributes?.length > 0
-                  && <CategoryAttributesBlock attributes={attributes} color={color} id={categoryId} types={attributeTypes} /> }
+              { attributes?.length > 0 && (
+                <AttributesBlock attributes={attributes} color={color} id={categoryId} types={attributeTypes} vertical>
+                  {plan.actionStatuses.length ? <ActionGroupStatus category={categoryId} /> : null}
+                </AttributesBlock>
+              )}
             </HeaderContent>
           </Col>
         </Row>


### PR DESCRIPTION
Hope this is acceptable. I refactored the component `CategoryAttributesBlock` to the new component `AttributesBlock` which is now rendered for category pages and action pages. Since the way it's displayed should differ between the two, there might be some layout issues.
Further things to look into:
- Numeric attributes are just displayed as a number right now. Perhaps we want to display this in some nice way.
- "Optional choice with optional text" attributes aren't displayed at all right now.