### PR TITLE
Get indicator showcase bar colors from theme

### DIFF
--- a/components/indicators/IndicatorProgressBar.js
+++ b/components/indicators/IndicatorProgressBar.js
@@ -2,6 +2,7 @@
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { ThemeContext } from 'styled-components';
+import { readableColor } from 'polished';
 import { motion, useAnimation, animate } from 'framer-motion';
 import { useTranslation } from 'common/i18n';
 import dayjs from 'common/dayjs';
@@ -243,9 +244,9 @@ function IndicatorProgressBar(props) {
   const bars = { w: width - rightMargin, h: 3 * barHeight };
   const scale = bars.w / startValue;
   const segmentsY = bars.h + barMargin * 2;
-  const goalColor = theme.graphColors.green030;
-  const latestColor = theme.graphColors.blue030;
-  const startColor = theme.graphColors.red030;
+  const goalColor = theme.section.indicatorShowcase.goalColor;
+  const latestColor = theme.section.indicatorShowcase.latestColor;
+  const startColor = theme.section.indicatorShowcase.startColor;
   const canvas = {
     w: bars.w + rightMargin,
     h: bars.h + topMargin + bottomMargin,
@@ -433,6 +434,7 @@ function IndicatorProgressBar(props) {
                   value={formatValue(startValue, i18n.language, minPrecision)}
                   unit={unit}
                   locale={i18n.language}
+                  negative={readableColor(startColor) === '#ffffff'}
                 />
                 {showReduction && (
                   <text
@@ -488,6 +490,7 @@ function IndicatorProgressBar(props) {
                 value={formatValue(latestValue, i18n.language, minPrecision)}
                 unit={unit}
                 locale={i18n.language}
+                negative={readableColor(latestColor) === '#ffffff'}
               />
             </motion.g>
             <motion.text
@@ -546,7 +549,9 @@ function IndicatorProgressBar(props) {
               )}
               unit={unit}
               locale={i18n.language}
-              negative={goalBar.w < 80}
+              negative={
+                readableColor(goalColor) === '#ffffff' || goalBar.w < 80
+              }
             />
             <text
               transform={`translate(${goalBar.x + goalBar.w / 2} ${

--- a/components/indicators/IndicatorProgressBar.js
+++ b/components/indicators/IndicatorProgressBar.js
@@ -434,7 +434,13 @@ function IndicatorProgressBar(props) {
                   value={formatValue(startValue, i18n.language, minPrecision)}
                   unit={unit}
                   locale={i18n.language}
-                  negative={readableColor(startColor) === '#ffffff'}
+                  negative={
+                    readableColor(
+                      startColor,
+                      theme.themeColors.black,
+                      theme.themeColors.white
+                    ) === theme.themeColors.white
+                  }
                 />
                 {showReduction && (
                   <text
@@ -490,7 +496,13 @@ function IndicatorProgressBar(props) {
                 value={formatValue(latestValue, i18n.language, minPrecision)}
                 unit={unit}
                 locale={i18n.language}
-                negative={readableColor(latestColor) === '#ffffff'}
+                negative={
+                  readableColor(
+                    latestColor,
+                    theme.themeColors.black,
+                    theme.themeColors.white
+                  ) === theme.themeColors.white
+                }
               />
             </motion.g>
             <motion.text
@@ -551,7 +563,11 @@ function IndicatorProgressBar(props) {
               unit={unit}
               locale={i18n.language}
               negative={
-                readableColor(goalColor) === '#ffffff' || goalBar.w < 120
+                readableColor(
+                  startColor,
+                  theme.themeColors.black,
+                  theme.themeColors.white
+                ) === theme.themeColors.white || goalBar.w < 120
               }
             />
             <text

--- a/components/indicators/IndicatorProgressBar.js
+++ b/components/indicators/IndicatorProgressBar.js
@@ -518,7 +518,7 @@ function IndicatorProgressBar(props) {
               height={barHeight - barMargin}
               fill={goalColor}
             />
-            {goalBar.w > 0 && (
+            {goalBar.w > 3 && (
               <line
                 x1={goalBar.x + 1}
                 y1={goalBar.y}
@@ -538,8 +538,9 @@ function IndicatorProgressBar(props) {
               strokeWidth="2"
             />
             <ValueGroup
+              text-anchor={goalBar.w > 120 ? 'start' : 'end'}
               transform={`translate(${
-                goalBar.w > 80 ? goalBar.x + 4 : goalBar.x - 50
+                goalBar.w > 120 ? goalBar.x + 4 : goalBar.x - 8
               } ${goalBar.y})`}
               date={graphValues.goalYear}
               value={formatValue(
@@ -550,7 +551,7 @@ function IndicatorProgressBar(props) {
               unit={unit}
               locale={i18n.language}
               negative={
-                readableColor(goalColor) === '#ffffff' || goalBar.w < 80
+                readableColor(goalColor) === '#ffffff' || goalBar.w < 120
               }
             />
             <text

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@elastic/react-search-ui": "^1.11.2",
     "@kausal/mapboxgl-legend": "^1.7.2",
     "@kausal/plotly-custom": "^2.14.3",
-    "@kausal/themes": "^0.7.6",
+    "@kausal/themes": "^0.7.7",
     "@koa/router": "^10.1.1",
     "@n8tb1t/use-scroll-position": "^2.0.3",
     "@next/bundle-analyzer": "^12.1.6",
@@ -158,7 +158,7 @@
   ],
   "packageManager": "yarn@3.2.1",
   "optionalDependencies": {
-    "@kausal/themes-private": "^0.3.13"
+    "@kausal/themes-private": "^0.3.14"
   },
   "lint-staged": {
     "*.{tsx,ts,js,css,scss,md,json}": "prettier --write"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3413,17 +3413,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kausal/themes-private@npm:^0.3.13":
-  version: 0.3.13
-  resolution: "@kausal/themes-private@npm:0.3.13"
-  checksum: 0779bd977347c03431746b64535c081dee3074135b6d7fda9eb041bf375cfdd451117004493cb0eb02fa5f1f3a4f772b07346f99b928b088aada4932c5c3d030
+"@kausal/themes-private@npm:^0.3.14":
+  version: 0.3.14
+  resolution: "@kausal/themes-private@npm:0.3.14"
+  checksum: b2af6cbea14d6a92de55391f871b60efe2bd046824795902bbaf658f3f6c728c2f861fdb1554239b0315c3215fee4c9c74906c6bd36a93dad9bf4b745b627fdd
   languageName: node
   linkType: hard
 
-"@kausal/themes@npm:^0.7.6":
-  version: 0.7.6
-  resolution: "@kausal/themes@npm:0.7.6"
-  checksum: 21e1e79bcb71b63e1526099d078ef2b1090fe497481454ca210befb61d795e60f36dd81448d20ed82c8968dd56039b65510e6201d03bf0d2c79d4ef09864a8af
+"@kausal/themes@npm:^0.7.7":
+  version: 0.7.7
+  resolution: "@kausal/themes@npm:0.7.7"
+  checksum: 8ba85330185e0f8462aada0bda3a1758127470a2aa9b3e91a222a6c80f259f349b53dc3e28a0a380f040a563b0055b08574e8d28362fcea82c81a1d671c37a7f
   languageName: node
   linkType: hard
 
@@ -17085,8 +17085,8 @@ __metadata:
     "@graphql-codegen/typescript-react-apollo": ^3.3.7
     "@kausal/mapboxgl-legend": ^1.7.2
     "@kausal/plotly-custom": ^2.14.3
-    "@kausal/themes": ^0.7.6
-    "@kausal/themes-private": ^0.3.13
+    "@kausal/themes": ^0.7.7
+    "@kausal/themes-private": ^0.3.14
     "@koa/router": ^10.1.1
     "@n8tb1t/use-scroll-position": ^2.0.3
     "@next/bundle-analyzer": ^12.1.6


### PR DESCRIPTION
Also fix misaligned label on very short goal bars

before:
<img width="710" alt="Screenshot 2023-11-27 at 16 53 29" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/d0ac1b88-fc35-4f60-a904-43895edb831b">
afters:
<img width="803" alt="Screenshot 2023-11-27 at 17 03 41" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/3efb7413-71be-4e58-be6a-f7bbe09b85e7">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206010535152027