### PR TITLE
fix: support filtering indicators by custom categories

### DIFF
--- a/common/categories.ts
+++ b/common/categories.ts
@@ -147,3 +147,9 @@ export function mapActionCategories<
   });
   return mappedActions;
 }
+
+/**
+ * Format category identifier for query parameters
+ */
+export const getCategoryString = (catIdentifier: string) =>
+  `cat-${catIdentifier}`;

--- a/common/links.tsx
+++ b/common/links.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import Link, { LinkProps } from 'next/link';
 import PropTypes from 'prop-types';
 import getConfig from 'next/config';
+import { getCategoryString } from './categories';
 
 export function setBasePath() {
   const { publicRuntimeConfig } = getConfig();
@@ -150,7 +151,7 @@ ActionListLink.getLinkProps = (
   const query = {};
   if (categoryFilters) {
     categoryFilters.forEach(
-      (f) => (query[`cat-${f.typeIdentifier}`] = f.categoryId)
+      (f) => (query[getCategoryString(f.typeIdentifier)] = f.categoryId)
     );
   }
   if (organizationFilter) {

--- a/components/actions/ActionHero.tsx
+++ b/components/actions/ActionHero.tsx
@@ -12,6 +12,7 @@ import {
 import { usePlan } from 'context/plan';
 
 import Icon from 'components/common/Icon';
+import { getCategoryString } from 'common/categories';
 
 const Hero = styled.header<{ bgColor: string }>`
   position: relative;
@@ -169,9 +170,9 @@ function ActionCategories(props) {
       if (cat.identifier && showIdentifiers)
         categoryTitle = `${cat.identifier}. ${cat.name}`;
     } else if (primaryCT) {
-      displayCategories[
-        indx
-      ].url = `/actions?cat-${primaryCT.identifier}=${cat.id}`;
+      displayCategories[indx].url = `/actions?${getCategoryString(
+        primaryCT.identifier
+      )}=${cat.id}`;
     }
     displayCategories[indx].name = categoryTitle;
     displayCategories[indx].id = cat.id;
@@ -184,9 +185,9 @@ function ActionCategories(props) {
           categoryParentTitle = `${cat.parent.identifier}. ${cat.parent.name}`;
         }
       } else {
-        displayCategories[
-          indx
-        ].parent.url = `/actions?cat-${primaryCT.identifier}=${cat.parent.id}`;
+        displayCategories[indx].parent.url = `/actions?${getCategoryString(
+          primaryCT.identifier
+        )}=${cat.parent.id}`;
       }
       displayCategories[indx].parent.name = categoryParentTitle;
       displayCategories[indx].parent.id = cat.parent.id;

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -32,6 +32,7 @@ import {
   CategoryHierarchyMember,
   CategoryTypeHierarchy,
   constructCatHierarchy,
+  getCategoryString,
 } from 'common/categories';
 import Icon from 'components/common/Icon';
 import { createFilter } from 'react-select';
@@ -610,7 +611,7 @@ class CategoryFilter extends DefaultFilter<FilterValue> {
   ) {
     super();
     this.ct = config.categoryType!;
-    this.id = `cat-${this.ct!.identifier}`;
+    this.id = getCategoryString(this.ct!.identifier);
     this.showAllLabel = config.showAllLabel;
     this.hasMultipleValues =
       this.ct!.selectionType === CategoryTypeSelectWidget.Multiple;
@@ -1012,7 +1013,11 @@ ActionListFilters.constructFilters = (opts: ConstructFiltersOpts) => {
           filters.push(new CategoryFilter(block, filterByCommonCategory));
           break;
         case 'ActionAttributeTypeFilterBlock':
-          const allowedFormats = ['ORDERED_CHOICE', 'UNORDERED_CHOICE', 'OPTIONAL_CHOICE'];
+          const allowedFormats = [
+            'ORDERED_CHOICE',
+            'UNORDERED_CHOICE',
+            'OPTIONAL_CHOICE',
+          ];
           if (!allowedFormats.includes(block.attributeType.format)) {
             console.error(
               'Invalid format for ActionAttributeTypeFilterBlock: ',

--- a/components/contentblocks/ActionCategoryFilterCardsBlock.tsx
+++ b/components/contentblocks/ActionCategoryFilterCardsBlock.tsx
@@ -8,6 +8,7 @@ import { Link } from 'common/links';
 import CategoryTreeBlock from 'components/contentblocks/CategoryTreeBlock';
 import Card from 'components/common/Card';
 import { CommonContentBlockProps } from 'common/blocks.types';
+import { getCategoryString } from 'common/categories';
 
 const CategoryListSection = styled.div`
   background-color: ${(props) => props.theme.brandDark};
@@ -76,7 +77,9 @@ const CategoryListBlock = ({ id = '', cards }: Props) => {
               style={{ transition: 'all 0.5s ease' }}
             >
               <Link
-                href={`/actions?cat-${card.category.type.identifier}=${card.category.id}`}
+                href={`/actions?${getCategoryString(
+                  card.category.type.identifier
+                )}=${card.category.id}`}
               >
                 <a className="card-wrapper">
                   <Card customColor={theme.brandDark}>

--- a/components/dashboard/ActionList.tsx
+++ b/components/dashboard/ActionList.tsx
@@ -39,6 +39,7 @@ import {
   CategoryTypeHierarchy,
   constructCatHierarchy,
   mapActionCategories,
+  getCategoryString,
 } from 'common/categories';
 import { useEffect } from 'react';
 
@@ -540,7 +541,7 @@ const ActionList = (props: ActionListProps) => {
   let groupBy = 'category';
   if (
     plan.features.hasActionPrimaryOrgs &&
-    `cat-${primaryCatType.identifier}` in activeFilters
+    `${getCategoryString(primaryCatType.identifier)}` in activeFilters
   ) {
     groupBy = 'primaryOrg';
   }


### PR DESCRIPTION
Fixes the [broken Longmont umbrella plan indicator filtering](https://longmont-indicators.watch-test.kausal.tech/indicators)

Previously the category type identifier for filtering was hardcoded, this change uses the identifier of the first usable indicator category.