### PR TITLE
Display customer-specific theme column label

### DIFF
--- a/components/indicators/IndicatorList.tsx
+++ b/components/indicators/IndicatorList.tsx
@@ -338,6 +338,7 @@ const IndicatorList = ({ title, leadContent }: Props) => {
       <Container>
         <IndicatorListFiltered
           {...indicatorListProps}
+          categoryColumnLabel={data?.plan?.categoryTypes[0]?.name}
           indicators={filteredIndicators}
           filters={filters}
           hierarchy={hierarchy}

--- a/components/indicators/IndicatorListFiltered.js
+++ b/components/indicators/IndicatorListFiltered.js
@@ -297,6 +297,7 @@ const IndicatorListFiltered = (props) => {
   const {
     t,
     indicators,
+    categoryColumnLabel,
     i18n,
     displayMunicipality,
     hierarchy,
@@ -434,7 +435,7 @@ const IndicatorListFiltered = (props) => {
           if (someIndicatorsHaveCategories) {
             headers.push(
               <IndentableTableHeader key="hr-themes">
-                {t('themes')}
+                {categoryColumnLabel || t('themes')}
               </IndentableTableHeader>
             );
           }
@@ -633,6 +634,7 @@ const IndicatorListFiltered = (props) => {
 };
 
 IndicatorListFiltered.propTypes = {
+  categoryColumnLabel: PropTypes.string,
   t: PropTypes.func.isRequired,
   indicators: PropTypes.arrayOf(PropTypes.object).isRequired,
   categories: PropTypes.arrayOf(PropTypes.object).isRequired,


### PR DESCRIPTION
Display the name chosen by the user for themes in the indicator table.

<img width="1048" alt="Screenshot 2023-08-28 at 18 29 11" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/8ffd5623-b939-43f4-8533-4a7100ba1d17">
