### PR TITLE
Hide redundant action status visualisation

### DIFF
--- a/components/actions/ActionPhase.js
+++ b/components/actions/ActionPhase.js
@@ -73,7 +73,9 @@ function Phase(props) {
   const theme = useTheme();
 
   let blockColor = theme.themeColors.light;
-  const color = getStatusColorForAction(action, plan, theme);
+  const color = statusSummary
+    ? getStatusColorForAction(action, plan, theme)
+    : theme.graphColors.grey050;
 
   let labelClass = 'disabled';
 
@@ -85,7 +87,7 @@ function Phase(props) {
   } else if (active) {
     blockColor = color;
     labelClass = 'active';
-  } else if (statusSummary.isCompleted) {
+  } else if (statusSummary?.isCompleted) {
     blockColor = color;
     labelClass = 'disabled';
   }
@@ -115,9 +117,10 @@ function ActionPhase(props) {
   }
   // Override phase name in special case statuses
   const inactive = ['cancelled', 'merged', 'postponed', 'completed'].includes(
-    status.identifier
+    status?.identifier
   );
-  if (inactive) {
+
+  if (status && inactive) {
     activePhaseName =
       status.identifier === ActionStatusSummaryIdentifier.Merged
         ? `${t('actions:action-status-merged', getActionTermContext(plan))}`
@@ -141,7 +144,7 @@ function ActionPhase(props) {
           />
         ))}
       </ul>
-      {!compact && status.identifier !== 'UNDEFINED' && (
+      {!compact && !!status && status.identifier !== 'UNDEFINED' && (
         <>
           <strong>{status.label}</strong>
           {reason && (
@@ -158,7 +161,8 @@ function ActionPhase(props) {
 }
 
 ActionPhase.propTypes = {
-  status: PropTypes.shape().isRequired,
+  /** If status is undefined, status colors and labels will be hidden */
+  status: PropTypes.shape(),
   activePhase: PropTypes.shape(),
   reason: PropTypes.string,
   phases: PropTypes.arrayOf(

--- a/components/dashboard/ActionStatusTable.tsx
+++ b/components/dashboard/ActionStatusTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useState, createContext } from 'react';
 import { Table, Button } from 'reactstrap';
 import styled from 'styled-components';
 
@@ -15,6 +15,21 @@ import {
 } from './dashboard.types';
 import { PlanContextFragment } from 'common/__generated__/graphql';
 import { COLUMN_CONFIG } from './dashboard.constants';
+
+type TActionTableContext = {
+  plan?: PlanContextFragment;
+  planViewUrl?: string | null;
+  /** Custom configuration for cell components */
+  config: {
+    hasPhaseAndStatusColumns?: boolean;
+  };
+};
+
+export const ActionTableContext = createContext<TActionTableContext>({
+  plan: undefined,
+  planViewUrl: undefined,
+  config: {},
+});
 
 const TableWrapper = styled.div`
   width: 100%;
@@ -163,6 +178,12 @@ const preprocessForSorting = (
   }
 };
 
+const hasPhaseAndStatusColumns = (columns: ColumnConfig[]) =>
+  !!(
+    columns.find((c) => c.__typename === 'ImplementationPhaseColumnBlock') &&
+    columns.find((c) => c.__typename === 'StatusColumnBlock')
+  );
+
 interface Props {
   actions: ActionListAction[];
   orgs: ActionListOrganization[];
@@ -232,7 +253,15 @@ const ActionStatusTable = (props: Props) => {
     : columns;
 
   return (
-    <>
+    <ActionTableContext.Provider
+      value={{
+        plan,
+        planViewUrl,
+        config: {
+          hasPhaseAndStatusColumns: hasPhaseAndStatusColumns(filteredColumns),
+        },
+      }}
+    >
       <ToolBar>
         <ResetSorting>
           {sort.key && (
@@ -294,7 +323,7 @@ const ActionStatusTable = (props: Props) => {
           </tbody>
         </DashTable>
       </TableWrapper>
-    </>
+    </ActionTableContext.Provider>
   );
 };
 

--- a/components/dashboard/ActionTableTooltips.tsx
+++ b/components/dashboard/ActionTableTooltips.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
 import dayjs from 'common/dayjs';
 import {
@@ -11,6 +11,7 @@ import { ActionListAction } from './dashboard.types';
 import { PlanContextFragment } from 'common/__generated__/graphql';
 import { getTaskCounts } from './cells/TasksStatusCell';
 import { useTheme } from 'common/theme';
+import { ActionTableContext } from './ActionStatusTable';
 
 const TooltipTitle = styled.p`
   font-weight: ${(props) => props.theme.fontWeightBold};
@@ -126,13 +127,17 @@ export const TasksTooltipContent = ({ action, plan }: TooltipWithPlanProps) => {
 // TODO: Should we split implementation phase and status?
 export const ImplementationPhaseTooltipContent = ({
   action,
-  plan,
 }: TooltipWithPlanProps) => {
   const { t } = useTranslation(['common', 'actions']);
+  const { plan, config } = useContext(ActionTableContext);
 
   const activePhase = action.implementationPhase;
   const merged = action.mergedWith;
   const status = action.statusSummary;
+
+  if (!plan) {
+    return null;
+  }
 
   const getMergedName = (mergedWith, planId) => {
     if (mergedWith.plan.id !== planId) {
@@ -145,6 +150,7 @@ export const ImplementationPhaseTooltipContent = ({
   const statusDisplay = (
     <StatusLabel $color={status?.color}>{status.label}</StatusLabel>
   );
+
   // If action is merged, display merged status
   if (merged) {
     return (
@@ -156,6 +162,7 @@ export const ImplementationPhaseTooltipContent = ({
       </TooltipTitle>
     );
   }
+
   // If action has no active phase or it's cancelled, or plan has no implementation phases : display only status
   if (!activePhase || status?.identifier === 'cancelled') {
     return statusDisplay;
@@ -163,8 +170,12 @@ export const ImplementationPhaseTooltipContent = ({
 
   return (
     <div>
-      {statusDisplay}
-      <Divider />
+      {!config.hasPhaseAndStatusColumns && (
+        <>
+          {statusDisplay}
+          <Divider />
+        </>
+      )}
       <TooltipTitle>{t('actions:action-implementation-phase')}:</TooltipTitle>
       <PhasesTooltipList>
         {plan.actionImplementationPhases.map((phase) => (

--- a/components/dashboard/cells/ImplementationPhaseCell.tsx
+++ b/components/dashboard/cells/ImplementationPhaseCell.tsx
@@ -2,6 +2,8 @@ import { ActionListAction } from '../dashboard.types';
 import styled from 'styled-components';
 import { PlanContextFragment } from 'common/__generated__/graphql';
 import ActionPhase from 'components/actions/ActionPhase';
+import { useContext } from 'react';
+import { ActionTableContext } from '../ActionStatusTable';
 
 interface Props {
   action: ActionListAction;
@@ -13,18 +15,28 @@ const StatusDisplay = styled.div`
   height: 100%;
 `;
 
-const ImplementationPhaseCell = ({ action, plan }: Props) => (
-  <StatusDisplay>
-    <ActionPhase
-      action={action}
-      status={action.statusSummary}
-      activePhase={action.implementationPhase}
-      reason={action.manualStatusReason}
-      mergedWith={action.mergedWith?.identifier}
-      phases={plan.actionImplementationPhases}
-      compact
-    />
-  </StatusDisplay>
-);
+const ImplementationPhaseCell = ({ action }: Props) => {
+  const { plan, config } = useContext(ActionTableContext);
+
+  if (!plan) {
+    return null;
+  }
+
+  return (
+    <StatusDisplay>
+      <ActionPhase
+        action={action}
+        status={
+          config.hasPhaseAndStatusColumns ? undefined : action.statusSummary
+        }
+        activePhase={action.implementationPhase}
+        reason={action.manualStatusReason}
+        mergedWith={action.mergedWith?.identifier}
+        phases={plan.actionImplementationPhases}
+        compact
+      />
+    </StatusDisplay>
+  );
+};
 
 export default ImplementationPhaseCell;


### PR DESCRIPTION
When both phase and status are shown in the action list table, hide the status colour and labels from the phase column content.

- Add `ActionTableContext` to support passing props and custom config down to action table cells
- Update `ActionPhase` to hide status related information if `status` is undefined – this component might benefit from a refactor at some point

### When only phase is shown (no changes)

<img width="800" alt="Screenshot 2023-11-06 at 11 48 25" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/f85f9dba-93ab-434a-9fc6-bd71f5f0c014">

### When both phase and status are shown

<img width="800" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/bdb8ae4e-9e07-4f30-b0a2-aee2df5101b9">

<img width="800" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/6e033072-9329-4cf7-bbe5-1abd9a66bcf1">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205802844678626