### PR TITLE
Filter out unused themes from indicator filters

### DIFF
--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -7467,7 +7467,13 @@ export type IndicatorListQuery = (
           ) | null> | null }
           & { __typename?: 'CommonIndicator' }
         ) | null, categories: Array<(
-          { id: string, name: string }
+          { id: string, name: string, parent?: (
+            { id: string }
+            & { __typename?: 'Category' }
+          ) | null, type: (
+            { id: string }
+            & { __typename?: 'CategoryType' }
+          ) }
           & { __typename?: 'Category' }
         )>, latestGraph?: (
           { id: string }

--- a/components/indicators/IndicatorList.tsx
+++ b/components/indicators/IndicatorList.tsx
@@ -29,7 +29,7 @@ const createFilterUnusedCategories =
       categories.find(
         ({ id, parent }) => id === category.id || parent?.id === category.id
       )
-  );
+    );
 
 const getFilterConfig = (categoryType, indicators) => ({
   mainFilters: [
@@ -89,6 +89,9 @@ const GET_INDICATOR_LIST = gql`
             id
             name
             parent {
+              id
+            }
+            type {
               id
             }
           }
@@ -338,9 +341,13 @@ const IndicatorList = ({ title, leadContent }: Props) => {
       <Container>
         <IndicatorListFiltered
           {...indicatorListProps}
+          categoryColumnLabel={data?.plan?.categoryTypes[0]?.name}
           indicators={filteredIndicators}
           filters={filters}
           hierarchy={hierarchy}
+          shouldDisplayCategory={(category: Category) =>
+            category.type.id === data?.plan?.categoryTypes[0]?.id
+          }
         />
       </Container>
     </>

--- a/components/indicators/IndicatorList.tsx
+++ b/components/indicators/IndicatorList.tsx
@@ -15,20 +15,23 @@ import ActionListFilters, {
   FilterValue,
 } from 'components/actions/ActionListFilters';
 import {
-  CategoryType,
+  Category,
+  Indicator,
   IndicatorListPage,
   IndicatorListQuery,
 } from 'common/__generated__/graphql';
 import { useTranslation } from 'next-i18next';
 import { useRouter } from 'next/router';
 
-const getCategoriesFromTypes = (categoryTypes: CategoryType[]) =>
-  categoryTypes.reduce(
-    (categories, categoryType) => [...categories, ...categoryType.categories],
-    []
+const createFilterUnusedCategories =
+  (indicators: Indicator[]) => (category: Category) =>
+    indicators.find(({ categories }) =>
+      categories.find(
+        ({ id, parent }) => id === category.id || parent?.id === category.id
+      )
   );
 
-const getFilterConfig = (categoryType) => ({
+const getFilterConfig = (categoryType, indicators) => ({
   mainFilters: [
     {
       __typename: 'CategoryTypeFilterBlock',
@@ -39,6 +42,9 @@ const getFilterConfig = (categoryType) => ({
       depth: null,
       categoryType: {
         ...categoryType,
+        categories: categoryType.categories.filter(
+          createFilterUnusedCategories(indicators)
+        ),
         hideCategoryIdentifiers: true,
         selectionType: 'SINGLE',
       },
@@ -82,6 +88,9 @@ const GET_INDICATOR_LIST = gql`
           categories {
             id
             name
+            parent {
+              id
+            }
           }
           latestGraph {
             id
@@ -277,11 +286,8 @@ const IndicatorList = ({ title, leadContent }: Props) => {
       return { ...indicator, level: level.toLowerCase() };
     });
 
-    const categories = getCategoriesFromTypes(categoryTypes);
-
     return {
       indicators,
-      categories,
       leadContent: generalContent.indicatorListLeadContent,
       displayMunicipality,
       displayNormalizedValues,
@@ -295,7 +301,7 @@ const IndicatorList = ({ title, leadContent }: Props) => {
   const hierarchy = processCommonIndicatorHierarchy(data?.planIndicators);
   const showInsights = hasInsights(data);
   const filterConfig = !!data?.plan?.categoryTypes[0]
-    ? getFilterConfig(data.plan.categoryTypes[0])
+    ? getFilterConfig(data.plan.categoryTypes[0], indicatorListProps.indicators)
     : {};
 
   const filterSections: ActionListFilterSection[] =

--- a/components/indicators/IndicatorListFiltered.js
+++ b/components/indicators/IndicatorListFiltered.js
@@ -297,10 +297,12 @@ const IndicatorListFiltered = (props) => {
   const {
     t,
     indicators,
+    categoryColumnLabel,
     i18n,
     displayMunicipality,
     hierarchy,
     displayNormalizedValues,
+    shouldDisplayCategory,
   } = props;
 
   // used for multi-city group expanding/collapsing
@@ -434,7 +436,7 @@ const IndicatorListFiltered = (props) => {
           if (someIndicatorsHaveCategories) {
             headers.push(
               <IndentableTableHeader key="hr-themes">
-                {t('themes')}
+                {categoryColumnLabel || t('themes')}
               </IndentableTableHeader>
             );
           }
@@ -574,7 +576,7 @@ const IndicatorListFiltered = (props) => {
                       {someIndicatorsHaveCategories && (
                         <IndentableTableCell>
                           {item.categories.map((cat) => {
-                            if (cat)
+                            if (cat && (shouldDisplayCategory?.(cat) ?? true))
                               return (
                                 <StyledBadge key={cat.id}>
                                   {cat.name}
@@ -633,9 +635,10 @@ const IndicatorListFiltered = (props) => {
 };
 
 IndicatorListFiltered.propTypes = {
+  categoryColumnLabel: PropTypes.string,
   t: PropTypes.func.isRequired,
   indicators: PropTypes.arrayOf(PropTypes.object).isRequired,
-  categories: PropTypes.arrayOf(PropTypes.object).isRequired,
+  shouldDisplayCategory: PropTypes.func,
 };
 
 export default withTranslation('common')(IndicatorListFiltered);


### PR DESCRIPTION
If a theme hasn't been linked to an indicator it will be hidden from the theme filter dropdown. The filtering logic contains a few nested loops, which aren't ideal, but this functionality will eventually be moved to the backend.