### PR TITLE
Show full category tree as breadcrumb on category pages

### DIFF
--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -2202,6 +2202,8 @@ export type IndicatorGroupBlock = StreamFieldInterface & {
   field: Scalars['String'];
   id?: Maybe<Scalars['String']>;
   indicators?: Maybe<Array<Maybe<StreamFieldInterface>>>;
+  /** @deprecated Use 'indicators' instead */
+  items?: Maybe<Array<Maybe<StreamFieldInterface>>>;
   rawValue: Scalars['String'];
   title?: Maybe<Scalars['String']>;
 };
@@ -9852,6 +9854,55 @@ export type TemplatedCategoryPageFragmentFragment = (
   & { __typename?: 'CategoryPage' }
 );
 
+export type RecursiveCategoryParentFragmentFragment = (
+  { parent?: (
+    { name: string, parent?: (
+      { identifier: string, name: string, parent?: (
+        { identifier: string, name: string, categoryPage?: (
+          { urlPath: string }
+          & { __typename?: 'CategoryPage' }
+        ) | null, type: (
+          { id: string, hideCategoryIdentifiers: boolean }
+          & { __typename?: 'CategoryType' }
+        ), parent?: (
+          { identifier: string, name: string, categoryPage?: (
+            { urlPath: string }
+            & { __typename?: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, hideCategoryIdentifiers: boolean }
+            & { __typename?: 'CategoryType' }
+          ) }
+          & { __typename?: 'Category' }
+        ) | null }
+        & { __typename?: 'Category' }
+      ) | null, categoryPage?: (
+        { urlPath: string }
+        & { __typename?: 'CategoryPage' }
+      ) | null, type: (
+        { id: string, hideCategoryIdentifiers: boolean }
+        & { __typename?: 'CategoryType' }
+      ) }
+      & { __typename?: 'Category' }
+    ) | null }
+    & { __typename?: 'Category' }
+  ) | null }
+  & { __typename?: 'Category' }
+);
+
+export type CategoryParentFragmentFragment = (
+  { name: string, parent?: (
+    { identifier: string, name: string, categoryPage?: (
+      { urlPath: string }
+      & { __typename?: 'CategoryPage' }
+    ) | null, type: (
+      { id: string, hideCategoryIdentifiers: boolean }
+      & { __typename?: 'CategoryType' }
+    ) }
+    & { __typename?: 'Category' }
+  ) | null }
+  & { __typename?: 'Category' }
+);
+
 export type GetPlanPageGeneralQueryVariables = Exact<{
   plan: Scalars['ID'];
   path: Scalars['String'];
@@ -10294,7 +10345,43 @@ export type GetPlanPageGeneralQuery = (
         ) | null, type: (
           { id: string, hideCategoryIdentifiers: boolean }
           & { __typename?: 'CategoryType' }
-        ) }
+        ), parent?: (
+          { identifier: string, name: string, categoryPage?: (
+            { urlPath: string }
+            & { __typename?: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, hideCategoryIdentifiers: boolean }
+            & { __typename?: 'CategoryType' }
+          ), parent?: (
+            { identifier: string, name: string, parent?: (
+              { identifier: string, name: string, categoryPage?: (
+                { urlPath: string }
+                & { __typename?: 'CategoryPage' }
+              ) | null, type: (
+                { id: string, hideCategoryIdentifiers: boolean }
+                & { __typename?: 'CategoryType' }
+              ), parent?: (
+                { identifier: string, name: string, categoryPage?: (
+                  { urlPath: string }
+                  & { __typename?: 'CategoryPage' }
+                ) | null, type: (
+                  { id: string, hideCategoryIdentifiers: boolean }
+                  & { __typename?: 'CategoryType' }
+                ) }
+                & { __typename?: 'Category' }
+              ) | null }
+              & { __typename?: 'Category' }
+            ) | null, categoryPage?: (
+              { urlPath: string }
+              & { __typename?: 'CategoryPage' }
+            ) | null, type: (
+              { id: string, hideCategoryIdentifiers: boolean }
+              & { __typename?: 'CategoryType' }
+            ) }
+            & { __typename?: 'Category' }
+          ) | null }
+          & { __typename?: 'Category' }
+        ) | null }
         & { __typename?: 'Category' }
       ) | null, attributes?: Array<(
         { id: string, type: (

--- a/components/common/Breadcrumbs.tsx
+++ b/components/common/Breadcrumbs.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { UncontrolledTooltip } from 'reactstrap';
+import styled from 'styled-components';
+
+import { Link } from 'common/links';
+import { MAX_CRUMB_LENGTH } from 'common/categories';
+
+type TCrumb = {
+  name: string;
+  id: string;
+  url?: string;
+};
+
+type Props = {
+  breadcrumbs: TCrumb[];
+};
+
+const StyledContainer = styled.div`
+  margin-bottom: ${(props) => props.theme.spaces.s100};
+`;
+
+function Crumb({ crumb }: { crumb: TCrumb }) {
+  const id = `crumb-${crumb.id}`;
+  const ariaId = `tt-content-${crumb.id}`;
+  const isTruncated = crumb.name.length > MAX_CRUMB_LENGTH;
+  const name = isTruncated
+    ? `${crumb.name.slice(0, MAX_CRUMB_LENGTH).trim()}...`
+    : crumb.name;
+
+  return (
+    <>
+      <span id={id} aria-describedby={isTruncated ? ariaId : undefined}>
+        {crumb.url ? (
+          <Link href={crumb.url} passHref>
+            {name}
+          </Link>
+        ) : (
+          name
+        )}
+        &nbsp;/{' '}
+      </span>
+
+      {isTruncated && (
+        <UncontrolledTooltip
+          target={id}
+          id={ariaId}
+          placement="top"
+          role="tooltip"
+          trigger="focus hover"
+        >
+          {crumb.name}
+        </UncontrolledTooltip>
+      )}
+    </>
+  );
+}
+
+export function Breadcrumbs({ breadcrumbs }: Props) {
+  return (
+    <StyledContainer>
+      {breadcrumbs.map((crumb) => (
+        <Crumb key={crumb.id} crumb={crumb} />
+      ))}
+    </StyledContainer>
+  );
+}

--- a/components/common/Breadcrumbs.tsx
+++ b/components/common/Breadcrumbs.tsx
@@ -16,6 +16,7 @@ type Props = {
 };
 
 const StyledContainer = styled.div`
+  font-size: ${(props) => props.theme.fontSizeMd};
   margin-bottom: ${(props) => props.theme.spaces.s100};
 `;
 

--- a/components/contentblocks/CategoryPageHeaderBlock.tsx
+++ b/components/contentblocks/CategoryPageHeaderBlock.tsx
@@ -168,11 +168,6 @@ const AttributesContainer = styled.div`
   margin: 0 auto;
 `;
 
-const Breadcrumb = styled.div`
-  font-size: ${(props) => props.theme.fontSizeMd};
-  margin-bottom: ${(props) => props.theme.spaces.s100};
-`;
-
 const getIconHeight = (size: IconSize = IconSize.M, theme: Theme) => {
   switch (size) {
     case IconSize.L:

--- a/components/contentblocks/CategoryPageHeaderBlock.tsx
+++ b/components/contentblocks/CategoryPageHeaderBlock.tsx
@@ -18,6 +18,8 @@ import CategoryPageStreamField, {
 } from 'components/common/CategoryPageStreamField';
 import { ChartType } from 'components/dashboard/ActionStatusGraphs';
 import ActionStatusGraphsBlock from './ActionStatusGraphsBlock';
+import { Breadcrumbs } from 'components/common/Breadcrumbs';
+import { getBreadcrumbsFromCategoryHierarchy } from 'common/categories';
 
 export const GET_CATEGORY_ATTRIBUTE_TYPES = gql`
   query GetCategoryAttributeTypes($plan: ID!) {
@@ -271,8 +273,6 @@ interface Props {
   iconImage;
   headerImage;
   imageAlign?: string;
-  parentTitle;
-  parentUrl;
   color;
   attributes;
   typeId;
@@ -289,8 +289,6 @@ function CategoryPageHeaderBlock({
   iconImage,
   headerImage,
   imageAlign = 'center',
-  parentTitle,
-  parentUrl,
   color,
   attributes,
   typeId,
@@ -300,6 +298,9 @@ function CategoryPageHeaderBlock({
   const plan = useContext(PlanContext);
   const theme = useTheme();
   const { t } = useTranslation();
+
+  const showIdentifiers =
+    !plan.primaryActionClassification?.hideCategoryIdentifiers;
 
   const { loading, error, data } = useQuery<GetCategoryAttributeTypesQuery>(
     GET_CATEGORY_ATTRIBUTE_TYPES,
@@ -336,14 +337,16 @@ function CategoryPageHeaderBlock({
               hasImage={!!headerImage}
             >
               {level && <CategoryLevelName>{level}</CategoryLevelName>}
-              {parentTitle && (
-                <Breadcrumb>
-                  <Link href={parentUrl}>
-                    <a>{parentTitle}</a>
-                  </Link>{' '}
-                  /
-                </Breadcrumb>
+
+              {!!page.category?.parent && (
+                <Breadcrumbs
+                  breadcrumbs={getBreadcrumbsFromCategoryHierarchy(
+                    [page.category.parent],
+                    showIdentifiers
+                  )}
+                />
               )}
+
               {iconImage && (
                 <CategoryIconImage
                   size={(page?.layout?.iconSize as IconSize) ?? undefined}


### PR DESCRIPTION
- Unify category page and action page breadcrumbs
- Show full category tree on category pages

<img width="1255" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/26ec1d4a-de01-4d09-b10f-3b3bee9aeabf">
