### PR TITLE
Fix missing breadcrumb categories and remove duplicates

### DIFF
--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -442,6 +442,7 @@ export type ActionIndicator = {
   indicator: Indicator;
 };
 
+/** An enumeration. */
 export enum ActionIndicatorEffectType {
   /** decreases */
   Decreases = 'DECREASES',
@@ -678,6 +679,7 @@ export type ActionResponsiblePartyReporteportValue = ReportValueInterface & {
   responsibleParty?: Maybe<ActionResponsibleParty>;
 };
 
+/** An enumeration. */
 export enum ActionResponsiblePartyRole {
   /** Collaborator */
   Collaborator = 'COLLABORATOR',
@@ -759,6 +761,7 @@ export type ActionStatusSummary = {
   sentiment: Sentiment;
 };
 
+/** An enumeration. */
 export enum ActionStatusSummaryIdentifier {
   Cancelled = 'CANCELLED',
   Completed = 'COMPLETED',
@@ -827,6 +830,7 @@ export type ActionTask = {
   state: ActionTaskState;
 };
 
+/** An enumeration. */
 export enum ActionTaskState {
   /** cancelled */
   Cancelled = 'CANCELLED',
@@ -857,6 +861,7 @@ export type ActionTimeliness = {
   sentiment: Sentiment;
 };
 
+/** An enumeration. */
 export enum ActionTimelinessIdentifier {
   Acceptable = 'ACCEPTABLE',
   Late = 'LATE',
@@ -1071,6 +1076,7 @@ export type AttributeTypeChoiceOption = {
   name: Scalars['String'];
 };
 
+/** An enumeration. */
 export enum AttributeTypeFormat {
   /** Category */
   CategoryChoice = 'CATEGORY_CHOICE',
@@ -1140,6 +1146,7 @@ export type CartographyProviderCredentials = {
   publicAccessToken: Scalars['String'];
 };
 
+/** An enumeration. */
 export enum CartographyProviderCredentialsProvider {
   /** MapBox */
   Mapbox = 'MAPBOX'
@@ -1484,6 +1491,7 @@ export type CategoryTypePageSiblingsArgs = {
   searchQuery?: InputMaybe<Scalars['String']>;
 };
 
+/** An enumeration. */
 export enum CategoryTypeSelectWidget {
   /** Multiple */
   Multiple = 'MULTIPLE',
@@ -1587,6 +1595,7 @@ export type CommonIndicatorNormalization = {
   unit?: Maybe<Unit>;
 };
 
+/** An enumeration. */
 export enum Comparison {
   Gt = 'GT',
   Lte = 'LTE'
@@ -2138,6 +2147,7 @@ export type IndicatorLevel = {
   plan: Plan;
 };
 
+/** An enumeration. */
 export enum IndicatorLevelLevel {
   /** operational */
   Operational = 'OPERATIONAL',
@@ -2258,6 +2268,7 @@ export type IndicatorShowcaseBlock = StreamFieldInterface & {
   title?: Maybe<Scalars['String']>;
 };
 
+/** An enumeration. */
 export enum IndicatorTimeResolution {
   /** day */
   Day = 'DAY',
@@ -2941,6 +2952,7 @@ export type PlanFeatures = {
   showAdminLink: Scalars['Boolean'];
 };
 
+/** An enumeration. */
 export enum PlanFeaturesContactPersonsPublicData {
   /** Show all information */
   All = 'ALL',
@@ -3184,6 +3196,7 @@ export type PrivacyPolicyPageSiblingsArgs = {
   searchQuery?: InputMaybe<Scalars['String']>;
 };
 
+/** An enumeration. */
 export enum PublicationStatus {
   Published = 'PUBLISHED',
   Scheduled = 'SCHEDULED',
@@ -3363,6 +3376,7 @@ export type RelatedCommonIndicator = {
   id: Scalars['ID'];
 };
 
+/** An enumeration. */
 export enum RelatedCommonIndicatorEffectType {
   /** decreases */
   Decreases = 'DECREASES',
@@ -3384,6 +3398,7 @@ export type RelatedIndicator = {
   id: Scalars['ID'];
 };
 
+/** An enumeration. */
 export enum RelatedIndicatorConfidenceLevel {
   /** high */
   High = 'HIGH',
@@ -3393,6 +3408,7 @@ export enum RelatedIndicatorConfidenceLevel {
   Medium = 'MEDIUM'
 }
 
+/** An enumeration. */
 export enum RelatedIndicatorEffectType {
   /** decreases */
   Decreases = 'DECREASES',
@@ -3541,6 +3557,7 @@ export type SearchResults = {
   hits?: Maybe<Array<Maybe<SearchHit>>>;
 };
 
+/** An enumeration. */
 export enum Sentiment {
   Negative = 'NEGATIVE',
   Neutral = 'NEUTRAL',
@@ -3564,6 +3581,7 @@ export type SiteGeneralContent = {
   siteTitle: Scalars['String'];
 };
 
+/** An enumeration. */
 export enum SiteGeneralContentActionTerm {
   /** Action */
   Action = 'ACTION',
@@ -3904,6 +3922,7 @@ export type UserFeedbackNode = {
   url: Scalars['String'];
 };
 
+/** An enumeration. */
 export enum UserFeedbackType {
   /** Accessibility */
   Accessibility = 'ACCESSIBILITY',
@@ -4042,7 +4061,52 @@ export type GetActionDetailsQuery = (
         { title: string, urlPath: string }
         & { __typename?: 'CategoryPage' }
       ) | null, parent?: (
-        { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+        { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+          { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+            { rendition?: (
+              { src: string }
+              & { __typename?: 'ImageRendition' }
+            ) | null }
+            & { __typename?: 'Image' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename?: 'CategoryType' }
+          ), level?: (
+            { id: string, name: string, namePlural?: string | null }
+            & { __typename?: 'CategoryLevel' }
+          ) | null, image?: (
+            { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename?: 'ImageRendition' }
+            ) | null, small?: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename?: 'ImageRendition' }
+            ) | null, social?: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename?: 'ImageRendition' }
+            ) | null, rendition?: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename?: 'ImageRendition' }
+            ) | null }
+            & { __typename?: 'Image' }
+          ) | null, categoryPage?: (
+            { title: string, urlPath: string }
+            & { __typename?: 'CategoryPage' }
+          ) | null }
+          & { __typename?: 'Category' }
+        ) | null, iconImage?: (
+          { rendition?: (
+            { src: string }
+            & { __typename?: 'ImageRendition' }
+          ) | null }
+          & { __typename?: 'Image' }
+        ) | null, type: (
+          { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+          & { __typename?: 'CategoryType' }
+        ), level?: (
+          { id: string, name: string, namePlural?: string | null }
+          & { __typename?: 'CategoryLevel' }
+        ) | null, image?: (
           { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
             { id: string, width: number, height: number, src: string }
             & { __typename?: 'ImageRendition' }
@@ -4054,12 +4118,6 @@ export type GetActionDetailsQuery = (
             & { __typename?: 'ImageRendition' }
           ) | null, rendition?: (
             { id: string, width: number, height: number, src: string }
-            & { __typename?: 'ImageRendition' }
-          ) | null }
-          & { __typename?: 'Image' }
-        ) | null, iconImage?: (
-          { rendition?: (
-            { src: string }
             & { __typename?: 'ImageRendition' }
           ) | null }
           & { __typename?: 'Image' }
@@ -4301,7 +4359,52 @@ export type GetActionDetailsQuery = (
           { title: string, urlPath: string }
           & { __typename?: 'CategoryPage' }
         ) | null, parent?: (
-          { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+          { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+            { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+              { rendition?: (
+                { src: string }
+                & { __typename?: 'ImageRendition' }
+              ) | null }
+              & { __typename?: 'Image' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename?: 'CategoryType' }
+            ), level?: (
+              { id: string, name: string, namePlural?: string | null }
+              & { __typename?: 'CategoryLevel' }
+            ) | null, image?: (
+              { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename?: 'ImageRendition' }
+              ) | null, small?: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename?: 'ImageRendition' }
+              ) | null, social?: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename?: 'ImageRendition' }
+              ) | null, rendition?: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename?: 'ImageRendition' }
+              ) | null }
+              & { __typename?: 'Image' }
+            ) | null, categoryPage?: (
+              { title: string, urlPath: string }
+              & { __typename?: 'CategoryPage' }
+            ) | null }
+            & { __typename?: 'Category' }
+          ) | null, iconImage?: (
+            { rendition?: (
+              { src: string }
+              & { __typename?: 'ImageRendition' }
+            ) | null }
+            & { __typename?: 'Image' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename?: 'CategoryType' }
+          ), level?: (
+            { id: string, name: string, namePlural?: string | null }
+            & { __typename?: 'CategoryLevel' }
+          ) | null, image?: (
             { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
               { id: string, width: number, height: number, src: string }
               & { __typename?: 'ImageRendition' }
@@ -4313,12 +4416,6 @@ export type GetActionDetailsQuery = (
               & { __typename?: 'ImageRendition' }
             ) | null, rendition?: (
               { id: string, width: number, height: number, src: string }
-              & { __typename?: 'ImageRendition' }
-            ) | null }
-            & { __typename?: 'Image' }
-          ) | null, iconImage?: (
-            { rendition?: (
-              { src: string }
               & { __typename?: 'ImageRendition' }
             ) | null }
             & { __typename?: 'Image' }
@@ -4480,7 +4577,52 @@ export type GetActionDetailsQuery = (
                     { title: string, urlPath: string }
                     & { __typename?: 'CategoryPage' }
                   ) | null, parent?: (
-                    { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+                    { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+                      { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+                        { rendition?: (
+                          { src: string }
+                          & { __typename?: 'ImageRendition' }
+                        ) | null }
+                        & { __typename?: 'Image' }
+                      ) | null, type: (
+                        { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                        & { __typename?: 'CategoryType' }
+                      ), level?: (
+                        { id: string, name: string, namePlural?: string | null }
+                        & { __typename?: 'CategoryLevel' }
+                      ) | null, image?: (
+                        { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+                          { id: string, width: number, height: number, src: string }
+                          & { __typename?: 'ImageRendition' }
+                        ) | null, small?: (
+                          { id: string, width: number, height: number, src: string }
+                          & { __typename?: 'ImageRendition' }
+                        ) | null, social?: (
+                          { id: string, width: number, height: number, src: string }
+                          & { __typename?: 'ImageRendition' }
+                        ) | null, rendition?: (
+                          { id: string, width: number, height: number, src: string }
+                          & { __typename?: 'ImageRendition' }
+                        ) | null }
+                        & { __typename?: 'Image' }
+                      ) | null, categoryPage?: (
+                        { title: string, urlPath: string }
+                        & { __typename?: 'CategoryPage' }
+                      ) | null }
+                      & { __typename?: 'Category' }
+                    ) | null, iconImage?: (
+                      { rendition?: (
+                        { src: string }
+                        & { __typename?: 'ImageRendition' }
+                      ) | null }
+                      & { __typename?: 'Image' }
+                    ) | null, type: (
+                      { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                      & { __typename?: 'CategoryType' }
+                    ), level?: (
+                      { id: string, name: string, namePlural?: string | null }
+                      & { __typename?: 'CategoryLevel' }
+                    ) | null, image?: (
                       { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
                         { id: string, width: number, height: number, src: string }
                         & { __typename?: 'ImageRendition' }
@@ -4492,12 +4634,6 @@ export type GetActionDetailsQuery = (
                         & { __typename?: 'ImageRendition' }
                       ) | null, rendition?: (
                         { id: string, width: number, height: number, src: string }
-                        & { __typename?: 'ImageRendition' }
-                      ) | null }
-                      & { __typename?: 'Image' }
-                    ) | null, iconImage?: (
-                      { rendition?: (
-                        { src: string }
                         & { __typename?: 'ImageRendition' }
                       ) | null }
                       & { __typename?: 'Image' }
@@ -4605,7 +4741,52 @@ export type GetActionDetailsQuery = (
                   { title: string, urlPath: string }
                   & { __typename?: 'CategoryPage' }
                 ) | null, parent?: (
-                  { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+                  { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+                    { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+                      { rendition?: (
+                        { src: string }
+                        & { __typename?: 'ImageRendition' }
+                      ) | null }
+                      & { __typename?: 'Image' }
+                    ) | null, type: (
+                      { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                      & { __typename?: 'CategoryType' }
+                    ), level?: (
+                      { id: string, name: string, namePlural?: string | null }
+                      & { __typename?: 'CategoryLevel' }
+                    ) | null, image?: (
+                      { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+                        { id: string, width: number, height: number, src: string }
+                        & { __typename?: 'ImageRendition' }
+                      ) | null, small?: (
+                        { id: string, width: number, height: number, src: string }
+                        & { __typename?: 'ImageRendition' }
+                      ) | null, social?: (
+                        { id: string, width: number, height: number, src: string }
+                        & { __typename?: 'ImageRendition' }
+                      ) | null, rendition?: (
+                        { id: string, width: number, height: number, src: string }
+                        & { __typename?: 'ImageRendition' }
+                      ) | null }
+                      & { __typename?: 'Image' }
+                    ) | null, categoryPage?: (
+                      { title: string, urlPath: string }
+                      & { __typename?: 'CategoryPage' }
+                    ) | null }
+                    & { __typename?: 'Category' }
+                  ) | null, iconImage?: (
+                    { rendition?: (
+                      { src: string }
+                      & { __typename?: 'ImageRendition' }
+                    ) | null }
+                    & { __typename?: 'Image' }
+                  ) | null, type: (
+                    { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                    & { __typename?: 'CategoryType' }
+                  ), level?: (
+                    { id: string, name: string, namePlural?: string | null }
+                    & { __typename?: 'CategoryLevel' }
+                  ) | null, image?: (
                     { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
                       { id: string, width: number, height: number, src: string }
                       & { __typename?: 'ImageRendition' }
@@ -4617,12 +4798,6 @@ export type GetActionDetailsQuery = (
                       & { __typename?: 'ImageRendition' }
                     ) | null, rendition?: (
                       { id: string, width: number, height: number, src: string }
-                      & { __typename?: 'ImageRendition' }
-                    ) | null }
-                    & { __typename?: 'Image' }
-                  ) | null, iconImage?: (
-                    { rendition?: (
-                      { src: string }
                       & { __typename?: 'ImageRendition' }
                     ) | null }
                     & { __typename?: 'Image' }
@@ -4786,7 +4961,52 @@ export type GetActionDetailsQuery = (
                     { title: string, urlPath: string }
                     & { __typename?: 'CategoryPage' }
                   ) | null, parent?: (
-                    { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+                    { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+                      { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+                        { rendition?: (
+                          { src: string }
+                          & { __typename?: 'ImageRendition' }
+                        ) | null }
+                        & { __typename?: 'Image' }
+                      ) | null, type: (
+                        { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                        & { __typename?: 'CategoryType' }
+                      ), level?: (
+                        { id: string, name: string, namePlural?: string | null }
+                        & { __typename?: 'CategoryLevel' }
+                      ) | null, image?: (
+                        { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+                          { id: string, width: number, height: number, src: string }
+                          & { __typename?: 'ImageRendition' }
+                        ) | null, small?: (
+                          { id: string, width: number, height: number, src: string }
+                          & { __typename?: 'ImageRendition' }
+                        ) | null, social?: (
+                          { id: string, width: number, height: number, src: string }
+                          & { __typename?: 'ImageRendition' }
+                        ) | null, rendition?: (
+                          { id: string, width: number, height: number, src: string }
+                          & { __typename?: 'ImageRendition' }
+                        ) | null }
+                        & { __typename?: 'Image' }
+                      ) | null, categoryPage?: (
+                        { title: string, urlPath: string }
+                        & { __typename?: 'CategoryPage' }
+                      ) | null }
+                      & { __typename?: 'Category' }
+                    ) | null, iconImage?: (
+                      { rendition?: (
+                        { src: string }
+                        & { __typename?: 'ImageRendition' }
+                      ) | null }
+                      & { __typename?: 'Image' }
+                    ) | null, type: (
+                      { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                      & { __typename?: 'CategoryType' }
+                    ), level?: (
+                      { id: string, name: string, namePlural?: string | null }
+                      & { __typename?: 'CategoryLevel' }
+                    ) | null, image?: (
                       { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
                         { id: string, width: number, height: number, src: string }
                         & { __typename?: 'ImageRendition' }
@@ -4798,12 +5018,6 @@ export type GetActionDetailsQuery = (
                         & { __typename?: 'ImageRendition' }
                       ) | null, rendition?: (
                         { id: string, width: number, height: number, src: string }
-                        & { __typename?: 'ImageRendition' }
-                      ) | null }
-                      & { __typename?: 'Image' }
-                    ) | null, iconImage?: (
-                      { rendition?: (
-                        { src: string }
                         & { __typename?: 'ImageRendition' }
                       ) | null }
                       & { __typename?: 'Image' }
@@ -4911,7 +5125,52 @@ export type GetActionDetailsQuery = (
                   { title: string, urlPath: string }
                   & { __typename?: 'CategoryPage' }
                 ) | null, parent?: (
-                  { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+                  { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+                    { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+                      { rendition?: (
+                        { src: string }
+                        & { __typename?: 'ImageRendition' }
+                      ) | null }
+                      & { __typename?: 'Image' }
+                    ) | null, type: (
+                      { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                      & { __typename?: 'CategoryType' }
+                    ), level?: (
+                      { id: string, name: string, namePlural?: string | null }
+                      & { __typename?: 'CategoryLevel' }
+                    ) | null, image?: (
+                      { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+                        { id: string, width: number, height: number, src: string }
+                        & { __typename?: 'ImageRendition' }
+                      ) | null, small?: (
+                        { id: string, width: number, height: number, src: string }
+                        & { __typename?: 'ImageRendition' }
+                      ) | null, social?: (
+                        { id: string, width: number, height: number, src: string }
+                        & { __typename?: 'ImageRendition' }
+                      ) | null, rendition?: (
+                        { id: string, width: number, height: number, src: string }
+                        & { __typename?: 'ImageRendition' }
+                      ) | null }
+                      & { __typename?: 'Image' }
+                    ) | null, categoryPage?: (
+                      { title: string, urlPath: string }
+                      & { __typename?: 'CategoryPage' }
+                    ) | null }
+                    & { __typename?: 'Category' }
+                  ) | null, iconImage?: (
+                    { rendition?: (
+                      { src: string }
+                      & { __typename?: 'ImageRendition' }
+                    ) | null }
+                    & { __typename?: 'Image' }
+                  ) | null, type: (
+                    { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                    & { __typename?: 'CategoryType' }
+                  ), level?: (
+                    { id: string, name: string, namePlural?: string | null }
+                    & { __typename?: 'CategoryLevel' }
+                  ) | null, image?: (
                     { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
                       { id: string, width: number, height: number, src: string }
                       & { __typename?: 'ImageRendition' }
@@ -4923,12 +5182,6 @@ export type GetActionDetailsQuery = (
                       & { __typename?: 'ImageRendition' }
                     ) | null, rendition?: (
                       { id: string, width: number, height: number, src: string }
-                      & { __typename?: 'ImageRendition' }
-                    ) | null }
-                    & { __typename?: 'Image' }
-                  ) | null, iconImage?: (
-                    { rendition?: (
-                      { src: string }
                       & { __typename?: 'ImageRendition' }
                     ) | null }
                     & { __typename?: 'Image' }
@@ -5179,7 +5432,52 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
               { title: string, urlPath: string }
               & { __typename?: 'CategoryPage' }
             ) | null, parent?: (
-              { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+              { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+                { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+                  { rendition?: (
+                    { src: string }
+                    & { __typename?: 'ImageRendition' }
+                  ) | null }
+                  & { __typename?: 'Image' }
+                ) | null, type: (
+                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                  & { __typename?: 'CategoryType' }
+                ), level?: (
+                  { id: string, name: string, namePlural?: string | null }
+                  & { __typename?: 'CategoryLevel' }
+                ) | null, image?: (
+                  { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename?: 'ImageRendition' }
+                  ) | null, small?: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename?: 'ImageRendition' }
+                  ) | null, social?: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename?: 'ImageRendition' }
+                  ) | null, rendition?: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename?: 'ImageRendition' }
+                  ) | null }
+                  & { __typename?: 'Image' }
+                ) | null, categoryPage?: (
+                  { title: string, urlPath: string }
+                  & { __typename?: 'CategoryPage' }
+                ) | null }
+                & { __typename?: 'Category' }
+              ) | null, iconImage?: (
+                { rendition?: (
+                  { src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null }
+                & { __typename?: 'Image' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename?: 'CategoryType' }
+              ), level?: (
+                { id: string, name: string, namePlural?: string | null }
+                & { __typename?: 'CategoryLevel' }
+              ) | null, image?: (
                 { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
                   { id: string, width: number, height: number, src: string }
                   & { __typename?: 'ImageRendition' }
@@ -5191,12 +5489,6 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
                   & { __typename?: 'ImageRendition' }
                 ) | null, rendition?: (
                   { id: string, width: number, height: number, src: string }
-                  & { __typename?: 'ImageRendition' }
-                ) | null }
-                & { __typename?: 'Image' }
-              ) | null, iconImage?: (
-                { rendition?: (
-                  { src: string }
                   & { __typename?: 'ImageRendition' }
                 ) | null }
                 & { __typename?: 'Image' }
@@ -5308,7 +5600,52 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
             { title: string, urlPath: string }
             & { __typename?: 'CategoryPage' }
           ) | null, parent?: (
-            { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+            { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+              { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+                { rendition?: (
+                  { src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null }
+                & { __typename?: 'Image' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename?: 'CategoryType' }
+              ), level?: (
+                { id: string, name: string, namePlural?: string | null }
+                & { __typename?: 'CategoryLevel' }
+              ) | null, image?: (
+                { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null, small?: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null, social?: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null, rendition?: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null }
+                & { __typename?: 'Image' }
+              ) | null, categoryPage?: (
+                { title: string, urlPath: string }
+                & { __typename?: 'CategoryPage' }
+              ) | null }
+              & { __typename?: 'Category' }
+            ) | null, iconImage?: (
+              { rendition?: (
+                { src: string }
+                & { __typename?: 'ImageRendition' }
+              ) | null }
+              & { __typename?: 'Image' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename?: 'CategoryType' }
+            ), level?: (
+              { id: string, name: string, namePlural?: string | null }
+              & { __typename?: 'CategoryLevel' }
+            ) | null, image?: (
               { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
                 { id: string, width: number, height: number, src: string }
                 & { __typename?: 'ImageRendition' }
@@ -5320,12 +5657,6 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
                 & { __typename?: 'ImageRendition' }
               ) | null, rendition?: (
                 { id: string, width: number, height: number, src: string }
-                & { __typename?: 'ImageRendition' }
-              ) | null }
-              & { __typename?: 'Image' }
-            ) | null, iconImage?: (
-              { rendition?: (
-                { src: string }
                 & { __typename?: 'ImageRendition' }
               ) | null }
               & { __typename?: 'Image' }
@@ -5432,7 +5763,52 @@ export type ReportComparisonBlockActionContentFragment = (
             { title: string, urlPath: string }
             & { __typename?: 'CategoryPage' }
           ) | null, parent?: (
-            { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+            { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+              { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+                { rendition?: (
+                  { src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null }
+                & { __typename?: 'Image' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename?: 'CategoryType' }
+              ), level?: (
+                { id: string, name: string, namePlural?: string | null }
+                & { __typename?: 'CategoryLevel' }
+              ) | null, image?: (
+                { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null, small?: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null, social?: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null, rendition?: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null }
+                & { __typename?: 'Image' }
+              ) | null, categoryPage?: (
+                { title: string, urlPath: string }
+                & { __typename?: 'CategoryPage' }
+              ) | null }
+              & { __typename?: 'Category' }
+            ) | null, iconImage?: (
+              { rendition?: (
+                { src: string }
+                & { __typename?: 'ImageRendition' }
+              ) | null }
+              & { __typename?: 'Image' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename?: 'CategoryType' }
+            ), level?: (
+              { id: string, name: string, namePlural?: string | null }
+              & { __typename?: 'CategoryLevel' }
+            ) | null, image?: (
               { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
                 { id: string, width: number, height: number, src: string }
                 & { __typename?: 'ImageRendition' }
@@ -5444,12 +5820,6 @@ export type ReportComparisonBlockActionContentFragment = (
                 & { __typename?: 'ImageRendition' }
               ) | null, rendition?: (
                 { id: string, width: number, height: number, src: string }
-                & { __typename?: 'ImageRendition' }
-              ) | null }
-              & { __typename?: 'Image' }
-            ) | null, iconImage?: (
-              { rendition?: (
-                { src: string }
                 & { __typename?: 'ImageRendition' }
               ) | null }
               & { __typename?: 'Image' }
@@ -5748,6 +6118,112 @@ export type GetActionStatusesQuery = (
   & { __typename?: 'Query' }
 );
 
+export type CategoryFieldsFragmentFragment = (
+  { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+    { rendition?: (
+      { src: string }
+      & { __typename?: 'ImageRendition' }
+    ) | null }
+    & { __typename?: 'Image' }
+  ) | null, type: (
+    { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+    & { __typename?: 'CategoryType' }
+  ), level?: (
+    { id: string, name: string, namePlural?: string | null }
+    & { __typename?: 'CategoryLevel' }
+  ) | null, image?: (
+    { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+      { id: string, width: number, height: number, src: string }
+      & { __typename?: 'ImageRendition' }
+    ) | null, small?: (
+      { id: string, width: number, height: number, src: string }
+      & { __typename?: 'ImageRendition' }
+    ) | null, social?: (
+      { id: string, width: number, height: number, src: string }
+      & { __typename?: 'ImageRendition' }
+    ) | null, rendition?: (
+      { id: string, width: number, height: number, src: string }
+      & { __typename?: 'ImageRendition' }
+    ) | null }
+    & { __typename?: 'Image' }
+  ) | null, categoryPage?: (
+    { title: string, urlPath: string }
+    & { __typename?: 'CategoryPage' }
+  ) | null }
+  & { __typename?: 'Category' }
+);
+
+export type CategoriesRecursiveFragmentFragment = (
+  { parent?: (
+    { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+      { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+        { rendition?: (
+          { src: string }
+          & { __typename?: 'ImageRendition' }
+        ) | null }
+        & { __typename?: 'Image' }
+      ) | null, type: (
+        { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+        & { __typename?: 'CategoryType' }
+      ), level?: (
+        { id: string, name: string, namePlural?: string | null }
+        & { __typename?: 'CategoryLevel' }
+      ) | null, image?: (
+        { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename?: 'ImageRendition' }
+        ) | null, small?: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename?: 'ImageRendition' }
+        ) | null, social?: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename?: 'ImageRendition' }
+        ) | null, rendition?: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename?: 'ImageRendition' }
+        ) | null }
+        & { __typename?: 'Image' }
+      ) | null, categoryPage?: (
+        { title: string, urlPath: string }
+        & { __typename?: 'CategoryPage' }
+      ) | null }
+      & { __typename?: 'Category' }
+    ) | null, iconImage?: (
+      { rendition?: (
+        { src: string }
+        & { __typename?: 'ImageRendition' }
+      ) | null }
+      & { __typename?: 'Image' }
+    ) | null, type: (
+      { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+      & { __typename?: 'CategoryType' }
+    ), level?: (
+      { id: string, name: string, namePlural?: string | null }
+      & { __typename?: 'CategoryLevel' }
+    ) | null, image?: (
+      { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename?: 'ImageRendition' }
+      ) | null, small?: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename?: 'ImageRendition' }
+      ) | null, social?: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename?: 'ImageRendition' }
+      ) | null, rendition?: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename?: 'ImageRendition' }
+      ) | null }
+      & { __typename?: 'Image' }
+    ) | null, categoryPage?: (
+      { title: string, urlPath: string }
+      & { __typename?: 'CategoryPage' }
+    ) | null }
+    & { __typename?: 'Category' }
+  ) | null }
+  & { __typename?: 'Category' }
+);
+
 export type CategoryTagsCategoryFragment = (
   { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
     { rendition?: (
@@ -5780,7 +6256,52 @@ export type CategoryTagsCategoryFragment = (
     { title: string, urlPath: string }
     & { __typename?: 'CategoryPage' }
   ) | null, parent?: (
-    { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+    { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+      { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+        { rendition?: (
+          { src: string }
+          & { __typename?: 'ImageRendition' }
+        ) | null }
+        & { __typename?: 'Image' }
+      ) | null, type: (
+        { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+        & { __typename?: 'CategoryType' }
+      ), level?: (
+        { id: string, name: string, namePlural?: string | null }
+        & { __typename?: 'CategoryLevel' }
+      ) | null, image?: (
+        { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename?: 'ImageRendition' }
+        ) | null, small?: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename?: 'ImageRendition' }
+        ) | null, social?: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename?: 'ImageRendition' }
+        ) | null, rendition?: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename?: 'ImageRendition' }
+        ) | null }
+        & { __typename?: 'Image' }
+      ) | null, categoryPage?: (
+        { title: string, urlPath: string }
+        & { __typename?: 'CategoryPage' }
+      ) | null }
+      & { __typename?: 'Category' }
+    ) | null, iconImage?: (
+      { rendition?: (
+        { src: string }
+        & { __typename?: 'ImageRendition' }
+      ) | null }
+      & { __typename?: 'Image' }
+    ) | null, type: (
+      { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+      & { __typename?: 'CategoryType' }
+    ), level?: (
+      { id: string, name: string, namePlural?: string | null }
+      & { __typename?: 'CategoryLevel' }
+    ) | null, image?: (
       { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
         { id: string, width: number, height: number, src: string }
         & { __typename?: 'ImageRendition' }
@@ -5792,12 +6313,6 @@ export type CategoryTagsCategoryFragment = (
         & { __typename?: 'ImageRendition' }
       ) | null, rendition?: (
         { id: string, width: number, height: number, src: string }
-        & { __typename?: 'ImageRendition' }
-      ) | null }
-      & { __typename?: 'Image' }
-    ) | null, iconImage?: (
-      { rendition?: (
-        { src: string }
         & { __typename?: 'ImageRendition' }
       ) | null }
       & { __typename?: 'Image' }
@@ -5873,7 +6388,52 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
       { title: string, urlPath: string }
       & { __typename?: 'CategoryPage' }
     ) | null, parent?: (
-      { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+      { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+        { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+          { rendition?: (
+            { src: string }
+            & { __typename?: 'ImageRendition' }
+          ) | null }
+          & { __typename?: 'Image' }
+        ) | null, type: (
+          { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+          & { __typename?: 'CategoryType' }
+        ), level?: (
+          { id: string, name: string, namePlural?: string | null }
+          & { __typename?: 'CategoryLevel' }
+        ) | null, image?: (
+          { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename?: 'ImageRendition' }
+          ) | null, small?: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename?: 'ImageRendition' }
+          ) | null, social?: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename?: 'ImageRendition' }
+          ) | null, rendition?: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename?: 'ImageRendition' }
+          ) | null }
+          & { __typename?: 'Image' }
+        ) | null, categoryPage?: (
+          { title: string, urlPath: string }
+          & { __typename?: 'CategoryPage' }
+        ) | null }
+        & { __typename?: 'Category' }
+      ) | null, iconImage?: (
+        { rendition?: (
+          { src: string }
+          & { __typename?: 'ImageRendition' }
+        ) | null }
+        & { __typename?: 'Image' }
+      ) | null, type: (
+        { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+        & { __typename?: 'CategoryType' }
+      ), level?: (
+        { id: string, name: string, namePlural?: string | null }
+        & { __typename?: 'CategoryLevel' }
+      ) | null, image?: (
         { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
           { id: string, width: number, height: number, src: string }
           & { __typename?: 'ImageRendition' }
@@ -5885,12 +6445,6 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
           & { __typename?: 'ImageRendition' }
         ) | null, rendition?: (
           { id: string, width: number, height: number, src: string }
-          & { __typename?: 'ImageRendition' }
-        ) | null }
-        & { __typename?: 'Image' }
-      ) | null, iconImage?: (
-        { rendition?: (
-          { src: string }
           & { __typename?: 'ImageRendition' }
         ) | null }
         & { __typename?: 'Image' }
@@ -6002,7 +6556,52 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
       { title: string, urlPath: string }
       & { __typename?: 'CategoryPage' }
     ) | null, parent?: (
-      { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+      { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+        { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+          { rendition?: (
+            { src: string }
+            & { __typename?: 'ImageRendition' }
+          ) | null }
+          & { __typename?: 'Image' }
+        ) | null, type: (
+          { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+          & { __typename?: 'CategoryType' }
+        ), level?: (
+          { id: string, name: string, namePlural?: string | null }
+          & { __typename?: 'CategoryLevel' }
+        ) | null, image?: (
+          { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename?: 'ImageRendition' }
+          ) | null, small?: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename?: 'ImageRendition' }
+          ) | null, social?: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename?: 'ImageRendition' }
+          ) | null, rendition?: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename?: 'ImageRendition' }
+          ) | null }
+          & { __typename?: 'Image' }
+        ) | null, categoryPage?: (
+          { title: string, urlPath: string }
+          & { __typename?: 'CategoryPage' }
+        ) | null }
+        & { __typename?: 'Category' }
+      ) | null, iconImage?: (
+        { rendition?: (
+          { src: string }
+          & { __typename?: 'ImageRendition' }
+        ) | null }
+        & { __typename?: 'Image' }
+      ) | null, type: (
+        { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+        & { __typename?: 'CategoryType' }
+      ), level?: (
+        { id: string, name: string, namePlural?: string | null }
+        & { __typename?: 'CategoryLevel' }
+      ) | null, image?: (
         { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
           { id: string, width: number, height: number, src: string }
           & { __typename?: 'ImageRendition' }
@@ -6014,12 +6613,6 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
           & { __typename?: 'ImageRendition' }
         ) | null, rendition?: (
           { id: string, width: number, height: number, src: string }
-          & { __typename?: 'ImageRendition' }
-        ) | null }
-        & { __typename?: 'Image' }
-      ) | null, iconImage?: (
-        { rendition?: (
-          { src: string }
           & { __typename?: 'ImageRendition' }
         ) | null }
         & { __typename?: 'Image' }
@@ -8771,7 +9364,52 @@ export type GetPlanPageGeneralQuery = (
             { title: string, urlPath: string }
             & { __typename?: 'CategoryPage' }
           ) | null, parent?: (
-            { id: string, identifier: string, name: string, color?: string | null, iconSvgUrl?: string | null, image?: (
+            { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, parent?: (
+              { id: string, identifier: string, name: string, leadParagraph: string, color?: string | null, iconSvgUrl?: string | null, helpText: string, iconImage?: (
+                { rendition?: (
+                  { src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null }
+                & { __typename?: 'Image' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename?: 'CategoryType' }
+              ), level?: (
+                { id: string, name: string, namePlural?: string | null }
+                & { __typename?: 'CategoryLevel' }
+              ) | null, image?: (
+                { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null, small?: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null, social?: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null, rendition?: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename?: 'ImageRendition' }
+                ) | null }
+                & { __typename?: 'Image' }
+              ) | null, categoryPage?: (
+                { title: string, urlPath: string }
+                & { __typename?: 'CategoryPage' }
+              ) | null }
+              & { __typename?: 'Category' }
+            ) | null, iconImage?: (
+              { rendition?: (
+                { src: string }
+                & { __typename?: 'ImageRendition' }
+              ) | null }
+              & { __typename?: 'Image' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename?: 'CategoryType' }
+            ), level?: (
+              { id: string, name: string, namePlural?: string | null }
+              & { __typename?: 'CategoryLevel' }
+            ) | null, image?: (
               { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, large?: (
                 { id: string, width: number, height: number, src: string }
                 & { __typename?: 'ImageRendition' }
@@ -8783,12 +9421,6 @@ export type GetPlanPageGeneralQuery = (
                 & { __typename?: 'ImageRendition' }
               ) | null, rendition?: (
                 { id: string, width: number, height: number, src: string }
-                & { __typename?: 'ImageRendition' }
-              ) | null }
-              & { __typename?: 'Image' }
-            ) | null, iconImage?: (
-              { rendition?: (
-                { src: string }
                 & { __typename?: 'ImageRendition' }
               ) | null }
               & { __typename?: 'Image' }

--- a/components/actions/CategoryTags.tsx
+++ b/components/actions/CategoryTags.tsx
@@ -164,7 +164,7 @@ function CategoryTags(props: CategoryTagsProps) {
 }
 
 export const categoryFragment = gql`
-  fragment CategoryTagsCategory on Category {
+  fragment CategoryFieldsFragment on Category {
     id
     identifier
     name
@@ -194,25 +194,24 @@ export const categoryFragment = gql`
       title
       urlPath
     }
+  }
+
+  # Support parent categories up to two levels deep
+  fragment CategoriesRecursiveFragment on Category {
     parent {
-      id
-      identifier
-      name
-      image {
-        ...MultiUseImageFragment
-      }
-      color
-      iconSvgUrl
-      iconImage {
-        rendition(size: "400x400", crop: false) {
-          src
+      ...CategoryFieldsFragment
+      parent {
+        ...CategoryFieldsFragment
+        parent {
+          ...CategoryFieldsFragment
         }
       }
-      categoryPage {
-        title
-        urlPath
-      }
     }
+  }
+
+  fragment CategoryTagsCategory on Category {
+    ...CategoryFieldsFragment
+    ...CategoriesRecursiveFragment
   }
 `;
 


### PR DESCRIPTION
1. Fix duplicate categories in the breadcrumb

<img width="1512" alt="Screenshot 2023-09-22 at 11 16 12" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/e44ff99c-a127-45a5-baf8-956ad1626b28">

2. Fix missing top level category: category hierarchies will be displayed in the breadcrumb up to three levels deep

<img width="1512" alt="Screenshot 2023-09-22 at 11 17 01" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/abd30648-07f4-4ec8-aba5-e5a82aa80b94">
