### PR TITLE
Accommodate multiple logos on custom bgcolor in footer

### DIFF
--- a/components/common/SiteFooter.tsx
+++ b/components/common/SiteFooter.tsx
@@ -9,7 +9,6 @@ import { useTranslation, withTranslation } from 'common/i18n';
 import { NavigationLink, Link } from 'common/links';
 import Icon from './Icon';
 import PlanSelector from 'components/plans/PlanSelector';
-import { usePlan } from 'context/plan';
 import { useTheme } from 'common/theme';
 
 const StyledFooter = styled.footer`
@@ -17,19 +16,19 @@ const StyledFooter = styled.footer`
   min-height: 14em;
   clear: both;
   background-color: ${(props) => props.theme.footerBackgroundColor};
-  color: ${(props) => transparentize(0.2, props.theme.footerColor)}};
+  color: ${(props) => transparentize(0.2, props.theme.footerColor)};
   padding: ${(props) => props.theme.spaces.s400} 0;
 
   a {
+    color: ${(props) => props.theme.footerColor};
+
+    &:hover {
       color: ${(props) => props.theme.footerColor};
-
-      &:hover {
-        color: ${(props) => props.theme.footerColor};
-        text-decoration: underline;
-      }
+      text-decoration: underline;
     }
+  }
 
-  .footer-column{
+  .footer-column {
     @media (max-width: ${(props) => props.theme.breakpointMd}) {
       margin-bottom: ${(props) => props.theme.spaces.s300};
       text-align: center;
@@ -37,8 +36,8 @@ const StyledFooter = styled.footer`
   }
 
   @media (max-width: ${(props) => props.theme.breakpointMd}) {
-      text-align: center;
-    }
+    text-align: center;
+  }
 
   @media print {
     display: none;
@@ -306,15 +305,13 @@ const BaseLink = styled.li`
   }
 `;
 
-const FooterExtras = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+const SecondFooter = styled.div`
+  background-color: ${(props) => props.theme.secondFooterBackgroundColor};
+  color: ${(props) => props.theme.secondFooterColor};
+`;
 
-  @media (min-width: ${(props) => props.theme.breakpointMd}) {
-    flex-direction: row;
-    width: 100%;
-  }
+const FooterExtras = styled.div`
+  padding: ${(props) => props.theme.spaces.s100} 0;
 `;
 
 const FooterStatement = styled.div`
@@ -334,6 +331,7 @@ const FooterStatement = styled.div`
 `;
 
 const FundingInstruments = styled.div`
+  width: 100%;
   flex: 1 0 auto;
   display: flex;
   flex-wrap: wrap;
@@ -362,6 +360,11 @@ const FundingInstrumentContainer = styled.div`
   width: calc(2 * ${(props) => props.theme.spaces.s800});
   margin-left: ${(props) => props.theme.spaces.s300};
   text-align: right;
+
+  &.small {
+    height: calc(2 * ${(props) => props.theme.spaces.s400});
+    width: calc(2 * ${(props) => props.theme.spaces.s400});
+  }
 
   svg {
     height: 100%;
@@ -580,50 +583,57 @@ function SiteFooter(props) {
             </BaseLink>
           </BaseColumn>
         </BaseSection>
-        <FooterExtras>
-          {footerStatement && (
-            <FooterStatement
-              dangerouslySetInnerHTML={{ __html: footerStatement }}
-            />
-          )}
-          {fundingInstruments?.length > 0 && (
-            <FundingInstruments>
-              <FundingHeader>{t('supported-by')}</FundingHeader>
-              {fundingInstruments.map((funder) => (
-                <FundingInstrumentContainer key={funder.id}>
-                  <a href={funder.link} target="_blank" rel="noreferrer">
-                    <SVG
-                      src={funder.logo}
-                      preserveAspectRatio="xMidYMid meet"
-                      title={funder.name}
-                    />
-                  </a>
-                </FundingInstrumentContainer>
-              ))}
-            </FundingInstruments>
-          )}
-          {otherLogos?.length > 0 && (
-            <FundingInstruments>
-              {otherLogos.map((logo) => (
-                <FundingInstrumentContainer key={logo.id}>
-                  <a
-                    href={logo.link ? logo.link : '#'}
-                    target={logo.link ? '_blank' : '_self'}
-                    rel={logo.link ? 'noreferrer' : ''}
-                  >
-                    <SVG
-                      src={logo.logo}
-                      preserveAspectRatio="xMidYMid meet"
-                      title={logo.name}
-                      style={{ display: 'block' }}
-                    />
-                  </a>
-                </FundingInstrumentContainer>
-              ))}
-            </FundingInstruments>
-          )}
-        </FooterExtras>
       </Container>
+      <SecondFooter>
+        <Container>
+          <FooterExtras>
+            {fundingInstruments?.length > 0 && (
+              <FundingInstruments>
+                <FundingHeader>{t('supported-by')}</FundingHeader>
+                {fundingInstruments.map((funder) => (
+                  <FundingInstrumentContainer key={funder.id}>
+                    <a href={funder.link} target="_blank" rel="noreferrer">
+                      <SVG
+                        src={funder.logo}
+                        preserveAspectRatio="xMidYMid meet"
+                        title={funder.name}
+                      />
+                    </a>
+                  </FundingInstrumentContainer>
+                ))}
+              </FundingInstruments>
+            )}
+            {otherLogos?.length > 0 && (
+              <FundingInstruments>
+                {otherLogos.map((logo) => (
+                  <FundingInstrumentContainer
+                    key={logo.id}
+                    className={otherLogos.length > 3 ? 'small' : ''}
+                  >
+                    <a
+                      href={logo.link ? logo.link : '#'}
+                      target={logo.link ? '_blank' : '_self'}
+                      rel={logo.link ? 'noreferrer' : ''}
+                    >
+                      <SVG
+                        src={logo.logo}
+                        preserveAspectRatio="xMidYMid meet"
+                        title={logo.name}
+                        style={{ display: 'block' }}
+                      />
+                    </a>
+                  </FundingInstrumentContainer>
+                ))}
+              </FundingInstruments>
+            )}
+            {footerStatement && (
+              <FooterStatement
+                dangerouslySetInnerHTML={{ __html: footerStatement }}
+              />
+            )}
+          </FooterExtras>
+        </Container>
+      </SecondFooter>
     </StyledFooter>
   );
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@elastic/react-search-ui": "^1.11.2",
     "@kausal/mapboxgl-legend": "^1.7.2",
     "@kausal/plotly-custom": "^2.14.3",
-    "@kausal/themes": "^0.7.0",
+    "@kausal/themes": "^0.7.2",
     "@koa/router": "^10.1.1",
     "@n8tb1t/use-scroll-position": "^2.0.3",
     "@next/bundle-analyzer": "^12.1.6",
@@ -158,7 +158,7 @@
   ],
   "packageManager": "yarn@3.2.1",
   "optionalDependencies": {
-    "@kausal/themes-private": "^0.3.5"
+    "@kausal/themes-private": "^0.3.7"
   },
   "lint-staged": {
     "*.{tsx,ts,js,css,scss,md,json}": "prettier --write"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3413,17 +3413,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kausal/themes-private@npm:^0.3.5":
-  version: 0.3.5
-  resolution: "@kausal/themes-private@npm:0.3.5"
-  checksum: aa3b684676b1e698d7f365564436d231087e6cf7c39d32d3024dd23e80078bd62202cc768272fee07e39a2187ee26f83dea8c1587da3df10f73bed317857e6e3
+"@kausal/themes-private@npm:^0.3.7":
+  version: 0.3.7
+  resolution: "@kausal/themes-private@npm:0.3.7"
+  checksum: 105647402f435e41ae609c6b6e1de2b0afbd032e258d0baf26892123deecb5c78709ec480cfe204b0137314a8d5a842c054733f8d0072cf727ee67fe188d57f6
   languageName: node
   linkType: hard
 
-"@kausal/themes@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "@kausal/themes@npm:0.7.0"
-  checksum: 572e8cda465723322eb86b4496a1ecb43c68a10981a45b34ef323c04b4b4311fdebab8139c9e37f7467ebfbde4f84c2d644b7784ac88717c97ca51802e118dde
+"@kausal/themes@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "@kausal/themes@npm:0.7.2"
+  checksum: 9e1fb7b21aa48aacf3a4c874a1f43b9e7420db1954a207fc46067cb89fcbe089984a838ec5ce3085e1b8fcf49ce4ce2e791b40aeae2f244221f4626991add039
   languageName: node
   linkType: hard
 
@@ -17085,8 +17085,8 @@ __metadata:
     "@graphql-codegen/typescript-react-apollo": ^3.3.7
     "@kausal/mapboxgl-legend": ^1.7.2
     "@kausal/plotly-custom": ^2.14.3
-    "@kausal/themes": ^0.7.0
-    "@kausal/themes-private": ^0.3.5
+    "@kausal/themes": ^0.7.2
+    "@kausal/themes-private": ^0.3.7
     "@koa/router": ^10.1.1
     "@n8tb1t/use-scroll-position": ^2.0.3
     "@next/bundle-analyzer": ^12.1.6


### PR DESCRIPTION
** requires theme update **
https://github.com/kausaltech/kausal-themes/pull/7

- Use new theme variables to enable different footer colors for secondary footer content (Statement, Funding logos, Other logos)
- Style more than 3 extra logos smaller

<img width="1358" alt="Screenshot 2023-10-31 at 18 16 13" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/232d7c8d-d027-4e41-a64a-d224c50040c1">

Side effects:
If second footer contains statement AND otherLogos they are not adjacent anymore:
 
<img width="1343" alt="Screenshot 2023-10-31 at 18 25 02" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/4c1f7ef5-bc1b-4053-bc1b-79ea8880c287">

Needs more work to handle this edge case, but should be ok for now


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205750873498146