### PR TITLE
feat: support block anchor links 

### DIFF
--- a/common/blocks.types.ts
+++ b/common/blocks.types.ts
@@ -1,0 +1,3 @@
+export interface CommonContentBlockProps {
+    id?: string
+}

--- a/components/common/RichText.tsx
+++ b/components/common/RichText.tsx
@@ -183,7 +183,7 @@ export default function RichText(props: RichTextProps) {
           return <a href={`${plan.serveFileBaseUrl}${attribs.href}`}>{domToReact(children, options)}</a>;
         }
         // Internal link
-        if (cutHttp(attribs.href.split('.')[0]) === currentDomain) {
+        if (cutHttp(attribs.href.split('.')[0]) === currentDomain || attribs.href.startsWith('#')) {
           return <a href={attribs.href}>{domToReact(children, options)}</a>;
         }
         // Assumed external link, open in new tab

--- a/components/common/StreamField.tsx
+++ b/components/common/StreamField.tsx
@@ -281,6 +281,7 @@ ${CategoryListBlock.fragments.category}
 `;
 
 type StreamFieldBlockProps = {
+  id: string;
   page: any,
   block: StreamFieldFragmentFragment,
   color: string,
@@ -288,7 +289,7 @@ type StreamFieldBlockProps = {
 }
 
 function StreamFieldBlock(props: StreamFieldBlockProps) {
-  const { page, block, color, hasSidebar } = props;
+  const { id, page, block, color, hasSidebar } = props;
   const { __typename } = block;
   const plan = useContext(PlanContext);
 
@@ -298,7 +299,7 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
       const COLLAPSIBLE_BREAKPOINT = 1200;
       const isCollapsible = (page.__typename === 'CategoryPage') && (value.length > COLLAPSIBLE_BREAKPOINT);
       return (
-        <Container>
+        <Container id={id}>
           <Row>
             <Col
               xl={{ size: hasSidebar ? 7 : 6, offset: hasSidebar ? 4 : 3 }}
@@ -318,6 +319,7 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
     case 'QuestionAnswerBlock': {
       const { heading, questions } = block;
       return <QuestionAnswerBlock
+                id={id}
                 heading={heading}
                 questions={questions}
                 hasSidebar={hasSidebar}
@@ -325,7 +327,7 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
     }
     case 'CharBlock': {
       const { value } = block;
-      return <Container><Row><Col><div>{value}</div></Col></Row></Container>;
+      return <Container id={id}><Row><Col><div>{value}</div></Col></Row></Container>;
     }
     case 'IndicatorGroupBlock': {
       const { items } = block;
@@ -355,6 +357,7 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
       const fallbackImage = (pageCategory?.image || plan.image);
       return (
         <CategoryListBlock
+          id={id}
           categories={categories}
           color={color}
           fallbackImage={fallbackImage}
@@ -369,6 +372,7 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
       } = block;
       return (
         <FrontPageHeroBlock
+          id={id}
           layout={layout}
           imageSrc={image?.large?.src}
           imageAlign={getBgImageAlignment(image)}
@@ -382,6 +386,7 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
     case 'IndicatorShowcaseBlock': {
       const { indicator, title, body } = block;
       return <IndicatorShowcaseBlock
+                id={id}
                 indicator={indicator}
                 title={title}
                 body={body}
@@ -390,6 +395,7 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
     case 'CardListBlock': {
       const { cards, lead, heading } = block;
       return <CardListBlock
+        id={id}
         cards={cards}
         lead={lead}
         heading={heading}
@@ -397,32 +403,33 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
         />;
     }
     case 'ActionHighlightsBlock': {
-      return <ActionHighlightsBlock />;
+      return <ActionHighlightsBlock id={id} />;
     }
     case 'ActionStatusGraphsBlock': {
-      return <ActionStatusGraphsBlock />;
+      return <ActionStatusGraphsBlock id={id} />;
     }
     case 'IndicatorHighlightsBlock': {
-      return <IndicatorHighlightsBlock />;
+      return <IndicatorHighlightsBlock id={id} />;
     }
     case 'RelatedIndicatorsBlock': {
-      return <RelatedIndicatorsBlock indicators={page?.category?.indicators} />;
+      return <RelatedIndicatorsBlock id={id} indicators={page?.category?.indicators} />;
     }
     case 'RelatedPlanListBlock': {
-      return <RelatedPlanListBlock />;
+      return <RelatedPlanListBlock id={id} />;
     }
     case 'ActionCategoryFilterCardsBlock': {
       const { cards } = block;
-      return <ActionCategoryFilterCardsBlock cards={cards} />;
+      return <ActionCategoryFilterCardsBlock id={id} cards={cards} />;
     }
     case 'CategoryTreeMapBlock': {
       return <CategoryTreeBlock
                 {...block}
+                id={id}
                 hasSidebar={hasSidebar}
               />
     }
     case 'AdaptiveEmbedBlock': {
-      return <Container>
+      return <Container id={id}>
         <Row>
           <Col
             xl={{ size: hasSidebar ? 7 : 6, offset: hasSidebar ? 4 : 3 }}
@@ -439,6 +446,7 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
       const { account, style, styleOverrides } = block;
       const accessToken = account?.publicAccessToken;
       return <CartographyVisualisationBlock
+        id={id}
         styleUrl={style}
         accessToken={accessToken}
         styleOverrides={styleOverrides}
@@ -447,21 +455,21 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
 
     }
     case 'AccessibilityStatementComplianceStatusBlock': {
-      return <AccessibilityStatementComplianceStatusBlock {...block} />
+      return <AccessibilityStatementComplianceStatusBlock {...block} id={id} />
     }
     case 'AccessibilityStatementContactFormBlock': {
-      return <AccessibilityStatementContactFormBlock {...block} />
+      return <AccessibilityStatementContactFormBlock {...block} id={id} />
     }
     case 'AccessibilityStatementContactInformationBlock': {
       const { blocks } = block;
-      return <AccessibilityStatementContactInformationBlock content={blocks}/>
+      return <AccessibilityStatementContactInformationBlock id={id} content={blocks}/>
     }
     case 'AccessibilityStatementPreparationInformationBlock': {
-      return <AccessibilityStatementPreparationInformationBlock {...block}/>
+      return <AccessibilityStatementPreparationInformationBlock {...block} id={id} />
     }
     default:
       return (
-        <div>
+        <div id={id}>
           { `Component for ${__typename} does not exist` }
         </div>
       );
@@ -479,8 +487,9 @@ function StreamField(props: StreamFieldProps) {
   const { page, blocks, color, hasSidebar = false } = props;
   return (
     <>
-      { blocks.map((block) => (
+      { blocks.map((block, index) => (
         <StreamFieldBlock
+          id={`block-${index + 1}`}
           block={block}
           page={page}
           key={block.id}

--- a/components/common/StreamField.tsx
+++ b/components/common/StreamField.tsx
@@ -489,7 +489,7 @@ function StreamField(props: StreamFieldProps) {
     <>
       { blocks.map((block, index) => (
         <StreamFieldBlock
-          id={`block-${index + 1}`}
+          id={`section-${index + 1}`}
           block={block}
           page={page}
           key={block.id}

--- a/components/contentblocks/AccessibilityStatementComplianceStatusBlock.js
+++ b/components/contentblocks/AccessibilityStatementComplianceStatusBlock.js
@@ -4,7 +4,7 @@ import { useTranslation } from 'common/i18n';
 import { Container, Row, Col } from 'reactstrap';
 import accessibilityStatementData from 'public/static/accessibility';
 
-const AccessibilityStatementComplianceStatusBlock = (props) => {
+const AccessibilityStatementComplianceStatusBlock = ({ id = '' }) => {
   const { t, i18n } = useTranslation(['a11y']);
 
   let locale = i18n.language;
@@ -16,7 +16,7 @@ const AccessibilityStatementComplianceStatusBlock = (props) => {
   const complianceStatusText = t(`a11y:${complianceStatus}-compliant`);
 
   return (
-    <Container className="my-2 text-content">
+    <Container id={id} className="my-2 text-content">
       <Row>
         <Col
           xl={{ size: 6, offset: 3 }}

--- a/components/contentblocks/AccessibilityStatementContactFormBlock.tsx
+++ b/components/contentblocks/AccessibilityStatementContactFormBlock.tsx
@@ -4,13 +4,14 @@ import { Container, Row, Col } from 'reactstrap';
 
 import PlanContext from 'context/plan';
 import FeedbackForm from 'components/common/FeedbackForm';
+import { CommonContentBlockProps } from 'common/blocks.types';
 
-const AccessibilityStatementContactFormBlock = (props) => {
+const AccessibilityStatementContactFormBlock = ({ id = ''}: CommonContentBlockProps) => {
   const { t } = useTranslation(['a11y']);
   const plan = useContext(PlanContext);
 
   return (
-    <Container className="my-2 text-content">
+    <Container id={id} className="my-2 text-content">
       <Row>
         <Col
           xl={{ size: 6, offset: 3 }}

--- a/components/contentblocks/AccessibilityStatementContactInformationBlock.tsx
+++ b/components/contentblocks/AccessibilityStatementContactInformationBlock.tsx
@@ -3,9 +3,13 @@ import PropTypes from 'prop-types';
 import { useTranslation } from 'common/i18n';
 import { Container, Row, Col } from 'reactstrap';
 import PlanContext from 'context/plan';
+import { CommonContentBlockProps } from 'common/blocks.types';
 
-const AccessibilityStatementContactInformationBlock = (props) => {
-  const { content } = props;
+interface Props extends CommonContentBlockProps {
+  content: unknown // TODO: Type this prop
+}
+
+const AccessibilityStatementContactInformationBlock = ({ id = '', content }: Props) => {
   const { t, i18n } = useTranslation(['a11y']);
   const plan = useContext(PlanContext);
 
@@ -15,7 +19,7 @@ const AccessibilityStatementContactInformationBlock = (props) => {
   const responsibleBody = publisher || plan.generalContent.ownerName;
 
   return (
-    <Container className="my-2 text-content">
+    <Container id={id} className="my-2 text-content">
       <Row>
         <Col
           xl={{ size: 6, offset: 3 }}

--- a/components/contentblocks/AccessibilityStatementPreparationInformationBlock.tsx
+++ b/components/contentblocks/AccessibilityStatementPreparationInformationBlock.tsx
@@ -4,8 +4,9 @@ import dayjs from 'common/dayjs';
 import { useTranslation } from 'common/i18n';
 import { Container, Row, Col } from 'reactstrap';
 import accessibilityStatementData from 'public/static/accessibility';
+import { CommonContentBlockProps } from 'common/blocks.types';
 
-const AccessibilityStatementPreparationInformationBlock = (props) => {
+const AccessibilityStatementPreparationInformationBlock = ({ id = '' }: CommonContentBlockProps) => {
   const { t, i18n } = useTranslation(['a11y']);
 
   let locale = i18n.language;
@@ -14,7 +15,7 @@ const AccessibilityStatementPreparationInformationBlock = (props) => {
   }
 
   return (
-    <Container className="my-2 text-content">
+    <Container id={id} className="my-2 text-content">
       <Row>
         <Col
           xl={{ size: 6, offset: 3 }}

--- a/components/contentblocks/ActionCategoryFilterCardsBlock.tsx
+++ b/components/contentblocks/ActionCategoryFilterCardsBlock.tsx
@@ -7,6 +7,7 @@ import { getBgImageAlignment } from 'common/images';
 import { Link } from 'common/links';
 import CategoryTreeBlock from 'components/contentblocks/CategoryTreeBlock';
 import Card from 'components/common/Card';
+import { CommonContentBlockProps } from 'common/blocks.types';
 
 
 const CategoryListSection = styled.div`
@@ -55,11 +56,14 @@ const Identifier = styled.span`
   color: ${(props) => props.theme.graphColors.grey050};
 `;
 
-const CategoryListBlock = (props) => {
-  const { cards } = props;
+interface Props extends CommonContentBlockProps {
+  cards: unknown // TODO: Type this prop
+}
+
+const CategoryListBlock = ({ id = '', cards }: Props) => {
   const theme = useTheme();
   return (
-    <CategoryListSection bg={theme.themeColors.dark}>
+    <CategoryListSection id={id} bg={theme.themeColors.dark}>
       <Container>
         <Row tag="ul" className="justify-content-center">
           { cards?.map((card) => (

--- a/components/contentblocks/ActionHighlightsBlock.tsx
+++ b/components/contentblocks/ActionHighlightsBlock.tsx
@@ -5,31 +5,39 @@ import { readableColor } from 'polished';
 import PlanContext from 'context/plan';
 
 import ActionHighlightsList from 'components/actions/ActionHighlightsList';
+import { CommonContentBlockProps } from 'common/blocks.types';
 
 const ActionsSection = styled.div`
   background-color: ${(props) => props.theme.neutralLight};
   position: relative;
-  padding: ${(props) => props.theme.spaces.s800} 0 ${(props) => props.theme.spaces.s400};
-  color: ${
-    (props) => readableColor(props.theme.neutralLight, props.theme.themeColors.black, props.theme.themeColors.white)
-    };
+  padding: ${(props) => props.theme.spaces.s800} 0
+    ${(props) => props.theme.spaces.s400};
+  color: ${(props) =>
+    readableColor(
+      props.theme.neutralLight,
+      props.theme.themeColors.black,
+      props.theme.themeColors.white
+    )};
 
   .container {
     text-align: center;
   }
 
   h2 {
-    color: ${
-    (props) => readableColor(props.theme.neutralLight, props.theme.headingsColor, props.theme.themeColors.white)
-    };
+    color: ${(props) =>
+      readableColor(
+        props.theme.neutralLight,
+        props.theme.headingsColor,
+        props.theme.themeColors.white
+      )};
   }
 `;
 
-const ActionHighlightsBlock = () => {
+const ActionHighlightsBlock = ({ id = '' }: CommonContentBlockProps) => {
   const plan = useContext(PlanContext);
 
   return (
-    <ActionsSection className="actions-section">
+    <ActionsSection id={id} className="actions-section">
       <Container>
         <ActionHighlightsList plan={plan} />
       </Container>

--- a/components/contentblocks/ActionListBlock.tsx
+++ b/components/contentblocks/ActionListBlock.tsx
@@ -41,7 +41,7 @@ const SectionHeader = styled.h2`
 
 
 const ActionListBlock = (props) => {
-  const { categoryId, color } = props;
+  const { id = '', categoryId, color } = props;
   const { t } = useTranslation();
   const plan = useContext(PlanContext);
   const { loading, error, data } = useQuery(GET_ACTION_LIST_FOR_BLOCK, {
@@ -62,7 +62,7 @@ const ActionListBlock = (props) => {
 
   const heading = t('actions', getActionTermContext(plan));
   return (
-    <ActionListSection color={color}>
+    <ActionListSection id={id} color={color}>
       <Container>
         { heading && (<SectionHeader>{ heading }</SectionHeader>)}
         <ActionCardList
@@ -75,6 +75,7 @@ const ActionListBlock = (props) => {
 };
 
 ActionListBlock.propTypes = {
+  id: PropTypes.string,
   categoryId: PropTypes.string.isRequired,
   color: PropTypes.string
 };

--- a/components/contentblocks/ActionStatusGraphsBlock.tsx
+++ b/components/contentblocks/ActionStatusGraphsBlock.tsx
@@ -9,31 +9,32 @@ import PlanContext from 'context/plan';
 import { useTheme } from 'common/theme';
 import { useTranslation } from 'common/i18n';
 import ActionStatusGraphs from 'components/dashboard/ActionStatusGraphs';
+import { CommonContentBlockProps } from 'common/blocks.types';
 
 const GET_ACTION_LIST_FOR_GRAPHS = gql`
-query GetActionListForGraphs($plan: ID!) {
-  planActions(plan: $plan) {
-    color
-    statusSummary {
-      identifier
-    }
-    timeliness {
-      identifier
-    }
-    implementationPhase {
-      identifier
-      name
+  query GetActionListForGraphs($plan: ID!) {
+    planActions(plan: $plan) {
+      color
+      statusSummary {
+        identifier
+      }
+      timeliness {
+        identifier
+      }
+      implementationPhase {
+        identifier
+        name
+      }
     }
   }
-}
-`
+`;
 
-const ActionStatusGraphsBlock = () => {
+const ActionStatusGraphsBlock = ({ id = '' }: CommonContentBlockProps) => {
   const plan = useContext(PlanContext);
   const { t } = useTranslation();
   const theme = useTheme();
 
-   // add plan.feature.showActionUpdateStatus to backend
+  // add plan.feature.showActionUpdateStatus to backend
   const showUpdateStatus = theme.settings.dashboard?.showActionUpdateStatus;
 
   const { loading, error, data } = useQuery(GET_ACTION_LIST_FOR_GRAPHS, {
@@ -47,9 +48,18 @@ const ActionStatusGraphsBlock = () => {
   if (!planActions) {
     return <ErrorMessage statusCode={404} message={t('page-not-found')} />;
   }
-  return <Container><Row><Col xl={{size: 8, offset: 2}} lg={{ size: 10, offset: 1}}>
-    <ActionStatusGraphs actions={planActions} showUpdateStatus={showUpdateStatus} />
-  </Col></Row></Container>
-}
+  return (
+    <Container id={id}>
+      <Row>
+        <Col xl={{ size: 8, offset: 2 }} lg={{ size: 10, offset: 1 }}>
+          <ActionStatusGraphs
+            actions={planActions}
+            showUpdateStatus={showUpdateStatus}
+          />
+        </Col>
+      </Row>
+    </Container>
+  );
+};
 
 export default ActionStatusGraphsBlock;

--- a/components/contentblocks/CardListBlock.js
+++ b/components/contentblocks/CardListBlock.js
@@ -47,7 +47,7 @@ const CardHeader = styled.h3`
 `;
 
 const CardListBlock = (props) => {
-  const { heading, lead, cards, style } = props;
+  const { id = '', heading, lead, cards, style } = props;
   const theme = useTheme();
 
   const blockStyle = {
@@ -68,7 +68,7 @@ const CardListBlock = (props) => {
 
   // TODO : Summon a key value for cards
   return (
-    <CardListSection backgroundColor={blockStyle.backgroundColor}>
+    <CardListSection id={id} backgroundColor={blockStyle.backgroundColor}>
       <Container>
         { heading && (<SectionHeader color={blockStyle.color}>{ heading }</SectionHeader>)}
         <Content color={blockStyle.color}>{ lead }</Content>

--- a/components/contentblocks/CartographyVisualisationBlock.tsx
+++ b/components/contentblocks/CartographyVisualisationBlock.tsx
@@ -4,8 +4,9 @@ import Map, {useControl, useMap, NavigationControl} from 'react-map-gl';
 
 import LegendControl from '@kausal/mapboxgl-legend';
 import 'mapbox-gl/dist/mapbox-gl.css';
+import { CommonContentBlockProps } from 'common/blocks.types';
 
-interface CartographyVisualisationBlockProps {
+interface CartographyVisualisationBlockProps extends CommonContentBlockProps {
   styleUrl: string;
   accessToken: string;
   hasSidebar: boolean;
@@ -87,13 +88,13 @@ const LegendWithOverrides = ({styleOverrides}) => {
 }
 
 const CartographyVisualisationBlock = (props: CartographyVisualisationBlockProps) => {
-  const {styleUrl, accessToken, styleOverrides, hasSidebar} = props;
+  const {id = '', styleUrl, accessToken, styleOverrides, hasSidebar} = props;
   if (accessToken === undefined) {
     console.warn('No access token provided for MapBox visualisation.');
     return null;
   }
   return (
-    <Container>
+    <Container id={id}>
       <Row>
         <Col
           xl={{ size: 8, offset: hasSidebar ? 4 : 2 }}

--- a/components/contentblocks/CategoryListBlock.tsx
+++ b/components/contentblocks/CategoryListBlock.tsx
@@ -9,6 +9,7 @@ import Card from 'components/common/Card';
 import { MultiUseImageFragmentFragment } from 'common/__generated__/graphql';
 import { useFallbackCategories } from 'context/categories';
 import { gql } from '@apollo/client';
+import { CommonContentBlockProps } from 'common/blocks.types';
 
 const CATEGORY_FRAGMENT = gql`
   fragment CategoryListCategory on Category {
@@ -129,22 +130,26 @@ export type CategoryListBlockCategory = {
   }
 }
 
-type CategoryListBlockProps = {
-    categories?: Array<CategoryListBlockCategory>,
-    fallbackImage: MultiUseImageFragmentFragment,
-    heading?: string,
-    lead: string,
-    style?: "treemap" | "cards",
+interface CategoryListBlockProps extends CommonContentBlockProps {
+  categories?: Array<CategoryListBlockCategory>,
+  fallbackImage: MultiUseImageFragmentFragment,
+  heading?: string,
+  lead: string,
+  style?: "treemap" | "cards",
 }
 
 const CategoryListBlock = (props: CategoryListBlockProps) => {
-  let { categories } = props;
-  const { fallbackImage, heading, lead } = props;
   const fallbackCategories = useFallbackCategories();
+  const {
+    id = '',
+    fallbackImage,
+    heading,
+    lead,
+    categories = fallbackCategories,
+  } = props;
 
-  if (!categories) categories = fallbackCategories;
   return (
-    <CategoryListSection>
+    <CategoryListSection id={id}>
       <Container>
         { heading && (<SectionHeader>{ heading }</SectionHeader>)}
         <RichText html={lead} className="lead-text" />

--- a/components/contentblocks/CategoryTreeBlock.tsx
+++ b/components/contentblocks/CategoryTreeBlock.tsx
@@ -11,6 +11,7 @@ import { usePlan } from 'context/plan';
 import CategoryActionList from 'components/actions/CategoryActionList';
 import ErrorMessage from 'components/common/ErrorMessage';
 import { GetCategoriesForTreeMapQuery } from 'common/__generated__/graphql';
+import { CommonContentBlockProps } from 'common/blocks.types';
 
 const CategoryListSection = styled.div`
   background-color: ${(props) => props.theme.neutralLight};
@@ -162,6 +163,7 @@ query GetCategoriesForTreeMap($plan: ID!, $categoryType: ID!, $attributeType: ID
 `;
 
 type CategoryTreeSectionProps = {
+  id?: string;
   heading?: string,
   lead?: string,
   sections: GetCategoriesForTreeMapQuery['planCategories'],
@@ -172,7 +174,7 @@ type CategoryTreeSectionProps = {
   }
 };
 
-const CategoryTreeSection = ({ sections, valueAttribute, heading = 'Categories', hasSidebar }: CategoryTreeSectionProps) => {
+const CategoryTreeSection = ({ id = '', sections, valueAttribute, heading = 'Categories', hasSidebar }: CategoryTreeSectionProps) => {
   // console.log(sections);
   const rootSection = sections.find((sect) => sect.parent === null);
   const [activeCategory, setCategory] = useState(rootSection);
@@ -186,7 +188,7 @@ const CategoryTreeSection = ({ sections, valueAttribute, heading = 'Categories',
     }, [sections, rootSection],
   );
   return (
-    <CategoryListSection>
+    <CategoryListSection id={id}>
       <Container>
         <Row>
         <Col
@@ -228,7 +230,7 @@ const CategoryTreeSection = ({ sections, valueAttribute, heading = 'Categories',
   );
 };
 
-type CategoryTreeBlockProps = {
+interface CategoryTreeBlockProps extends CommonContentBlockProps {
   categoryType: {
     identifier: string,
   },
@@ -243,7 +245,7 @@ type CategoryTreeBlockProps = {
 }
 
 function CategoryTreeBlockBrowser(props: CategoryTreeBlockProps) {
-  const { categories:cats, heading, lead, hasSidebar } = props;
+  const { id = '', categories:cats, heading, lead, hasSidebar } = props;
   const catMap = useMemo(() => (new Map(cats.map((cat) => [cat.id, cat]))), [cats]);
 
   const findFirstAncestorColor = useCallback((id) => {
@@ -267,6 +269,7 @@ function CategoryTreeBlockBrowser(props: CategoryTreeBlockProps) {
 
   return (
     <CategoryTreeSection
+      id={id}
       heading={heading}
       lead={lead}
       sections={augmentedCategories}

--- a/components/contentblocks/FrontPageHeroBlock.js
+++ b/components/contentblocks/FrontPageHeroBlock.js
@@ -4,11 +4,12 @@ import HeroFullImage from 'components/home/HeroFullImage';
 
 const FrontPageHeroBlock = (props) => {
   const {
-    layout, imageSrc, imageAlign, heading, lead,
+    id = '', layout, imageSrc, imageAlign, heading, lead,
     altText, imageCredit,
   } = props;
   return (
     <HeroFullImage
+      id={id}
       bgImage={imageSrc}
       imageAlign={imageAlign}
       title={heading}
@@ -30,6 +31,7 @@ FrontPageHeroBlock.defaultProps = {
 };
 
 FrontPageHeroBlock.propTypes = {
+  id: PropTypes.string,
   layout: PropTypes.string,
   imageSrc: PropTypes.string,
   imageAlign: PropTypes.string,

--- a/components/contentblocks/IndicatorGroupBlock.js
+++ b/components/contentblocks/IndicatorGroupBlock.js
@@ -69,10 +69,10 @@ const IndicatorItem = (props) => {
 
 // TODO: Format as list for a11y
 const IndicatorGroupBlock = (props) => {
-  const { indicators } = props;
+  const { id = '', indicators } = props;
   const { t } = useTranslation();
   return (
-    <IndicatorGraphSection>
+    <IndicatorGraphSection id={id}>
       <Container>
         <h2>{t('indicators')}</h2>
         <Row className="justify-content-center">
@@ -90,6 +90,7 @@ const IndicatorGroupBlock = (props) => {
 };
 
 IndicatorGroupBlock.propTypes = {
+  id: PropTypes.string,
   indicators: PropTypes.arrayOf(
     PropTypes.shape(),
   ).isRequired,

--- a/components/contentblocks/IndicatorHighlightsBlock.tsx
+++ b/components/contentblocks/IndicatorHighlightsBlock.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import PlanContext from 'context/plan';
 
 import IndicatorHighlightsList from 'components/indicators/IndicatorHighlightsList';
+import { CommonContentBlockProps } from 'common/blocks.types';
 
 const IndicatorsSection = styled.div`
   background-color: ${(props) => props.theme.themeColors.white};
@@ -16,11 +17,11 @@ const IndicatorsSection = styled.div`
   }
 `;
 
-const IndicatorHighlightsBlock = () => {
+const IndicatorHighlightsBlock = ({ id = '' }: CommonContentBlockProps) => {
   const plan = useContext(PlanContext);
 
   return (
-    <IndicatorsSection className="indicators-section">
+    <IndicatorsSection id={id} className="indicators-section">
       <Container>
         <IndicatorHighlightsList plan={plan} />
       </Container>

--- a/components/contentblocks/IndicatorShowcaseBlock.js
+++ b/components/contentblocks/IndicatorShowcaseBlock.js
@@ -28,7 +28,7 @@ const IndicatorShowcase = styled.div`
 `;
 
 const IndicatorShowcaseBlock = (props) => {
-  const { indicator, title, body } = props;
+  const { id = '', indicator, title, body } = props;
   // Animation hook:  trigger when visible on screen
   const { ref, inView, entry } = useInView({
     triggerOnce: true,
@@ -37,7 +37,7 @@ const IndicatorShowcaseBlock = (props) => {
   const indicatorHasGoal = indicator.goals.length > 0;
 
   return (
-    <IndicatorShowcase>
+    <IndicatorShowcase id={id}>
       <Container>
         <Row>
           <Col
@@ -76,6 +76,7 @@ const IndicatorShowcaseBlock = (props) => {
   */
 
 IndicatorShowcaseBlock.propTypes = {
+  id: PropTypes.string,
   indicator: PropTypes.shape({
     id: PropTypes.string,
   }).isRequired,

--- a/components/contentblocks/QuestionAnswerBlock.js
+++ b/components/contentblocks/QuestionAnswerBlock.js
@@ -23,7 +23,7 @@ const FaqSection = styled.section`
 `;
 
 const QuestionAnswerBlock = (props) => {
-  const { heading, questions, hasSidebar } = props;
+  const { id = '', heading, questions, hasSidebar } = props;
   if (questions == null) {
     return null;
   }
@@ -32,7 +32,7 @@ const QuestionAnswerBlock = (props) => {
     ...question,
   }));
   return (
-    <FaqSection>
+    <FaqSection id={id}>
       <Container>
         <Row>
           <Col
@@ -65,6 +65,8 @@ QuestionAnswerBlock.defaultProps = {
 };
 
 QuestionAnswerBlock.propTypes = {
+  id: PropTypes.string,
+  hasSidebar: PropTypes.bool,
   heading: PropTypes.string,
   questions: PropTypes.arrayOf(PropTypes.object),
 };

--- a/components/contentblocks/RelatedIndicatorsBlock.js
+++ b/components/contentblocks/RelatedIndicatorsBlock.js
@@ -43,9 +43,9 @@ const IndicatorItem = (props) => {
 };
 
 const RelatedIndicatorsblock = (props) => {
-  const { indicators } = props;
+  const { id = '', indicators } = props;
   return (
-    <IndicatorGraphSection>
+    <IndicatorGraphSection id={id}>
       <Container>
         <Row className="align-items-end">
           { indicators?.map((item) => (
@@ -62,6 +62,7 @@ const RelatedIndicatorsblock = (props) => {
 };
 
 RelatedIndicatorsblock.propTypes = {
+  id: PropTypes.string,
   indicators: PropTypes.arrayOf(
     PropTypes.shape(),
   ).isRequired,

--- a/components/contentblocks/RelatedPlanListBlock.tsx
+++ b/components/contentblocks/RelatedPlanListBlock.tsx
@@ -39,7 +39,11 @@ const PlanList = styled.div`
   }
 `;
 
-const RelatedPlanListBlock = (props) => {
+interface Props {
+  id?: string
+}
+
+const RelatedPlanListBlock = ({ id }: Props) => {
   const plan = usePlan();
   const theme = useTheme();
   if (!plan.allRelatedPlans) return null;
@@ -47,7 +51,7 @@ const RelatedPlanListBlock = (props) => {
   const isParentPlan = plan.children.length > 0;
 
   return (
-    <PlanListSection>
+    <PlanListSection id={id}>
       <Container>
       <h2>
         <a href={plan.parent?.viewUrl || null}>

--- a/components/home/HeroFullImage.js
+++ b/components/home/HeroFullImage.js
@@ -121,7 +121,7 @@ const ImageCredit = styled.span`
 
 const HeroFullImage = (props) => {
   const {
-    bgImage, imageAlign, title, lead,
+    id = '', bgImage, imageAlign, title, lead,
     altText, imageCredit,
   } = props;
 
@@ -129,7 +129,7 @@ const HeroFullImage = (props) => {
   const theme = useTheme();
 
   return (
-    <Hero>
+    <Hero id={id}>
       <HeroImage
         image={bgImage}
         imageAlign={imageAlign}
@@ -163,6 +163,7 @@ HeroFullImage.defaultProps = {
 };
 
 HeroFullImage.propTypes = {
+  id: PropTypes.string,
   bgImage: PropTypes.string.isRequired,
   imageAlign: PropTypes.string,
   title: PropTypes.string.isRequired,


### PR DESCRIPTION
Add an autogenerated id to all `StreamField` blocks. For now they just follow the block index e.g. `#block-1` represents the first block in a page, in future we could improve the editor experience by allowing editors to add their own id. 