### PR TITLE
fix: navigate to active plan home rather than root umbrella plan

### DIFF
--- a/components/common/GlobalNav.tsx
+++ b/components/common/GlobalNav.tsx
@@ -513,7 +513,7 @@ function GlobalNav(props) {
               {homeLink && (
                 <NavItem active={activeBranch === ''}>
                   <NavLink>
-                    <NavigationLink slug={rootLink}>
+                    <NavigationLink slug={plan.viewUrl ?? '/'}>
                       <NavHighlighter
                         className={`highlighter ${
                           activeBranch === '' ? 'active' : ''


### PR DESCRIPTION
Rather than navigating to the root umbrella plan, navigate to the current plan home under the secondary navigation "Home" link