### PR TITLE
Fix id contrast for reverse colour category badges

### DIFF
--- a/components/actions/CategoryTags.tsx
+++ b/components/actions/CategoryTags.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { ActionListLink, StaticPageLink } from 'common/links';
 import BadgeTooltip from 'components/common/BadgeTooltip';
 import PopoverTip from 'components/common/PopoverTip';
+import { readableColor } from 'polished';
 import {
   CategoryTagsCategoryFragment,
   CategoryTagsCategoryTypeFragment,
@@ -87,7 +88,12 @@ type CategoryContentProps = {
 };
 
 const Identifier = styled.span`
-  color: ${(props) => props.theme.graphColors.grey060};
+  color: ${(props) =>
+    readableColor(
+      props.theme.neutralLight,
+      props.theme.graphColors.grey070,
+      props.theme.graphColors.grey020
+    )};
 `;
 
 export const CategoryContent = (props: CategoryContentProps) => {


### PR DESCRIPTION
![Screenshot 2023-10-25 at 17 00 50](https://github.com/kausaltech/kausal-watch-ui/assets/664877/6981ea33-b3f5-49e3-a367-7a5c23701d0d)
![Screenshot 2023-10-25 at 17 00 40](https://github.com/kausaltech/kausal-watch-ui/assets/664877/968bd25e-1ada-430a-9f05-d6b120a0878a)
![Screenshot 2023-10-25 at 17 00 29](https://github.com/kausaltech/kausal-watch-ui/assets/664877/4557cb25-72d8-4344-a872-7fd9f11ba610)
