### PR TITLE
Filter out categories that aren't indicator themes

### DIFF
--- a/components/indicators/IndicatorList.tsx
+++ b/components/indicators/IndicatorList.tsx
@@ -29,7 +29,7 @@ const createFilterUnusedCategories =
       categories.find(
         ({ id, parent }) => id === category.id || parent?.id === category.id
       )
-  );
+    );
 
 const getFilterConfig = (categoryType, indicators) => ({
   mainFilters: [
@@ -89,6 +89,9 @@ const GET_INDICATOR_LIST = gql`
             id
             name
             parent {
+              id
+            }
+            type {
               id
             }
           }
@@ -342,6 +345,9 @@ const IndicatorList = ({ title, leadContent }: Props) => {
           indicators={filteredIndicators}
           filters={filters}
           hierarchy={hierarchy}
+          shouldDisplayCategory={(category: Category) =>
+            category.type.id === data?.plan?.categoryTypes[0]?.id
+          }
         />
       </Container>
     </>

--- a/components/indicators/IndicatorListFiltered.js
+++ b/components/indicators/IndicatorListFiltered.js
@@ -302,6 +302,7 @@ const IndicatorListFiltered = (props) => {
     displayMunicipality,
     hierarchy,
     displayNormalizedValues,
+    shouldDisplayCategory,
   } = props;
 
   // used for multi-city group expanding/collapsing
@@ -575,7 +576,7 @@ const IndicatorListFiltered = (props) => {
                       {someIndicatorsHaveCategories && (
                         <IndentableTableCell>
                           {item.categories.map((cat) => {
-                            if (cat)
+                            if (cat && (shouldDisplayCategory?.(cat) ?? true))
                               return (
                                 <StyledBadge key={cat.id}>
                                   {cat.name}
@@ -637,7 +638,7 @@ IndicatorListFiltered.propTypes = {
   categoryColumnLabel: PropTypes.string,
   t: PropTypes.func.isRequired,
   indicators: PropTypes.arrayOf(PropTypes.object).isRequired,
-  categories: PropTypes.arrayOf(PropTypes.object).isRequired,
+  shouldDisplayCategory: PropTypes.func,
 };
 
 export default withTranslation('common')(IndicatorListFiltered);


### PR DESCRIPTION
In the indicators table, only display `usableForIndicators` theme categories in the themes column.