### PR TITLE
Improve area graphs and use trend line visibility setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@elastic/react-search-ui": "^1.11.2",
     "@kausal/mapboxgl-legend": "^1.7.2",
     "@kausal/plotly-custom": "^2.14.3",
-    "@kausal/themes": "^0.6.3",
+    "@kausal/themes": "^0.6.4",
     "@koa/router": "^10.1.1",
     "@n8tb1t/use-scroll-position": "^2.0.3",
     "@next/bundle-analyzer": "^12.1.6",
@@ -156,7 +156,7 @@
   ],
   "packageManager": "yarn@3.2.1",
   "optionalDependencies": {
-    "@kausal/themes-private": "^0.2.68"
+    "@kausal/themes-private": "^0.2.69"
   },
   "lint-staged": {
     "*.{tsx,ts,js,css,scss,md,json}": "prettier --write"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3395,17 +3395,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kausal/themes-private@npm:^0.2.68":
-  version: 0.2.68
-  resolution: "@kausal/themes-private@npm:0.2.68"
-  checksum: 8d473f85a13b8f70f2a6c904f23644c30ac1543aaaec15267a899dd772da92dd39a150b1cdec84b0552b5ce4316d819647fbb708b2e1d3681b4b0f17fa2395f0
+"@kausal/themes-private@npm:^0.2.69":
+  version: 0.2.69
+  resolution: "@kausal/themes-private@npm:0.2.69"
+  checksum: 072ddc60a7cd7a067c4052b136d8762a98a7d28cada2805d623b02d32f34096237d8def087af040a057ae95c374a73aed0795c680f37b253597e3cf839003f88
   languageName: node
   linkType: hard
 
-"@kausal/themes@npm:^0.6.3":
-  version: 0.6.3
-  resolution: "@kausal/themes@npm:0.6.3"
-  checksum: 5cca72397dd2c298f63023b0021fc10c65035bf849aabe4e8954f0df05d34e0d148506a3354e4be6ead99eddbf35192a8fec8c4da8e9ae8b02ad0fe6b8c69e6d
+"@kausal/themes@npm:^0.6.4":
+  version: 0.6.4
+  resolution: "@kausal/themes@npm:0.6.4"
+  checksum: 3223c70910df7c439b8aa9193686f34088c24c759a1bf8c0ee9056e2c1fa1815cabef1cee3559a2e4f7a38161338902ea82d6d0653d575f543dc81334d1540aa
   languageName: node
   linkType: hard
 
@@ -16899,8 +16899,8 @@ __metadata:
     "@graphql-codegen/typescript-react-apollo": ^3.3.7
     "@kausal/mapboxgl-legend": ^1.7.2
     "@kausal/plotly-custom": ^2.14.3
-    "@kausal/themes": ^0.6.3
-    "@kausal/themes-private": ^0.2.68
+    "@kausal/themes": ^0.6.4
+    "@kausal/themes-private": ^0.2.69
     "@koa/router": ^10.1.1
     "@n8tb1t/use-scroll-position": ^2.0.3
     "@next/bundle-analyzer": ^12.1.6


### PR DESCRIPTION
Improve drawing indicator graphs if `graphs.areaGraphs=true` in theme (should be in backend)
Also implement `graphs.showTrendline=false` theme setting (should be in backend)
From this:
<img width="887" alt="Screenshot 2023-10-02 at 22 05 22" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/16fa61b4-7b62-4e18-a389-ad2fa17f12a1">
to this (do not fill if multiple traces)
<img width="799" alt="Screenshot 2023-10-02 at 22 05 04" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/f1f78fdc-a3b7-4655-8a2d-0baffa814ded">
http://klima-winterthur.localhost:3000/indicators/1687

And from this:
<img width="903" alt="Screenshot 2023-10-02 at 22 06 55" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/4c3be165-e04a-4d9d-851b-664c21f97658">
to this (no trend line, fill also goal as per customer request):
<img width="809" alt="Screenshot 2023-10-02 at 22 07 18" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/28a19a37-af8b-4a45-8fd7-01e9c1a65685">
http://klima-winterthur.localhost:3000/indicators/2056


