### PR TITLE
Support custom category icon sizes

### DIFF
--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -9448,7 +9448,7 @@ export type PlanContextFragment = (
 
 export type TemplatedCategoryPageFragmentFragment = (
   { layout?: (
-    { layoutMainTop?: Array<(
+    { iconSize?: string | null, layoutMainTop?: Array<(
       { attributeType: (
         { identifier: string }
         & { __typename?: 'AttributeType' }
@@ -10384,7 +10384,7 @@ export type GetPlanPageGeneralQuery = (
       ) | null> | null }
       & { __typename?: 'QuestionAnswerBlock' }
     ) | null> | null, layout?: (
-      { layoutMainTop?: Array<(
+      { iconSize?: string | null, layoutMainTop?: Array<(
         { attributeType: (
           { identifier: string }
           & { __typename?: 'AttributeType' }

--- a/components/contentblocks/CategoryPageHeaderBlock.tsx
+++ b/components/contentblocks/CategoryPageHeaderBlock.tsx
@@ -2,14 +2,12 @@ import React, { useContext } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import { Container, Row, Col } from 'reactstrap';
 import styled from 'styled-components';
+import { Theme } from '@kausal/themes/types';
 import PlanContext, { usePlan } from 'context/plan';
 import { Link } from 'common/links';
 import { useTranslation } from 'common/i18n';
 import CategoryMetaBar from 'components/actions/CategoryMetaBar';
-import AttributesBlock, {
-  Attributes,
-  attributeHasValue,
-} from 'components/common/AttributesBlock';
+import AttributesBlock, { Attributes } from 'components/common/AttributesBlock';
 import { useTheme } from 'common/theme';
 import {
   CategoryPageMainTopBlock,
@@ -39,6 +37,12 @@ export const GET_CATEGORY_ATTRIBUTE_TYPES = gql`
     }
   }
 `;
+
+enum IconSize {
+  S = 'S',
+  M = 'M',
+  L = 'L',
+}
 
 const CategoryHeader = styled.div`
   width: 100%;
@@ -157,8 +161,20 @@ const Breadcrumb = styled.div`
   margin-bottom: ${(props) => props.theme.spaces.s100};
 `;
 
-const CategoryIconImage = styled.img`
-  max-height: ${(props) => props.theme.spaces.s600};
+const getIconHeight = (size: IconSize = IconSize.M, theme: Theme) => {
+  switch (size) {
+    case IconSize.L:
+      return '180px';
+    case IconSize.S:
+      return theme.spaces.s400;
+    case IconSize.M:
+    default:
+      return theme.spaces.s600;
+  }
+};
+
+const CategoryIconImage = styled.img<{ size?: IconSize }>`
+  max-height: ${({ theme, size }) => getIconHeight(size, theme)};
   margin-bottom: ${(props) => props.theme.spaces.s100};
 `;
 
@@ -313,7 +329,13 @@ function CategoryPageHeaderBlock({
                   /
                 </Breadcrumb>
               )}
-              {iconImage && <CategoryIconImage src={iconImage} alt />}
+              {iconImage && (
+                <CategoryIconImage
+                  size={(page?.layout?.iconSize as IconSize) ?? undefined}
+                  src={iconImage}
+                  alt=""
+                />
+              )}
               <h1>
                 {identifier && <Identifier>{identifier}.</Identifier>} {title}
               </h1>

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -24,6 +24,7 @@ const templatedCategoryPageFragment = gql`
   fragment TemplatedCategoryPageFragment on CategoryPage {
     layout {
       __typename
+      iconSize
       layoutMainTop {
         __typename
         ... on CategoryPageAttributeTypeBlock {


### PR DESCRIPTION
Requested by Surrey who use illustrations as category icons. Editors can specify an icon size of small, medium or large under category type page → "Level layouts" → "Icon size"

<img width="1225" alt="Screenshot 2023-09-28 at 11 43 38" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/4cebb694-1198-4ac5-a996-14db46c0b97f">