### PR TITLE
Update indicator table to make indicators accessible by name

### DIFF
--- a/components/common/Icon.js
+++ b/components/common/Icon.js
@@ -3,75 +3,74 @@ import PropTypes from 'prop-types';
 import SVG from 'react-inlinesvg';
 import { useTheme } from 'common/theme';
 
-const camelToKebabCase = (s) => s.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
+const camelToKebabCase = (s) =>
+  s.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
 
 const AVAILABLE_ICONS = [
-'angle-down.svg',
-'angle-left.svg',
-'angle-right.svg',
-'angle-up.svg',
-'arrow-down.svg',
-'arrow-left.svg',
-'arrow-right.svg',
-'arrow-up-down.svg',
-'arrow-up.svg',
-'arrow-up-right-from-square.svg',
-'bars.svg',
-'bullseye.svg',
-'calendar.svg',
-'chart-line.svg',
-'check.svg',
-'circle-full.svg',
-'circle-outline.svg',
-'commenting.svg',
-'dot-circle.svg',
-'exclamation-circle.svg',
-'globe.svg',
-'heart.svg',
-'home.svg',
-'link.svg',
-'lock.svg',
-'pencil.svg',
-'scope-global.svg',
-'scope-local.svg',
-'search.svg',
-'sort-down.svg',
-'sort-up.svg',
-'sort.svg',
-'sync.svg',
-'tachometer.svg',
-'times.svg',
-'user.svg',
+  'angle-down.svg',
+  'angle-left.svg',
+  'angle-right.svg',
+  'angle-up.svg',
+  'arrow-down.svg',
+  'arrow-left.svg',
+  'arrow-right.svg',
+  'arrow-up-down.svg',
+  'arrow-up-right-from-square.svg',
+  'arrow-up.svg',
+  'bars.svg',
+  'bullseye.svg',
+  'calendar.svg',
+  'chart-line.svg',
+  'check.svg',
+  'caret-down.svg',
+  'caret-left.svg',
+  'caret-right.svg',
+  'caret-up.svg',
+  'circle-full.svg',
+  'circle-outline.svg',
+  'commenting.svg',
+  'dot-circle.svg',
+  'exclamation-circle.svg',
+  'globe.svg',
+  'heart.svg',
+  'home.svg',
+  'link.svg',
+  'lock.svg',
+  'pencil.svg',
+  'scope-global.svg',
+  'scope-local.svg',
+  'search.svg',
+  'sort-down.svg',
+  'sort-up.svg',
+  'sort.svg',
+  'sync.svg',
+  'tachometer.svg',
+  'times.svg',
+  'user.svg',
 ];
 
 const Icon = (props) => {
   const theme = useTheme();
-  const {
-    name,
-    color,
-    width,
-    height,
-    className,
-    alt,
-    ...rest
-  } = props;
+  const { name, color, width, height, className, alt, ...rest } = props;
 
   return (
-    <svg className={`icon ${className}`}
-         onError={(error) => console.log(error.message)}
-         key={`${theme.name}-${name}`}
-         style={{width, height}}
-         aria-hidden={ alt ? 'false' : 'true' }
-         focusable={ alt ? 'true' : 'false' }
+    <svg
+      className={`icon ${className}`}
+      onError={(error) => console.log(error.message)}
+      key={`${theme.name}-${name}`}
+      style={{ width, height }}
+      aria-hidden={alt ? 'false' : 'true'}
+      focusable={alt ? 'true' : 'false'}
     >
-      { alt ? <title>{alt}</title> : null}
+      {alt ? <title>{alt}</title> : null}
       <use
         fill={color}
         xlinkHref={`#symbol-icon-${camelToKebabCase(name)}`}
-        {...rest} />
+        {...rest}
+      />
     </svg>
   );
-}
+};
 
 export const CombinedIconSymbols = () => {
   const theme = useTheme();
@@ -80,13 +79,8 @@ export const CombinedIconSymbols = () => {
   const iconFileName = camelToKebabCase(theme.combinedIconsFilename);
   const icon = `${theme.iconsUrl}/${iconFileName}.svg`;
 
-  return (
-    <SVG
-      style={{display: 'none'}}
-      src={icon}
-    />
-  );
-}
+  return <SVG style={{ display: 'none' }} src={icon} />;
+};
 
 Icon.defaultProps = {
   name: 'circleOutline',

--- a/stories/common/Icon.stories.js
+++ b/stories/common/Icon.stories.js
@@ -16,6 +16,10 @@ const iconsList = [
   'calendar',
   'chartLine',
   'check',
+  'chevronDown',
+  'chevronLeft',
+  'chevronRight',
+  'chevronUp',
   'circleFull',
   'circleOutline',
   'commenting',
@@ -35,7 +39,9 @@ const Icons = (props) => {
   const showIcons = iconsList.map((item) => (
     <div className="py-2 d-flex d-flex-row" key={item}>
       <Icon name={item} color={iconColor} width="2rem" height="2rem" />
-      <small className="ml-3" style={{ lineHeight: '2rem' }}>{item}</small>
+      <small className="ml-3" style={{ lineHeight: '2rem' }}>
+        {item}
+      </small>
     </div>
   ));
 
@@ -51,12 +57,18 @@ const IconsLayout = () => {
         <div className="col-6">
           <Icons />
         </div>
-        <div className="col-6" style={{ backgroundColor: theme.brandDark, color: theme.themeColors.light }}>
+        <div
+          className="col-6"
+          style={{
+            backgroundColor: theme.brandDark,
+            color: theme.themeColors.light,
+          }}
+        >
           <Icons iconColor={theme.brandLight} />
         </div>
       </div>
     </div>
-  )
+  );
 };
 
 export const IconsStory = (theme) => <IconsLayout theme={theme} />;


### PR DESCRIPTION
The indicator link was previously hard to find and raised by at least Äänekoski. This change makes the chevron icon a button to control expansion and the indicator name a link (consistent with our other tables).

A nice improvement here would be to remember the hierarchy expansion state between pages so that the user could easily navigate back and forth between nested indicators. We could think about this along side the bigger indicators redesign.

https://github.com/kausaltech/kausal-watch-ui/assets/15343658/3b6c461f-8743-4069-9f31-432159d0999e

