### PR TITLE
Ignore empty category page main templates

### DIFF
--- a/components/categories/CategoryPageContent.tsx
+++ b/components/categories/CategoryPageContent.tsx
@@ -79,7 +79,7 @@ const CategoryPageContent = ({
   page: CategoryPage;
   pageSectionColor: string;
 }) => {
-  const hasMainContentTemplate = !!page.layout?.layoutMainBottom;
+  const hasMainContentTemplate = !!page.layout?.layoutMainBottom?.length;
   const hasAsideTemplate = !!page.layout?.layoutAside;
   const hasAside =
     hasAsideTemplate &&


### PR DESCRIPTION
Fall back to legacy category page rendering if no blocks have been defined