### PR TITLE
Fix sorting of combined hierarchical and flat indicators

### DIFF
--- a/components/indicators/process-indicators.ts
+++ b/components/indicators/process-indicators.ts
@@ -1,0 +1,52 @@
+/**
+ * TODO:    This function is tricky to follow because `processed` is mutated
+ *          implicitly when calling `expandPaths`. This should be refactored
+ *          or rewritten when implementing the next larger indicator page updates.
+ */
+export const processCommonIndicatorHierarchy = (planIndicators) => {
+  const uniqueCommonIndicators = {};
+  planIndicators.forEach((i) => {
+    if (i.common != null && !(i.common.id in uniqueCommonIndicators)) {
+      uniqueCommonIndicators[i.common.id] = i.common;
+    }
+  });
+  const makeLinks = (commonIndicator) => ({
+    id: commonIndicator.id,
+    isRoot:
+      commonIndicator.relatedEffects.filter((e) => e.effectType === 'PART_OF')
+        .length === 0,
+    children: commonIndicator.relatedCauses
+      .filter((e) => e.effectType === 'PART_OF')
+      .filter((e) => uniqueCommonIndicators[e.causalIndicator.id] != null)
+      .map((e) => e.causalIndicator.id),
+  });
+  const processed = Object.fromEntries(
+    Object.values(uniqueCommonIndicators).map((i) => [i.id, makeLinks(i)])
+  );
+  const expandPaths = (indicators, path) => {
+    let descendants = [];
+    indicators.forEach((indicator) => {
+      const newPath = [...path, indicator.id];
+      indicator.path = newPath;
+      indicator.pathNames = newPath.map((p) => uniqueCommonIndicators[p].name);
+      indicator.descendants = expandPaths(
+        indicator.children.map((c) => processed[c]),
+        newPath
+      );
+
+      descendants = descendants.concat(indicator.descendants, [indicator.id]);
+    });
+    return descendants;
+  };
+
+  const rootIndicators = Object.values(processed).filter((i) => i.isRoot);
+
+  if (rootIndicators.length === Object.keys(uniqueCommonIndicators).length) {
+    // The hierarchy is flat because all the common indicators are root
+    return {};
+  }
+
+  expandPaths(rootIndicators, []);
+
+  return processed;
+};

--- a/components/indicators/tests/IndicatorList.test.ts
+++ b/components/indicators/tests/IndicatorList.test.ts
@@ -1,0 +1,8 @@
+import { processCommonIndicatorHierarchy } from '../process-indicators';
+import { EXPECTED_OUTPUT, INPUT } from './mocks';
+
+describe('processCommonIndicatorHierarchy', () => {
+  it('processes indicators', () => {
+    expect(processCommonIndicatorHierarchy(INPUT)).toEqual(EXPECTED_OUTPUT);
+  });
+});

--- a/components/indicators/tests/mocks.ts
+++ b/components/indicators/tests/mocks.ts
@@ -1,0 +1,9957 @@
+export const INPUT = [
+  {
+    __typename: 'Indicator',
+    id: '2610',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '201',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2610',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1516',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '176',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '124',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2609',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '200',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2609',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1515',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '175',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '124',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2608',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '199',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2608',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1514',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '174',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '124',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2607',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '198',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2607',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1513',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '173',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '124',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2606',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '197',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2606',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1512',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '172',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '123',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2605',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '196',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2605',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1511',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '171',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '123',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2604',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '195',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2604',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1510',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '170',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '122',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2603',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '194',
+      name: 'TeollisuusIndicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2603',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1509',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '169',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '122',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2602',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '193',
+      name: 'Yhdyskunnan Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2602',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1508',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '168',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '121',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2601',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '192',
+      name: 'Teollisuuden Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2601',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1507',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '167',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '121',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2600',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '191',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2600',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1506',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '166',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '120',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2599',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '190',
+      name: 'Teollisuuden Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2599',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1505',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '165',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '120',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2598',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '189',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2598',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1504',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '164',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '119',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2597',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '236',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2597',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '190',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '119',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2596',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '188',
+      name: 'Eläinten ruoansulatuksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2596',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1503',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '163',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '119',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2595',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '187',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2595',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1502',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '162',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '118',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2594',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '186',
+      name: 'Peltoviljelyn maaperän päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2594',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1501',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '161',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '118',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2593',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '185',
+      name: 'Orgaanisten lannoitteiden päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2593',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1500',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '160',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '118',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2592',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '184',
+      name: 'Epäorgaanisten lannoitteiden päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2592',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1499',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '159',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '118',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2591',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '183',
+      name: 'TieIndicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2591',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1498',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '158',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '117',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2590',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '182',
+      name: 'Muiden Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2590',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1497',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '157',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '117',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2589',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '181',
+      name: 'Kaivos- ja teollisuusIndicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2589',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1496',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '156',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '117',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2588',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '180',
+      name: 'Maa- ja metsätalouskoneiden päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2588',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1495',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '155',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '117',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2587',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '179',
+      name: 'RakennusIndicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2587',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1494',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '154',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '117',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2586',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '178',
+      name: 'Teollisuuden polttoaineiden päästöt ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2586',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1493',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '153',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '116',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2585',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '235',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2585',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '189',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '116',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2584',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '234',
+      name: 'Teollisuuden polttoaineiden päästöt ei-HINKU',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2584',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '188',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '116',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2583',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '176',
+      name: 'Työveneiden ja -alusten päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2583',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1491',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '151',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '115',
+            name: 'Työveneiden päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2582',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '175',
+      name: 'Lauttojen ja lossien päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2582',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1490',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '150',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '115',
+            name: 'Työveneiden päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2581',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '174',
+      name: 'Kalastusalusten päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2581',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1489',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '149',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '115',
+            name: 'Työveneiden päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2580',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '173',
+      name: 'TavaraIndicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2580',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1488',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '148',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '114',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2579',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '172',
+      name: 'MatkustajaIndicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2579',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1487',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '147',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '114',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2578',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '171',
+      name: 'Huviveneiden päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2578',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1486',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '146',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '113',
+            name: 'Vesiliikenteen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2577',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '170',
+      name: 'Dieseltavarajunien päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2577',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1485',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '145',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '112',
+            name: 'Tavarajunaliikenteen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2576',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '233',
+      name: 'Sähkötavarajunien päästöt ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2576',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '187',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '112',
+            name: 'Tavarajunaliikenteen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2575',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '169',
+      name: 'Sähkötavarajunien päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2575',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1484',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '144',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '112',
+            name: 'Tavarajunaliikenteen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2574',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '168',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2574',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1483',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '143',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '111',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2573',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '167',
+      name: 'Sähköjunien päästöt ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2573',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '142',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '111',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2572',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '166',
+      name: 'Sähköjunien päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2572',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1481',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '141',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '111',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2571',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '165',
+      name: 'Metrojen ja raitiovaunujen päästöt ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2571',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '140',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '110',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2570',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '164',
+      name: 'Metrojen ja raitiovaunujen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2570',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1479',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '139',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '110',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2569',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '163',
+      name: 'Indicator name ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2569',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '138',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '110',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2568',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '162',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2568',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1477',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '137',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '110',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2567',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '161',
+      name: 'Läpiajoliikenteen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2567',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1476',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '136',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '36',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2566',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '160',
+      name: 'Moottoripyörien ja mopojen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2566',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1475',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '135',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '36',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2565',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '159',
+      name: 'Pakettiautojen päästöt (katuajo)',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2565',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1474',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '134',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '38',
+            name: 'Indicator name kaduilla',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2564',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '158',
+      name: 'Linja-autojen päästöt (katuajo)',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2564',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1473',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '133',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '38',
+            name: 'Indicator name kaduilla',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2563',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '157',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2563',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1472',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '132',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '38',
+            name: 'Indicator name kaduilla',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2562',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '156',
+      name: 'Henkilöautojen päästöt (katuajo)',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2562',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1471',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '131',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '38',
+            name: 'Indicator name kaduilla',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2561',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '155',
+      name: 'Pakettiautojen päästöt (maantieajo)',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2561',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1470',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '130',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '37',
+            name: 'Indicator name maanteillä',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2560',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '154',
+      name: 'Linja-autojen päästöt (maantieajo)',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2560',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1469',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '129',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '37',
+            name: 'Indicator name maanteillä',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2559',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '153',
+      name: 'Kuorma-autojen päästöt (maantieajo)',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2559',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1468',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '128',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '37',
+            name: 'Indicator name maanteillä',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2558',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '152',
+      name: 'Henkilöautojen päästöt (maantieajo)',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2558',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1467',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '127',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '37',
+            name: 'Indicator name maanteillä',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2557',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '151',
+      name: 'Maatalouden muun suoran lämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2557',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1466',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '126',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '35',
+            name: 'Rakennusten muun lämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2556',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '150',
+      name: 'Palveluiden muun suoran lämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2556',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1465',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '125',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '35',
+            name: 'Rakennusten muun lämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2555',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '149',
+      name: 'Asumisen muun suoran lämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2555',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1464',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '124',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '35',
+            name: 'Rakennusten muun lämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2554',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '148',
+      name: 'Maatalouden puulämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2554',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1463',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '123',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '34',
+            name: 'Puulämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2553',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '147',
+      name: 'Palveluiden puulämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2553',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1462',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '122',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '34',
+            name: 'Puulämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2552',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '146',
+      name: 'Asumisen puulämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2552',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1461',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '121',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '34',
+            name: 'Puulämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2551',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '145',
+      name: 'Maatalouden Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2551',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1460',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '120',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '33',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2550',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '144',
+      name: 'Palveluiden Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2550',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1459',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '119',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '33',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2549',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '143',
+      name: 'Asumisen Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2549',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1458',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '118',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '33',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2548',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '142',
+      name: 'Maatalouden Indicator name ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2548',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '117',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '32',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2547',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '141',
+      name: 'Maatalouden Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2547',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1456',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '116',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '32',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2546',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '140',
+      name: 'Teollisuuden Indicator name ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2546',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '115',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '32',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2545',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '139',
+      name: 'Teollisuuden Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2545',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1454',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '114',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '32',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2544',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '138',
+      name: 'Palveluiden Indicator name ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2544',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '113',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '32',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2543',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '137',
+      name: 'Palveluiden Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2543',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1452',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '112',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '32',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2542',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '136',
+      name: 'Asumisen Indicator name ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2542',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '111',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '32',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2541',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '135',
+      name: 'Asumisen Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2541',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1450',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '110',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '32',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2540',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '232',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2540',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '186',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '31',
+            name: 'Maalämmön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2539',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '134',
+      name: 'Maatalouden maalämmön päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2539',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1449',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '109',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '31',
+            name: 'Maalämmön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2538',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '231',
+      name: 'Palveluiden maalämmön päästöt ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2538',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '185',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '31',
+            name: 'Maalämmön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2537',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '133',
+      name: 'Palveluiden maalämmön päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2537',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1448',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '108',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '31',
+            name: 'Maalämmön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2536',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '230',
+      name: 'Asumisen maalämmön päästöt ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2536',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '184',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '31',
+            name: 'Maalämmön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2535',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '132',
+      name: 'Asumisen maalämmön päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2535',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1447',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '107',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '31',
+            name: 'Maalämmön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2534',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '229',
+      name: 'Maatalouden suoran sähkölämmityksen päästöt ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2534',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '183',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '30',
+            name: 'Rakennusten suoran sähkölämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2533',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '131',
+      name: 'Maatalouden suoran sähkölämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2533',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1446',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '106',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '30',
+            name: 'Rakennusten suoran sähkölämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2532',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '228',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2532',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '182',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '30',
+            name: 'Rakennusten suoran sähkölämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2531',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '130',
+      name: 'Palveluiden suoran sähkölämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2531',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1445',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '105',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '30',
+            name: 'Rakennusten suoran sähkölämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2530',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '227',
+      name: 'Asumisen suoran sähkölämmityksen päästöt ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2530',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '181',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '30',
+            name: 'Rakennusten suoran sähkölämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2529',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '129',
+      name: 'Asumisen suoran sähkölämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2529',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1444',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '104',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '30',
+            name: 'Rakennusten suoran sähkölämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2528',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '226',
+      name: 'Maatalouden kulutussähkön päästöt ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2528',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '180',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '24',
+            name: 'Kulutussähkön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2527',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '128',
+      name: 'Maatalouden kulutussähkön päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2527',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1443',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '103',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '24',
+            name: 'Kulutussähkön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2526',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '225',
+      name: 'Teollisuuden kulutussähkön päästöt ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2526',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '179',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '24',
+            name: 'Kulutussähkön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2525',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '127',
+      name: 'Teollisuuden kulutussähkön päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2525',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1442',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '102',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '24',
+            name: 'Kulutussähkön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2524',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '224',
+      name: 'Palveluiden kulutussähkön päästöt ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2524',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '178',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '24',
+            name: 'Kulutussähkön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2523',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '126',
+      name: 'Palveluiden kulutussähkön päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2523',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1441',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '101',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '24',
+            name: 'Kulutussähkön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2522',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '223',
+      name: 'Asumisen kulutussähkön päästöt ei-päästökauppa',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2522',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '177',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '24',
+            name: 'Kulutussähkön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2521',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '125',
+      name: 'Asumisen kulutussähkön päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2521',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1440',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '100',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '24',
+            name: 'Kulutussähkön päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2520',
+    relatedCauses: [],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '39',
+      name: 'Väestö',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2520',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1439',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1301',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1284',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1267',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1250',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1162',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1161',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1160',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1159',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1158',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1157',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1156',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1155',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1154',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1153',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1152',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [],
+      relatedEffects: [],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2519',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1820',
+        causalIndicator: { __typename: 'Indicator', id: '2607' },
+        effectIndicator: { __typename: 'Indicator', id: '2519' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1821',
+        causalIndicator: { __typename: 'Indicator', id: '2608' },
+        effectIndicator: { __typename: 'Indicator', id: '2519' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1822',
+        causalIndicator: { __typename: 'Indicator', id: '2609' },
+        effectIndicator: { __typename: 'Indicator', id: '2519' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1823',
+        causalIndicator: { __typename: 'Indicator', id: '2610' },
+        effectIndicator: { __typename: 'Indicator', id: '2519' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '124',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2519',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1438',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '198',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '199',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '200',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '201',
+            name: 'Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '99',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '23',
+            name: 'Net emissions (scope 2)',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2518',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1818',
+        causalIndicator: { __typename: 'Indicator', id: '2605' },
+        effectIndicator: { __typename: 'Indicator', id: '2518' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1819',
+        causalIndicator: { __typename: 'Indicator', id: '2606' },
+        effectIndicator: { __typename: 'Indicator', id: '2518' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '123',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2518',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1437',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '196',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '197',
+            name: 'Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '98',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '28',
+            name: 'Jätteiden käsittelyn päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2517',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1816',
+        causalIndicator: { __typename: 'Indicator', id: '2603' },
+        effectIndicator: { __typename: 'Indicator', id: '2517' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1817',
+        causalIndicator: { __typename: 'Indicator', id: '2604' },
+        effectIndicator: { __typename: 'Indicator', id: '2517' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '122',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2517',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1436',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '194',
+            name: 'TeollisuusIndicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '195',
+            name: 'Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '97',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '28',
+            name: 'Jätteiden käsittelyn päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2516',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1814',
+        causalIndicator: { __typename: 'Indicator', id: '2601' },
+        effectIndicator: { __typename: 'Indicator', id: '2516' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1815',
+        causalIndicator: { __typename: 'Indicator', id: '2602' },
+        effectIndicator: { __typename: 'Indicator', id: '2516' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '121',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2516',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1435',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '192',
+            name: 'Teollisuuden Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '193',
+            name: 'Yhdyskunnan Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '96',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '28',
+            name: 'Jätteiden käsittelyn päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2515',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1812',
+        causalIndicator: { __typename: 'Indicator', id: '2599' },
+        effectIndicator: { __typename: 'Indicator', id: '2515' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1813',
+        causalIndicator: { __typename: 'Indicator', id: '2600' },
+        effectIndicator: { __typename: 'Indicator', id: '2515' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '120',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2515',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1434',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '190',
+            name: 'Teollisuuden Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '191',
+            name: 'Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '95',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '28',
+            name: 'Jätteiden käsittelyn päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2514',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1729',
+        causalIndicator: { __typename: 'Indicator', id: '2515' },
+        effectIndicator: { __typename: 'Indicator', id: '2514' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1730',
+        causalIndicator: { __typename: 'Indicator', id: '2516' },
+        effectIndicator: { __typename: 'Indicator', id: '2514' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1731',
+        causalIndicator: { __typename: 'Indicator', id: '2517' },
+        effectIndicator: { __typename: 'Indicator', id: '2514' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1732',
+        causalIndicator: { __typename: 'Indicator', id: '2518' },
+        effectIndicator: { __typename: 'Indicator', id: '2514' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '28',
+      name: 'Jätteiden käsittelyn päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2514',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1031',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1032',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1034',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1035',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1036',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1037',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1038',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1040',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1433',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1300',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1283',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1266',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1249',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1039',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1033',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1030',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '120',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '121',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '122',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '123',
+            name: 'Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '5',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '23',
+            name: 'Net emissions (scope 2)',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2513',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1809',
+        causalIndicator: { __typename: 'Indicator', id: '2596' },
+        effectIndicator: { __typename: 'Indicator', id: '2513' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1810',
+        causalIndicator: { __typename: 'Indicator', id: '2597' },
+        effectIndicator: { __typename: 'Indicator', id: '2513' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1811',
+        causalIndicator: { __typename: 'Indicator', id: '2598' },
+        effectIndicator: { __typename: 'Indicator', id: '2513' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '119',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2513',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1432',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '188',
+            name: 'Eläinten ruoansulatuksen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '236',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '189',
+            name: 'Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '94',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '27',
+            name: 'Maatalouden päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2512',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1805',
+        causalIndicator: { __typename: 'Indicator', id: '2592' },
+        effectIndicator: { __typename: 'Indicator', id: '2512' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1806',
+        causalIndicator: { __typename: 'Indicator', id: '2593' },
+        effectIndicator: { __typename: 'Indicator', id: '2512' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1807',
+        causalIndicator: { __typename: 'Indicator', id: '2594' },
+        effectIndicator: { __typename: 'Indicator', id: '2512' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1808',
+        causalIndicator: { __typename: 'Indicator', id: '2595' },
+        effectIndicator: { __typename: 'Indicator', id: '2512' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '118',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2512',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1431',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '184',
+            name: 'Epäorgaanisten lannoitteiden päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '185',
+            name: 'Orgaanisten lannoitteiden päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '186',
+            name: 'Peltoviljelyn maaperän päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '187',
+            name: 'Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '93',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '27',
+            name: 'Maatalouden päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2511',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1726',
+        causalIndicator: { __typename: 'Indicator', id: '2512' },
+        effectIndicator: { __typename: 'Indicator', id: '2511' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1727',
+        causalIndicator: { __typename: 'Indicator', id: '2513' },
+        effectIndicator: { __typename: 'Indicator', id: '2511' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '27',
+      name: 'Maatalouden päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2511',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1430',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1299',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1282',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1265',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1248',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1029',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1028',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1027',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1026',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1025',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1024',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1023',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1022',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1021',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1020',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1019',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '118',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '119',
+            name: 'Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '4',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '23',
+            name: 'Net emissions (scope 2)',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2510',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1800',
+        causalIndicator: { __typename: 'Indicator', id: '2587' },
+        effectIndicator: { __typename: 'Indicator', id: '2510' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1801',
+        causalIndicator: { __typename: 'Indicator', id: '2588' },
+        effectIndicator: { __typename: 'Indicator', id: '2510' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1802',
+        causalIndicator: { __typename: 'Indicator', id: '2589' },
+        effectIndicator: { __typename: 'Indicator', id: '2510' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1803',
+        causalIndicator: { __typename: 'Indicator', id: '2590' },
+        effectIndicator: { __typename: 'Indicator', id: '2510' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1804',
+        causalIndicator: { __typename: 'Indicator', id: '2591' },
+        effectIndicator: { __typename: 'Indicator', id: '2510' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '117',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2510',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1429',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '179',
+            name: 'RakennusIndicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '180',
+            name: 'Maa- ja metsätalouskoneiden päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '181',
+            name: 'Kaivos- ja teollisuusIndicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '182',
+            name: 'Muiden Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '183',
+            name: 'TieIndicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '92',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '23',
+            name: 'Net emissions (scope 2)',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2509',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1797',
+        causalIndicator: { __typename: 'Indicator', id: '2584' },
+        effectIndicator: { __typename: 'Indicator', id: '2509' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1798',
+        causalIndicator: { __typename: 'Indicator', id: '2585' },
+        effectIndicator: { __typename: 'Indicator', id: '2509' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1799',
+        causalIndicator: { __typename: 'Indicator', id: '2586' },
+        effectIndicator: { __typename: 'Indicator', id: '2509' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '116',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2509',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1428',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '177',
+            name: 'Teollisuuden polttoaineiden päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '234',
+            name: 'Teollisuuden polttoaineiden päästöt ei-HINKU',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '235',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '178',
+            name: 'Teollisuuden polttoaineiden päästöt ei-päästökauppa',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '91',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '23',
+            name: 'Net emissions (scope 2)',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2508',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1794',
+        causalIndicator: { __typename: 'Indicator', id: '2581' },
+        effectIndicator: { __typename: 'Indicator', id: '2508' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1795',
+        causalIndicator: { __typename: 'Indicator', id: '2582' },
+        effectIndicator: { __typename: 'Indicator', id: '2508' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1796',
+        causalIndicator: { __typename: 'Indicator', id: '2583' },
+        effectIndicator: { __typename: 'Indicator', id: '2508' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '115',
+      name: 'Työveneiden päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2508',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1427',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '174',
+            name: 'Kalastusalusten päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '175',
+            name: 'Lauttojen ja lossien päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '176',
+            name: 'Työveneiden ja -alusten päästöt',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '90',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '113',
+            name: 'Vesiliikenteen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2507',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1792',
+        causalIndicator: { __typename: 'Indicator', id: '2579' },
+        effectIndicator: { __typename: 'Indicator', id: '2507' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1793',
+        causalIndicator: { __typename: 'Indicator', id: '2580' },
+        effectIndicator: { __typename: 'Indicator', id: '2507' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '114',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2507',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1426',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '172',
+            name: 'MatkustajaIndicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '173',
+            name: 'TavaraIndicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '89',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '113',
+            name: 'Vesiliikenteen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2506',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1721',
+        causalIndicator: { __typename: 'Indicator', id: '2507' },
+        effectIndicator: { __typename: 'Indicator', id: '2506' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1722',
+        causalIndicator: { __typename: 'Indicator', id: '2508' },
+        effectIndicator: { __typename: 'Indicator', id: '2506' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1791',
+        causalIndicator: { __typename: 'Indicator', id: '2578' },
+        effectIndicator: { __typename: 'Indicator', id: '2506' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '113',
+      name: 'Vesiliikenteen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2506',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1425',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '114',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '115',
+            name: 'Työveneiden päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '171',
+            name: 'Huviveneiden päästöt',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '88',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '26',
+            name: 'Liikenteen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2505',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1788',
+        causalIndicator: { __typename: 'Indicator', id: '2575' },
+        effectIndicator: { __typename: 'Indicator', id: '2505' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1789',
+        causalIndicator: { __typename: 'Indicator', id: '2576' },
+        effectIndicator: { __typename: 'Indicator', id: '2505' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1790',
+        causalIndicator: { __typename: 'Indicator', id: '2577' },
+        effectIndicator: { __typename: 'Indicator', id: '2505' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '112',
+      name: 'Tavarajunaliikenteen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2505',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1424',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '169',
+            name: 'Sähkötavarajunien päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '233',
+            name: 'Sähkötavarajunien päästöt ei-päästökauppa',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '170',
+            name: 'Dieseltavarajunien päästöt',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '87',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '109',
+            name: 'Raideliikenteen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2504',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1785',
+        causalIndicator: { __typename: 'Indicator', id: '2572' },
+        effectIndicator: { __typename: 'Indicator', id: '2504' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1786',
+        causalIndicator: { __typename: 'Indicator', id: '2573' },
+        effectIndicator: { __typename: 'Indicator', id: '2504' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1787',
+        causalIndicator: { __typename: 'Indicator', id: '2574' },
+        effectIndicator: { __typename: 'Indicator', id: '2504' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '111',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2504',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1423',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '166',
+            name: 'Sähköjunien päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '167',
+            name: 'Sähköjunien päästöt ei-päästökauppa',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '168',
+            name: 'Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '86',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '109',
+            name: 'Raideliikenteen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2503',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1781',
+        causalIndicator: { __typename: 'Indicator', id: '2568' },
+        effectIndicator: { __typename: 'Indicator', id: '2503' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1782',
+        causalIndicator: { __typename: 'Indicator', id: '2569' },
+        effectIndicator: { __typename: 'Indicator', id: '2503' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1783',
+        causalIndicator: { __typename: 'Indicator', id: '2570' },
+        effectIndicator: { __typename: 'Indicator', id: '2503' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1784',
+        causalIndicator: { __typename: 'Indicator', id: '2571' },
+        effectIndicator: { __typename: 'Indicator', id: '2503' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '110',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2503',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1422',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '162',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '163',
+            name: 'Indicator name ei-päästökauppa',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '164',
+            name: 'Metrojen ja raitiovaunujen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '165',
+            name: 'Metrojen ja raitiovaunujen päästöt ei-päästökauppa',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '85',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '109',
+            name: 'Raideliikenteen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2502',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1717',
+        causalIndicator: { __typename: 'Indicator', id: '2503' },
+        effectIndicator: { __typename: 'Indicator', id: '2502' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1718',
+        causalIndicator: { __typename: 'Indicator', id: '2504' },
+        effectIndicator: { __typename: 'Indicator', id: '2502' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1719',
+        causalIndicator: { __typename: 'Indicator', id: '2505' },
+        effectIndicator: { __typename: 'Indicator', id: '2502' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '109',
+      name: 'Raideliikenteen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2502',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1421',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '110',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '111',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '112',
+            name: 'Tavarajunaliikenteen päästöt',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '84',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '26',
+            name: 'Liikenteen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2501',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1775',
+        causalIndicator: { __typename: 'Indicator', id: '2562' },
+        effectIndicator: { __typename: 'Indicator', id: '2501' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1776',
+        causalIndicator: { __typename: 'Indicator', id: '2563' },
+        effectIndicator: { __typename: 'Indicator', id: '2501' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1777',
+        causalIndicator: { __typename: 'Indicator', id: '2564' },
+        effectIndicator: { __typename: 'Indicator', id: '2501' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1778',
+        causalIndicator: { __typename: 'Indicator', id: '2565' },
+        effectIndicator: { __typename: 'Indicator', id: '2501' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '38',
+      name: 'Indicator name kaduilla',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2501',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1420',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1298',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1281',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1264',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1247',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1140',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1139',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1138',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1137',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1136',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1135',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1134',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1133',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1132',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1131',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1151',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '156',
+            name: 'Henkilöautojen päästöt (katuajo)',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '157',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '158',
+            name: 'Linja-autojen päästöt (katuajo)',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '159',
+            name: 'Pakettiautojen päästöt (katuajo)',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '15',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '36',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2500',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1771',
+        causalIndicator: { __typename: 'Indicator', id: '2558' },
+        effectIndicator: { __typename: 'Indicator', id: '2500' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1772',
+        causalIndicator: { __typename: 'Indicator', id: '2559' },
+        effectIndicator: { __typename: 'Indicator', id: '2500' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1773',
+        causalIndicator: { __typename: 'Indicator', id: '2560' },
+        effectIndicator: { __typename: 'Indicator', id: '2500' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1774',
+        causalIndicator: { __typename: 'Indicator', id: '2561' },
+        effectIndicator: { __typename: 'Indicator', id: '2500' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '37',
+      name: 'Indicator name maanteillä',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2500',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1419',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1297',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1280',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1263',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1246',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1130',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1129',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1128',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1127',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1126',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1125',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1124',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1123',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1122',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1121',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1150',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '152',
+            name: 'Henkilöautojen päästöt (maantieajo)',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '153',
+            name: 'Kuorma-autojen päästöt (maantieajo)',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '154',
+            name: 'Linja-autojen päästöt (maantieajo)',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '155',
+            name: 'Pakettiautojen päästöt (maantieajo)',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '14',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '36',
+            name: 'Indicator name',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2499',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1714',
+        causalIndicator: { __typename: 'Indicator', id: '2500' },
+        effectIndicator: { __typename: 'Indicator', id: '2499' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1715',
+        causalIndicator: { __typename: 'Indicator', id: '2501' },
+        effectIndicator: { __typename: 'Indicator', id: '2499' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1779',
+        causalIndicator: { __typename: 'Indicator', id: '2566' },
+        effectIndicator: { __typename: 'Indicator', id: '2499' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1780',
+        causalIndicator: { __typename: 'Indicator', id: '2567' },
+        effectIndicator: { __typename: 'Indicator', id: '2499' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '36',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2499',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1418',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1296',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1279',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1262',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1245',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1120',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1119',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1118',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1117',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1116',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1115',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1114',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1113',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1112',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1111',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1149',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '37',
+            name: 'Indicator name maanteillä',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '38',
+            name: 'Indicator name kaduilla',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '160',
+            name: 'Moottoripyörien ja mopojen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '161',
+            name: 'Läpiajoliikenteen päästöt',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '13',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '26',
+            name: 'Liikenteen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2498',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1713',
+        causalIndicator: { __typename: 'Indicator', id: '2499' },
+        effectIndicator: { __typename: 'Indicator', id: '2498' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1716',
+        causalIndicator: { __typename: 'Indicator', id: '2502' },
+        effectIndicator: { __typename: 'Indicator', id: '2498' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1720',
+        causalIndicator: { __typename: 'Indicator', id: '2506' },
+        effectIndicator: { __typename: 'Indicator', id: '2498' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '26',
+      name: 'Liikenteen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2498',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1417',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1295',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1278',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1261',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1244',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1018',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1017',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1016',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1015',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1014',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1013',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1012',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1011',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1010',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1009',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1008',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '36',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '109',
+            name: 'Raideliikenteen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '113',
+            name: 'Vesiliikenteen päästöt',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '3',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '23',
+            name: 'Net emissions (scope 2)',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2497',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1768',
+        causalIndicator: { __typename: 'Indicator', id: '2555' },
+        effectIndicator: { __typename: 'Indicator', id: '2497' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1769',
+        causalIndicator: { __typename: 'Indicator', id: '2556' },
+        effectIndicator: { __typename: 'Indicator', id: '2497' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1770',
+        causalIndicator: { __typename: 'Indicator', id: '2557' },
+        effectIndicator: { __typename: 'Indicator', id: '2497' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '35',
+      name: 'Rakennusten muun lämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2497',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1416',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1294',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1277',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1260',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1243',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1110',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1109',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1108',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1107',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1106',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1105',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1104',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1103',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1102',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1101',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1148',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '149',
+            name: 'Asumisen muun suoran lämmityksen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '150',
+            name: 'Palveluiden muun suoran lämmityksen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '151',
+            name: 'Maatalouden muun suoran lämmityksen päästöt',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '12',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '25',
+            name: 'Rakennusten lämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2496',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1765',
+        causalIndicator: { __typename: 'Indicator', id: '2552' },
+        effectIndicator: { __typename: 'Indicator', id: '2496' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1766',
+        causalIndicator: { __typename: 'Indicator', id: '2553' },
+        effectIndicator: { __typename: 'Indicator', id: '2496' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1767',
+        causalIndicator: { __typename: 'Indicator', id: '2554' },
+        effectIndicator: { __typename: 'Indicator', id: '2496' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '34',
+      name: 'Puulämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2496',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1415',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1293',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1276',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1259',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1242',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1100',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1099',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1098',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1097',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1096',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1095',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1094',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1093',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1092',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1091',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1147',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '146',
+            name: 'Asumisen puulämmityksen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '147',
+            name: 'Palveluiden puulämmityksen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '148',
+            name: 'Maatalouden puulämmityksen päästöt',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '11',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '25',
+            name: 'Rakennusten lämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2495',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1762',
+        causalIndicator: { __typename: 'Indicator', id: '2549' },
+        effectIndicator: { __typename: 'Indicator', id: '2495' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1763',
+        causalIndicator: { __typename: 'Indicator', id: '2550' },
+        effectIndicator: { __typename: 'Indicator', id: '2495' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1764',
+        causalIndicator: { __typename: 'Indicator', id: '2551' },
+        effectIndicator: { __typename: 'Indicator', id: '2495' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '33',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2495',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1414',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1292',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1275',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1258',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1241',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1090',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1089',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1088',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1087',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1086',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1085',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1084',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1083',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1082',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1081',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1146',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '143',
+            name: 'Asumisen Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '144',
+            name: 'Palveluiden Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '145',
+            name: 'Maatalouden Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '10',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '25',
+            name: 'Rakennusten lämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2494',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1754',
+        causalIndicator: { __typename: 'Indicator', id: '2541' },
+        effectIndicator: { __typename: 'Indicator', id: '2494' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1755',
+        causalIndicator: { __typename: 'Indicator', id: '2542' },
+        effectIndicator: { __typename: 'Indicator', id: '2494' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1756',
+        causalIndicator: { __typename: 'Indicator', id: '2543' },
+        effectIndicator: { __typename: 'Indicator', id: '2494' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1757',
+        causalIndicator: { __typename: 'Indicator', id: '2544' },
+        effectIndicator: { __typename: 'Indicator', id: '2494' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1758',
+        causalIndicator: { __typename: 'Indicator', id: '2545' },
+        effectIndicator: { __typename: 'Indicator', id: '2494' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1759',
+        causalIndicator: { __typename: 'Indicator', id: '2546' },
+        effectIndicator: { __typename: 'Indicator', id: '2494' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1760',
+        causalIndicator: { __typename: 'Indicator', id: '2547' },
+        effectIndicator: { __typename: 'Indicator', id: '2494' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1761',
+        causalIndicator: { __typename: 'Indicator', id: '2548' },
+        effectIndicator: { __typename: 'Indicator', id: '2494' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '32',
+      name: 'Indicator name',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2494',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1413',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1291',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1274',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1257',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1240',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1080',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1079',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1078',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1077',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1076',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1075',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1074',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1073',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1072',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1071',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1145',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '135',
+            name: 'Asumisen Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '136',
+            name: 'Asumisen Indicator name ei-päästökauppa',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '137',
+            name: 'Palveluiden Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '138',
+            name: 'Palveluiden Indicator name ei-päästökauppa',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '139',
+            name: 'Teollisuuden Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '140',
+            name: 'Teollisuuden Indicator name ei-päästökauppa',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '141',
+            name: 'Maatalouden Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '142',
+            name: 'Maatalouden Indicator name ei-päästökauppa',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '9',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '25',
+            name: 'Rakennusten lämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2493',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1748',
+        causalIndicator: { __typename: 'Indicator', id: '2535' },
+        effectIndicator: { __typename: 'Indicator', id: '2493' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1749',
+        causalIndicator: { __typename: 'Indicator', id: '2536' },
+        effectIndicator: { __typename: 'Indicator', id: '2493' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1750',
+        causalIndicator: { __typename: 'Indicator', id: '2537' },
+        effectIndicator: { __typename: 'Indicator', id: '2493' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1751',
+        causalIndicator: { __typename: 'Indicator', id: '2538' },
+        effectIndicator: { __typename: 'Indicator', id: '2493' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1752',
+        causalIndicator: { __typename: 'Indicator', id: '2539' },
+        effectIndicator: { __typename: 'Indicator', id: '2493' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1753',
+        causalIndicator: { __typename: 'Indicator', id: '2540' },
+        effectIndicator: { __typename: 'Indicator', id: '2493' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '31',
+      name: 'Maalämmön päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2493',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1412',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1290',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1273',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1256',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1239',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1070',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1069',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1068',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1067',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1066',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1065',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1064',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1063',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1062',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1061',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1144',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '132',
+            name: 'Asumisen maalämmön päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '230',
+            name: 'Asumisen maalämmön päästöt ei-päästökauppa',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '133',
+            name: 'Palveluiden maalämmön päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '231',
+            name: 'Palveluiden maalämmön päästöt ei-päästökauppa',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '134',
+            name: 'Maatalouden maalämmön päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '232',
+            name: 'Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '8',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '29',
+            name: 'Rakennusten sähkölämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2492',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1742',
+        causalIndicator: { __typename: 'Indicator', id: '2529' },
+        effectIndicator: { __typename: 'Indicator', id: '2492' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1743',
+        causalIndicator: { __typename: 'Indicator', id: '2530' },
+        effectIndicator: { __typename: 'Indicator', id: '2492' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1744',
+        causalIndicator: { __typename: 'Indicator', id: '2531' },
+        effectIndicator: { __typename: 'Indicator', id: '2492' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1745',
+        causalIndicator: { __typename: 'Indicator', id: '2532' },
+        effectIndicator: { __typename: 'Indicator', id: '2492' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1746',
+        causalIndicator: { __typename: 'Indicator', id: '2533' },
+        effectIndicator: { __typename: 'Indicator', id: '2492' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1747',
+        causalIndicator: { __typename: 'Indicator', id: '2534' },
+        effectIndicator: { __typename: 'Indicator', id: '2492' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '30',
+      name: 'Rakennusten suoran sähkölämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2492',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1411',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1289',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1272',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1255',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1238',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1060',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1059',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1058',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1057',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1056',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1055',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1054',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1053',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1052',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1051',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1143',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '129',
+            name: 'Asumisen suoran sähkölämmityksen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '227',
+            name: 'Asumisen suoran sähkölämmityksen päästöt ei-päästökauppa',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '130',
+            name: 'Palveluiden suoran sähkölämmityksen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '228',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '131',
+            name: 'Maatalouden suoran sähkölämmityksen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '229',
+            name: 'Maatalouden suoran sähkölämmityksen päästöt ei-päästökauppa',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '7',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '29',
+            name: 'Rakennusten sähkölämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2491',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1706',
+        causalIndicator: { __typename: 'Indicator', id: '2492' },
+        effectIndicator: { __typename: 'Indicator', id: '2491' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1707',
+        causalIndicator: { __typename: 'Indicator', id: '2493' },
+        effectIndicator: { __typename: 'Indicator', id: '2491' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '29',
+      name: 'Rakennusten sähkölämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2491',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1410',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1288',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1271',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1254',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1237',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1050',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1049',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1048',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1047',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1046',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1045',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1044',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1043',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1042',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1041',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1142',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '30',
+            name: 'Rakennusten suoran sähkölämmityksen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '31',
+            name: 'Maalämmön päästöt',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '6',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '25',
+            name: 'Rakennusten lämmityksen päästöt',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2490',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1705',
+        causalIndicator: { __typename: 'Indicator', id: '2491' },
+        effectIndicator: { __typename: 'Indicator', id: '2490' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1708',
+        causalIndicator: { __typename: 'Indicator', id: '2494' },
+        effectIndicator: { __typename: 'Indicator', id: '2490' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1709',
+        causalIndicator: { __typename: 'Indicator', id: '2495' },
+        effectIndicator: { __typename: 'Indicator', id: '2490' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1710',
+        causalIndicator: { __typename: 'Indicator', id: '2496' },
+        effectIndicator: { __typename: 'Indicator', id: '2490' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1711',
+        causalIndicator: { __typename: 'Indicator', id: '2497' },
+        effectIndicator: { __typename: 'Indicator', id: '2490' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '25',
+      name: 'Rakennusten lämmityksen päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2490',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1409',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1287',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1270',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1253',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1236',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1007',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1006',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1005',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1004',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1003',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1002',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1001',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1000',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '999',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '998',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '997',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '29',
+            name: 'Rakennusten sähkölämmityksen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '32',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '33',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '34',
+            name: 'Puulämmityksen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '35',
+            name: 'Rakennusten muun lämmityksen päästöt',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '2',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '23',
+            name: 'Net emissions (scope 2)',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2489',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1734',
+        causalIndicator: { __typename: 'Indicator', id: '2521' },
+        effectIndicator: { __typename: 'Indicator', id: '2489' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1735',
+        causalIndicator: { __typename: 'Indicator', id: '2522' },
+        effectIndicator: { __typename: 'Indicator', id: '2489' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1736',
+        causalIndicator: { __typename: 'Indicator', id: '2523' },
+        effectIndicator: { __typename: 'Indicator', id: '2489' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1737',
+        causalIndicator: { __typename: 'Indicator', id: '2524' },
+        effectIndicator: { __typename: 'Indicator', id: '2489' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1738',
+        causalIndicator: { __typename: 'Indicator', id: '2525' },
+        effectIndicator: { __typename: 'Indicator', id: '2489' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1739',
+        causalIndicator: { __typename: 'Indicator', id: '2526' },
+        effectIndicator: { __typename: 'Indicator', id: '2489' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1740',
+        causalIndicator: { __typename: 'Indicator', id: '2527' },
+        effectIndicator: { __typename: 'Indicator', id: '2489' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1741',
+        causalIndicator: { __typename: 'Indicator', id: '2528' },
+        effectIndicator: { __typename: 'Indicator', id: '2489' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '24',
+      name: 'Kulutussähkön päästöt',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2489',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1408',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1286',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1269',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1252',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1235',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '996',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '995',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '994',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '993',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '992',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '991',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '990',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '989',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '988',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '987',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '986',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '125',
+            name: 'Asumisen kulutussähkön päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '223',
+            name: 'Asumisen kulutussähkön päästöt ei-päästökauppa',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '126',
+            name: 'Palveluiden kulutussähkön päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '224',
+            name: 'Palveluiden kulutussähkön päästöt ei-päästökauppa',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '127',
+            name: 'Teollisuuden kulutussähkön päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '225',
+            name: 'Teollisuuden kulutussähkön päästöt ei-päästökauppa',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '128',
+            name: 'Maatalouden kulutussähkön päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '226',
+            name: 'Maatalouden kulutussähkön päästöt ei-päästökauppa',
+          },
+        },
+      ],
+      relatedEffects: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          id: '1',
+          effectType: 'PART_OF',
+          effectIndicator: {
+            __typename: 'CommonIndicator',
+            id: '23',
+            name: 'Net emissions (scope 2)',
+          },
+        },
+      ],
+    },
+  },
+  {
+    __typename: 'Indicator',
+    id: '2488',
+    relatedCauses: [
+      {
+        __typename: 'RelatedIndicator',
+        id: '1703',
+        causalIndicator: { __typename: 'Indicator', id: '2489' },
+        effectIndicator: { __typename: 'Indicator', id: '2488' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1704',
+        causalIndicator: { __typename: 'Indicator', id: '2490' },
+        effectIndicator: { __typename: 'Indicator', id: '2488' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1712',
+        causalIndicator: { __typename: 'Indicator', id: '2498' },
+        effectIndicator: { __typename: 'Indicator', id: '2488' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1723',
+        causalIndicator: { __typename: 'Indicator', id: '2509' },
+        effectIndicator: { __typename: 'Indicator', id: '2488' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1724',
+        causalIndicator: { __typename: 'Indicator', id: '2510' },
+        effectIndicator: { __typename: 'Indicator', id: '2488' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1725',
+        causalIndicator: { __typename: 'Indicator', id: '2511' },
+        effectIndicator: { __typename: 'Indicator', id: '2488' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1728',
+        causalIndicator: { __typename: 'Indicator', id: '2514' },
+        effectIndicator: { __typename: 'Indicator', id: '2488' },
+        effectType: 'PART_OF',
+      },
+      {
+        __typename: 'RelatedIndicator',
+        id: '1733',
+        causalIndicator: { __typename: 'Indicator', id: '2519' },
+        effectIndicator: { __typename: 'Indicator', id: '2488' },
+        effectType: 'PART_OF',
+      },
+    ],
+    common: {
+      __typename: 'CommonIndicator',
+      id: '23',
+      name: 'Net emissions (scope 2)',
+      indicators: [
+        {
+          __typename: 'Indicator',
+          id: '2488',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1285',
+          organization: {
+            __typename: 'Organization',
+            name: 'Orgamoostion',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1268',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1251',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1234',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1327',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1407',
+          organization: {
+            __typename: 'Organization',
+            name: 'Ipsum orgsum',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '985',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '984',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '983',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '982',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '981',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '980',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '979',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '978',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '977',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '976',
+          organization: { __typename: 'Organization', name: 'Org' },
+        },
+        {
+          __typename: 'Indicator',
+          id: '975',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+        {
+          __typename: 'Indicator',
+          id: '1141',
+          organization: {
+            __typename: 'Organization',
+            name: 'Org',
+          },
+        },
+      ],
+      relatedCauses: [
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '24',
+            name: 'Kulutussähkön päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '25',
+            name: 'Rakennusten lämmityksen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '26',
+            name: 'Liikenteen päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '116',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '117',
+            name: 'Indicator name',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '27',
+            name: 'Maatalouden päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '28',
+            name: 'Jätteiden käsittelyn päästöt',
+          },
+        },
+        {
+          __typename: 'RelatedCommonIndicator',
+          effectType: 'PART_OF',
+          causalIndicator: {
+            __typename: 'CommonIndicator',
+            id: '124',
+            name: 'Indicator name',
+          },
+        },
+      ],
+      relatedEffects: [],
+    },
+  },
+  { __typename: 'Indicator', id: '2329', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2345', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2348', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2334', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2337', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2333', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2335', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2346', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2344', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2342', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2341', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2338', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2336', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2328', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2330', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2347', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2326', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2327', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2325', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2339', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2340', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2349', relatedCauses: [], common: null },
+  { __typename: 'Indicator', id: '2331', relatedCauses: [], common: null },
+];
+
+export const EXPECTED_OUTPUT = {
+  '23': {
+    id: '23',
+    isRoot: true,
+    children: ['24', '25', '26', '116', '117', '27', '28', '124'],
+    path: ['23'],
+    pathNames: ['Net emissions (scope 2)'],
+    descendants: [
+      '125',
+      '223',
+      '126',
+      '224',
+      '127',
+      '225',
+      '128',
+      '226',
+      '24',
+      '129',
+      '227',
+      '130',
+      '228',
+      '131',
+      '229',
+      '30',
+      '132',
+      '230',
+      '133',
+      '231',
+      '134',
+      '232',
+      '31',
+      '29',
+      '135',
+      '136',
+      '137',
+      '138',
+      '139',
+      '140',
+      '141',
+      '142',
+      '32',
+      '143',
+      '144',
+      '145',
+      '33',
+      '146',
+      '147',
+      '148',
+      '34',
+      '149',
+      '150',
+      '151',
+      '35',
+      '25',
+      '152',
+      '153',
+      '154',
+      '155',
+      '37',
+      '156',
+      '157',
+      '158',
+      '159',
+      '38',
+      '160',
+      '161',
+      '36',
+      '162',
+      '163',
+      '164',
+      '165',
+      '110',
+      '166',
+      '167',
+      '168',
+      '111',
+      '169',
+      '233',
+      '170',
+      '112',
+      '109',
+      '172',
+      '173',
+      '114',
+      '174',
+      '175',
+      '176',
+      '115',
+      '171',
+      '113',
+      '26',
+      '234',
+      '235',
+      '178',
+      '116',
+      '179',
+      '180',
+      '181',
+      '182',
+      '183',
+      '117',
+      '184',
+      '185',
+      '186',
+      '187',
+      '118',
+      '188',
+      '236',
+      '189',
+      '119',
+      '27',
+      '190',
+      '191',
+      '120',
+      '192',
+      '193',
+      '121',
+      '194',
+      '195',
+      '122',
+      '196',
+      '197',
+      '123',
+      '28',
+      '198',
+      '199',
+      '200',
+      '201',
+      '124',
+    ],
+  },
+  '24': {
+    id: '24',
+    isRoot: false,
+    children: ['125', '223', '126', '224', '127', '225', '128', '226'],
+    path: ['23', '24'],
+    pathNames: ['Net emissions (scope 2)', 'Kulutussähkön päästöt'],
+    descendants: ['125', '223', '126', '224', '127', '225', '128', '226'],
+  },
+  '25': {
+    id: '25',
+    isRoot: false,
+    children: ['29', '32', '33', '34', '35'],
+    path: ['23', '25'],
+    pathNames: ['Net emissions (scope 2)', 'Rakennusten lämmityksen päästöt'],
+    descendants: [
+      '129',
+      '227',
+      '130',
+      '228',
+      '131',
+      '229',
+      '30',
+      '132',
+      '230',
+      '133',
+      '231',
+      '134',
+      '232',
+      '31',
+      '29',
+      '135',
+      '136',
+      '137',
+      '138',
+      '139',
+      '140',
+      '141',
+      '142',
+      '32',
+      '143',
+      '144',
+      '145',
+      '33',
+      '146',
+      '147',
+      '148',
+      '34',
+      '149',
+      '150',
+      '151',
+      '35',
+    ],
+  },
+  '26': {
+    id: '26',
+    isRoot: false,
+    children: ['36', '109', '113'],
+    path: ['23', '26'],
+    pathNames: ['Net emissions (scope 2)', 'Liikenteen päästöt'],
+    descendants: [
+      '152',
+      '153',
+      '154',
+      '155',
+      '37',
+      '156',
+      '157',
+      '158',
+      '159',
+      '38',
+      '160',
+      '161',
+      '36',
+      '162',
+      '163',
+      '164',
+      '165',
+      '110',
+      '166',
+      '167',
+      '168',
+      '111',
+      '169',
+      '233',
+      '170',
+      '112',
+      '109',
+      '172',
+      '173',
+      '114',
+      '174',
+      '175',
+      '176',
+      '115',
+      '171',
+      '113',
+    ],
+  },
+  '27': {
+    id: '27',
+    isRoot: false,
+    children: ['118', '119'],
+    path: ['23', '27'],
+    pathNames: ['Net emissions (scope 2)', 'Maatalouden päästöt'],
+    descendants: [
+      '184',
+      '185',
+      '186',
+      '187',
+      '118',
+      '188',
+      '236',
+      '189',
+      '119',
+    ],
+  },
+  '28': {
+    id: '28',
+    isRoot: false,
+    children: ['120', '121', '122', '123'],
+    path: ['23', '28'],
+    pathNames: ['Net emissions (scope 2)', 'Jätteiden käsittelyn päästöt'],
+    descendants: [
+      '190',
+      '191',
+      '120',
+      '192',
+      '193',
+      '121',
+      '194',
+      '195',
+      '122',
+      '196',
+      '197',
+      '123',
+    ],
+  },
+  '29': {
+    id: '29',
+    isRoot: false,
+    children: ['30', '31'],
+    path: ['23', '25', '29'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+    ],
+    descendants: [
+      '129',
+      '227',
+      '130',
+      '228',
+      '131',
+      '229',
+      '30',
+      '132',
+      '230',
+      '133',
+      '231',
+      '134',
+      '232',
+      '31',
+    ],
+  },
+  '30': {
+    id: '30',
+    isRoot: false,
+    children: ['129', '227', '130', '228', '131', '229'],
+    path: ['23', '25', '29', '30'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Rakennusten suoran sähkölämmityksen päästöt',
+    ],
+    descendants: ['129', '227', '130', '228', '131', '229'],
+  },
+  '31': {
+    id: '31',
+    isRoot: false,
+    children: ['132', '230', '133', '231', '134', '232'],
+    path: ['23', '25', '29', '31'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Maalämmön päästöt',
+    ],
+    descendants: ['132', '230', '133', '231', '134', '232'],
+  },
+  '32': {
+    id: '32',
+    isRoot: false,
+    children: ['135', '136', '137', '138', '139', '140', '141', '142'],
+    path: ['23', '25', '32'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+    ],
+    descendants: ['135', '136', '137', '138', '139', '140', '141', '142'],
+  },
+  '33': {
+    id: '33',
+    isRoot: false,
+    children: ['143', '144', '145'],
+    path: ['23', '25', '33'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+    ],
+    descendants: ['143', '144', '145'],
+  },
+  '34': {
+    id: '34',
+    isRoot: false,
+    children: ['146', '147', '148'],
+    path: ['23', '25', '34'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Puulämmityksen päästöt',
+    ],
+    descendants: ['146', '147', '148'],
+  },
+  '35': {
+    id: '35',
+    isRoot: false,
+    children: ['149', '150', '151'],
+    path: ['23', '25', '35'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten muun lämmityksen päästöt',
+    ],
+    descendants: ['149', '150', '151'],
+  },
+  '36': {
+    id: '36',
+    isRoot: false,
+    children: ['37', '38', '160', '161'],
+    path: ['23', '26', '36'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+    ],
+    descendants: [
+      '152',
+      '153',
+      '154',
+      '155',
+      '37',
+      '156',
+      '157',
+      '158',
+      '159',
+      '38',
+      '160',
+      '161',
+    ],
+  },
+  '37': {
+    id: '37',
+    isRoot: false,
+    children: ['152', '153', '154', '155'],
+    path: ['23', '26', '36', '37'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+      'Indicator name maanteillä',
+    ],
+    descendants: ['152', '153', '154', '155'],
+  },
+  '38': {
+    id: '38',
+    isRoot: false,
+    children: ['156', '157', '158', '159'],
+    path: ['23', '26', '36', '38'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+      'Indicator name kaduilla',
+    ],
+    descendants: ['156', '157', '158', '159'],
+  },
+  '39': {
+    id: '39',
+    isRoot: true,
+    children: [],
+    path: ['39'],
+    pathNames: ['Väestö'],
+    descendants: [],
+  },
+  '109': {
+    id: '109',
+    isRoot: false,
+    children: ['110', '111', '112'],
+    path: ['23', '26', '109'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+    ],
+    descendants: [
+      '162',
+      '163',
+      '164',
+      '165',
+      '110',
+      '166',
+      '167',
+      '168',
+      '111',
+      '169',
+      '233',
+      '170',
+      '112',
+    ],
+  },
+  '110': {
+    id: '110',
+    isRoot: false,
+    children: ['162', '163', '164', '165'],
+    path: ['23', '26', '109', '110'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Indicator name',
+    ],
+    descendants: ['162', '163', '164', '165'],
+  },
+  '111': {
+    id: '111',
+    isRoot: false,
+    children: ['166', '167', '168'],
+    path: ['23', '26', '109', '111'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Indicator name',
+    ],
+    descendants: ['166', '167', '168'],
+  },
+  '112': {
+    id: '112',
+    isRoot: false,
+    children: ['169', '233', '170'],
+    path: ['23', '26', '109', '112'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Tavarajunaliikenteen päästöt',
+    ],
+    descendants: ['169', '233', '170'],
+  },
+  '113': {
+    id: '113',
+    isRoot: false,
+    children: ['114', '115', '171'],
+    path: ['23', '26', '113'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Vesiliikenteen päästöt',
+    ],
+    descendants: ['172', '173', '114', '174', '175', '176', '115', '171'],
+  },
+  '114': {
+    id: '114',
+    isRoot: false,
+    children: ['172', '173'],
+    path: ['23', '26', '113', '114'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Vesiliikenteen päästöt',
+      'Indicator name',
+    ],
+    descendants: ['172', '173'],
+  },
+  '115': {
+    id: '115',
+    isRoot: false,
+    children: ['174', '175', '176'],
+    path: ['23', '26', '113', '115'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Vesiliikenteen päästöt',
+      'Työveneiden päästöt',
+    ],
+    descendants: ['174', '175', '176'],
+  },
+  '116': {
+    id: '116',
+    isRoot: false,
+    children: ['234', '235', '178'],
+    path: ['23', '116'],
+    pathNames: ['Net emissions (scope 2)', 'Indicator name'],
+    descendants: ['234', '235', '178'],
+  },
+  '117': {
+    id: '117',
+    isRoot: false,
+    children: ['179', '180', '181', '182', '183'],
+    path: ['23', '117'],
+    pathNames: ['Net emissions (scope 2)', 'Indicator name'],
+    descendants: ['179', '180', '181', '182', '183'],
+  },
+  '118': {
+    id: '118',
+    isRoot: false,
+    children: ['184', '185', '186', '187'],
+    path: ['23', '27', '118'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Maatalouden päästöt',
+      'Indicator name',
+    ],
+    descendants: ['184', '185', '186', '187'],
+  },
+  '119': {
+    id: '119',
+    isRoot: false,
+    children: ['188', '236', '189'],
+    path: ['23', '27', '119'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Maatalouden päästöt',
+      'Indicator name',
+    ],
+    descendants: ['188', '236', '189'],
+  },
+  '120': {
+    id: '120',
+    isRoot: false,
+    children: ['190', '191'],
+    path: ['23', '28', '120'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Jätteiden käsittelyn päästöt',
+      'Indicator name',
+    ],
+    descendants: ['190', '191'],
+  },
+  '121': {
+    id: '121',
+    isRoot: false,
+    children: ['192', '193'],
+    path: ['23', '28', '121'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Jätteiden käsittelyn päästöt',
+      'Indicator name',
+    ],
+    descendants: ['192', '193'],
+  },
+  '122': {
+    id: '122',
+    isRoot: false,
+    children: ['194', '195'],
+    path: ['23', '28', '122'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Jätteiden käsittelyn päästöt',
+      'Indicator name',
+    ],
+    descendants: ['194', '195'],
+  },
+  '123': {
+    id: '123',
+    isRoot: false,
+    children: ['196', '197'],
+    path: ['23', '28', '123'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Jätteiden käsittelyn päästöt',
+      'Indicator name',
+    ],
+    descendants: ['196', '197'],
+  },
+  '124': {
+    id: '124',
+    isRoot: false,
+    children: ['198', '199', '200', '201'],
+    path: ['23', '124'],
+    pathNames: ['Net emissions (scope 2)', 'Indicator name'],
+    descendants: ['198', '199', '200', '201'],
+  },
+  '125': {
+    id: '125',
+    isRoot: false,
+    children: [],
+    path: ['23', '24', '125'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Kulutussähkön päästöt',
+      'Asumisen kulutussähkön päästöt',
+    ],
+    descendants: [],
+  },
+  '126': {
+    id: '126',
+    isRoot: false,
+    children: [],
+    path: ['23', '24', '126'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Kulutussähkön päästöt',
+      'Palveluiden kulutussähkön päästöt',
+    ],
+    descendants: [],
+  },
+  '127': {
+    id: '127',
+    isRoot: false,
+    children: [],
+    path: ['23', '24', '127'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Kulutussähkön päästöt',
+      'Teollisuuden kulutussähkön päästöt',
+    ],
+    descendants: [],
+  },
+  '128': {
+    id: '128',
+    isRoot: false,
+    children: [],
+    path: ['23', '24', '128'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Kulutussähkön päästöt',
+      'Maatalouden kulutussähkön päästöt',
+    ],
+    descendants: [],
+  },
+  '129': {
+    id: '129',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '29', '30', '129'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Rakennusten suoran sähkölämmityksen päästöt',
+      'Asumisen suoran sähkölämmityksen päästöt',
+    ],
+    descendants: [],
+  },
+  '130': {
+    id: '130',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '29', '30', '130'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Rakennusten suoran sähkölämmityksen päästöt',
+      'Palveluiden suoran sähkölämmityksen päästöt',
+    ],
+    descendants: [],
+  },
+  '131': {
+    id: '131',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '29', '30', '131'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Rakennusten suoran sähkölämmityksen päästöt',
+      'Maatalouden suoran sähkölämmityksen päästöt',
+    ],
+    descendants: [],
+  },
+  '132': {
+    id: '132',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '29', '31', '132'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Maalämmön päästöt',
+      'Asumisen maalämmön päästöt',
+    ],
+    descendants: [],
+  },
+  '133': {
+    id: '133',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '29', '31', '133'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Maalämmön päästöt',
+      'Palveluiden maalämmön päästöt',
+    ],
+    descendants: [],
+  },
+  '134': {
+    id: '134',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '29', '31', '134'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Maalämmön päästöt',
+      'Maatalouden maalämmön päästöt',
+    ],
+    descendants: [],
+  },
+  '135': {
+    id: '135',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '32', '135'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+      'Asumisen Indicator name',
+    ],
+    descendants: [],
+  },
+  '136': {
+    id: '136',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '32', '136'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+      'Asumisen Indicator name ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '137': {
+    id: '137',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '32', '137'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+      'Palveluiden Indicator name',
+    ],
+    descendants: [],
+  },
+  '138': {
+    id: '138',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '32', '138'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+      'Palveluiden Indicator name ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '139': {
+    id: '139',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '32', '139'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+      'Teollisuuden Indicator name',
+    ],
+    descendants: [],
+  },
+  '140': {
+    id: '140',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '32', '140'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+      'Teollisuuden Indicator name ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '141': {
+    id: '141',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '32', '141'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+      'Maatalouden Indicator name',
+    ],
+    descendants: [],
+  },
+  '142': {
+    id: '142',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '32', '142'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+      'Maatalouden Indicator name ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '143': {
+    id: '143',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '33', '143'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+      'Asumisen Indicator name',
+    ],
+    descendants: [],
+  },
+  '144': {
+    id: '144',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '33', '144'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+      'Palveluiden Indicator name',
+    ],
+    descendants: [],
+  },
+  '145': {
+    id: '145',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '33', '145'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Indicator name',
+      'Maatalouden Indicator name',
+    ],
+    descendants: [],
+  },
+  '146': {
+    id: '146',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '34', '146'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Puulämmityksen päästöt',
+      'Asumisen puulämmityksen päästöt',
+    ],
+    descendants: [],
+  },
+  '147': {
+    id: '147',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '34', '147'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Puulämmityksen päästöt',
+      'Palveluiden puulämmityksen päästöt',
+    ],
+    descendants: [],
+  },
+  '148': {
+    id: '148',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '34', '148'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Puulämmityksen päästöt',
+      'Maatalouden puulämmityksen päästöt',
+    ],
+    descendants: [],
+  },
+  '149': {
+    id: '149',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '35', '149'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten muun lämmityksen päästöt',
+      'Asumisen muun suoran lämmityksen päästöt',
+    ],
+    descendants: [],
+  },
+  '150': {
+    id: '150',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '35', '150'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten muun lämmityksen päästöt',
+      'Palveluiden muun suoran lämmityksen päästöt',
+    ],
+    descendants: [],
+  },
+  '151': {
+    id: '151',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '35', '151'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten muun lämmityksen päästöt',
+      'Maatalouden muun suoran lämmityksen päästöt',
+    ],
+    descendants: [],
+  },
+  '152': {
+    id: '152',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '36', '37', '152'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+      'Indicator name maanteillä',
+      'Henkilöautojen päästöt (maantieajo)',
+    ],
+    descendants: [],
+  },
+  '153': {
+    id: '153',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '36', '37', '153'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+      'Indicator name maanteillä',
+      'Kuorma-autojen päästöt (maantieajo)',
+    ],
+    descendants: [],
+  },
+  '154': {
+    id: '154',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '36', '37', '154'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+      'Indicator name maanteillä',
+      'Linja-autojen päästöt (maantieajo)',
+    ],
+    descendants: [],
+  },
+  '155': {
+    id: '155',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '36', '37', '155'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+      'Indicator name maanteillä',
+      'Pakettiautojen päästöt (maantieajo)',
+    ],
+    descendants: [],
+  },
+  '156': {
+    id: '156',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '36', '38', '156'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+      'Indicator name kaduilla',
+      'Henkilöautojen päästöt (katuajo)',
+    ],
+    descendants: [],
+  },
+  '157': {
+    id: '157',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '36', '38', '157'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+      'Indicator name kaduilla',
+      'Indicator name',
+    ],
+    descendants: [],
+  },
+  '158': {
+    id: '158',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '36', '38', '158'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+      'Indicator name kaduilla',
+      'Linja-autojen päästöt (katuajo)',
+    ],
+    descendants: [],
+  },
+  '159': {
+    id: '159',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '36', '38', '159'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+      'Indicator name kaduilla',
+      'Pakettiautojen päästöt (katuajo)',
+    ],
+    descendants: [],
+  },
+  '160': {
+    id: '160',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '36', '160'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+      'Moottoripyörien ja mopojen päästöt',
+    ],
+    descendants: [],
+  },
+  '161': {
+    id: '161',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '36', '161'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Indicator name',
+      'Läpiajoliikenteen päästöt',
+    ],
+    descendants: [],
+  },
+  '162': {
+    id: '162',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '109', '110', '162'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Indicator name',
+      'Indicator name',
+    ],
+    descendants: [],
+  },
+  '163': {
+    id: '163',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '109', '110', '163'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Indicator name',
+      'Indicator name ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '164': {
+    id: '164',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '109', '110', '164'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Indicator name',
+      'Metrojen ja raitiovaunujen päästöt',
+    ],
+    descendants: [],
+  },
+  '165': {
+    id: '165',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '109', '110', '165'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Indicator name',
+      'Metrojen ja raitiovaunujen päästöt ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '166': {
+    id: '166',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '109', '111', '166'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Indicator name',
+      'Sähköjunien päästöt',
+    ],
+    descendants: [],
+  },
+  '167': {
+    id: '167',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '109', '111', '167'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Indicator name',
+      'Sähköjunien päästöt ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '168': {
+    id: '168',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '109', '111', '168'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Indicator name',
+      'Indicator name',
+    ],
+    descendants: [],
+  },
+  '169': {
+    id: '169',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '109', '112', '169'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Tavarajunaliikenteen päästöt',
+      'Sähkötavarajunien päästöt',
+    ],
+    descendants: [],
+  },
+  '170': {
+    id: '170',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '109', '112', '170'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Tavarajunaliikenteen päästöt',
+      'Dieseltavarajunien päästöt',
+    ],
+    descendants: [],
+  },
+  '171': {
+    id: '171',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '113', '171'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Vesiliikenteen päästöt',
+      'Huviveneiden päästöt',
+    ],
+    descendants: [],
+  },
+  '172': {
+    id: '172',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '113', '114', '172'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Vesiliikenteen päästöt',
+      'Indicator name',
+      'MatkustajaIndicator name',
+    ],
+    descendants: [],
+  },
+  '173': {
+    id: '173',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '113', '114', '173'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Vesiliikenteen päästöt',
+      'Indicator name',
+      'TavaraIndicator name',
+    ],
+    descendants: [],
+  },
+  '174': {
+    id: '174',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '113', '115', '174'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Vesiliikenteen päästöt',
+      'Työveneiden päästöt',
+      'Kalastusalusten päästöt',
+    ],
+    descendants: [],
+  },
+  '175': {
+    id: '175',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '113', '115', '175'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Vesiliikenteen päästöt',
+      'Työveneiden päästöt',
+      'Lauttojen ja lossien päästöt',
+    ],
+    descendants: [],
+  },
+  '176': {
+    id: '176',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '113', '115', '176'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Vesiliikenteen päästöt',
+      'Työveneiden päästöt',
+      'Työveneiden ja -alusten päästöt',
+    ],
+    descendants: [],
+  },
+  '178': {
+    id: '178',
+    isRoot: false,
+    children: [],
+    path: ['23', '116', '178'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Indicator name',
+      'Teollisuuden polttoaineiden päästöt ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '179': {
+    id: '179',
+    isRoot: false,
+    children: [],
+    path: ['23', '117', '179'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Indicator name',
+      'RakennusIndicator name',
+    ],
+    descendants: [],
+  },
+  '180': {
+    id: '180',
+    isRoot: false,
+    children: [],
+    path: ['23', '117', '180'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Indicator name',
+      'Maa- ja metsätalouskoneiden päästöt',
+    ],
+    descendants: [],
+  },
+  '181': {
+    id: '181',
+    isRoot: false,
+    children: [],
+    path: ['23', '117', '181'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Indicator name',
+      'Kaivos- ja teollisuusIndicator name',
+    ],
+    descendants: [],
+  },
+  '182': {
+    id: '182',
+    isRoot: false,
+    children: [],
+    path: ['23', '117', '182'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Indicator name',
+      'Muiden Indicator name',
+    ],
+    descendants: [],
+  },
+  '183': {
+    id: '183',
+    isRoot: false,
+    children: [],
+    path: ['23', '117', '183'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Indicator name',
+      'TieIndicator name',
+    ],
+    descendants: [],
+  },
+  '184': {
+    id: '184',
+    isRoot: false,
+    children: [],
+    path: ['23', '27', '118', '184'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Maatalouden päästöt',
+      'Indicator name',
+      'Epäorgaanisten lannoitteiden päästöt',
+    ],
+    descendants: [],
+  },
+  '185': {
+    id: '185',
+    isRoot: false,
+    children: [],
+    path: ['23', '27', '118', '185'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Maatalouden päästöt',
+      'Indicator name',
+      'Orgaanisten lannoitteiden päästöt',
+    ],
+    descendants: [],
+  },
+  '186': {
+    id: '186',
+    isRoot: false,
+    children: [],
+    path: ['23', '27', '118', '186'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Maatalouden päästöt',
+      'Indicator name',
+      'Peltoviljelyn maaperän päästöt',
+    ],
+    descendants: [],
+  },
+  '187': {
+    id: '187',
+    isRoot: false,
+    children: [],
+    path: ['23', '27', '118', '187'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Maatalouden päästöt',
+      'Indicator name',
+      'Indicator name',
+    ],
+    descendants: [],
+  },
+  '188': {
+    id: '188',
+    isRoot: false,
+    children: [],
+    path: ['23', '27', '119', '188'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Maatalouden päästöt',
+      'Indicator name',
+      'Eläinten ruoansulatuksen päästöt',
+    ],
+    descendants: [],
+  },
+  '189': {
+    id: '189',
+    isRoot: false,
+    children: [],
+    path: ['23', '27', '119', '189'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Maatalouden päästöt',
+      'Indicator name',
+      'Indicator name',
+    ],
+    descendants: [],
+  },
+  '190': {
+    id: '190',
+    isRoot: false,
+    children: [],
+    path: ['23', '28', '120', '190'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Jätteiden käsittelyn päästöt',
+      'Indicator name',
+      'Teollisuuden Indicator name',
+    ],
+    descendants: [],
+  },
+  '191': {
+    id: '191',
+    isRoot: false,
+    children: [],
+    path: ['23', '28', '120', '191'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Jätteiden käsittelyn päästöt',
+      'Indicator name',
+      'Indicator name',
+    ],
+    descendants: [],
+  },
+  '192': {
+    id: '192',
+    isRoot: false,
+    children: [],
+    path: ['23', '28', '121', '192'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Jätteiden käsittelyn päästöt',
+      'Indicator name',
+      'Teollisuuden Indicator name',
+    ],
+    descendants: [],
+  },
+  '193': {
+    id: '193',
+    isRoot: false,
+    children: [],
+    path: ['23', '28', '121', '193'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Jätteiden käsittelyn päästöt',
+      'Indicator name',
+      'Yhdyskunnan Indicator name',
+    ],
+    descendants: [],
+  },
+  '194': {
+    id: '194',
+    isRoot: false,
+    children: [],
+    path: ['23', '28', '122', '194'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Jätteiden käsittelyn päästöt',
+      'Indicator name',
+      'TeollisuusIndicator name',
+    ],
+    descendants: [],
+  },
+  '195': {
+    id: '195',
+    isRoot: false,
+    children: [],
+    path: ['23', '28', '122', '195'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Jätteiden käsittelyn päästöt',
+      'Indicator name',
+      'Indicator name',
+    ],
+    descendants: [],
+  },
+  '196': {
+    id: '196',
+    isRoot: false,
+    children: [],
+    path: ['23', '28', '123', '196'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Jätteiden käsittelyn päästöt',
+      'Indicator name',
+      'Indicator name',
+    ],
+    descendants: [],
+  },
+  '197': {
+    id: '197',
+    isRoot: false,
+    children: [],
+    path: ['23', '28', '123', '197'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Jätteiden käsittelyn päästöt',
+      'Indicator name',
+      'Indicator name',
+    ],
+    descendants: [],
+  },
+  '198': {
+    id: '198',
+    isRoot: false,
+    children: [],
+    path: ['23', '124', '198'],
+    pathNames: ['Net emissions (scope 2)', 'Indicator name', 'Indicator name'],
+    descendants: [],
+  },
+  '199': {
+    id: '199',
+    isRoot: false,
+    children: [],
+    path: ['23', '124', '199'],
+    pathNames: ['Net emissions (scope 2)', 'Indicator name', 'Indicator name'],
+    descendants: [],
+  },
+  '200': {
+    id: '200',
+    isRoot: false,
+    children: [],
+    path: ['23', '124', '200'],
+    pathNames: ['Net emissions (scope 2)', 'Indicator name', 'Indicator name'],
+    descendants: [],
+  },
+  '201': {
+    id: '201',
+    isRoot: false,
+    children: [],
+    path: ['23', '124', '201'],
+    pathNames: ['Net emissions (scope 2)', 'Indicator name', 'Indicator name'],
+    descendants: [],
+  },
+  '223': {
+    id: '223',
+    isRoot: false,
+    children: [],
+    path: ['23', '24', '223'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Kulutussähkön päästöt',
+      'Asumisen kulutussähkön päästöt ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '224': {
+    id: '224',
+    isRoot: false,
+    children: [],
+    path: ['23', '24', '224'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Kulutussähkön päästöt',
+      'Palveluiden kulutussähkön päästöt ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '225': {
+    id: '225',
+    isRoot: false,
+    children: [],
+    path: ['23', '24', '225'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Kulutussähkön päästöt',
+      'Teollisuuden kulutussähkön päästöt ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '226': {
+    id: '226',
+    isRoot: false,
+    children: [],
+    path: ['23', '24', '226'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Kulutussähkön päästöt',
+      'Maatalouden kulutussähkön päästöt ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '227': {
+    id: '227',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '29', '30', '227'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Rakennusten suoran sähkölämmityksen päästöt',
+      'Asumisen suoran sähkölämmityksen päästöt ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '228': {
+    id: '228',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '29', '30', '228'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Rakennusten suoran sähkölämmityksen päästöt',
+      'Indicator name',
+    ],
+    descendants: [],
+  },
+  '229': {
+    id: '229',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '29', '30', '229'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Rakennusten suoran sähkölämmityksen päästöt',
+      'Maatalouden suoran sähkölämmityksen päästöt ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '230': {
+    id: '230',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '29', '31', '230'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Maalämmön päästöt',
+      'Asumisen maalämmön päästöt ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '231': {
+    id: '231',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '29', '31', '231'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Maalämmön päästöt',
+      'Palveluiden maalämmön päästöt ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '232': {
+    id: '232',
+    isRoot: false,
+    children: [],
+    path: ['23', '25', '29', '31', '232'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Rakennusten lämmityksen päästöt',
+      'Rakennusten sähkölämmityksen päästöt',
+      'Maalämmön päästöt',
+      'Indicator name',
+    ],
+    descendants: [],
+  },
+  '233': {
+    id: '233',
+    isRoot: false,
+    children: [],
+    path: ['23', '26', '109', '112', '233'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Liikenteen päästöt',
+      'Raideliikenteen päästöt',
+      'Tavarajunaliikenteen päästöt',
+      'Sähkötavarajunien päästöt ei-päästökauppa',
+    ],
+    descendants: [],
+  },
+  '234': {
+    id: '234',
+    isRoot: false,
+    children: [],
+    path: ['23', '116', '234'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Indicator name',
+      'Teollisuuden polttoaineiden päästöt ei-HINKU',
+    ],
+    descendants: [],
+  },
+  '235': {
+    id: '235',
+    isRoot: false,
+    children: [],
+    path: ['23', '116', '235'],
+    pathNames: ['Net emissions (scope 2)', 'Indicator name', 'Indicator name'],
+    descendants: [],
+  },
+  '236': {
+    id: '236',
+    isRoot: false,
+    children: [],
+    path: ['23', '27', '119', '236'],
+    pathNames: [
+      'Net emissions (scope 2)',
+      'Maatalouden päästöt',
+      'Indicator name',
+      'Indicator name',
+    ],
+    descendants: [],
+  },
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,10 +11,10 @@ const customJestConfig = {
   moduleNameMapper: {
     // Handle module aliases (this will be automatically configured for you soon)
     '^@/components/(.*)$': '<rootDir>/components/$1',
-    'components/(.*)$': '<rootDir>/components/$1',
+    '^components/(.*)$': '<rootDir>/components/$1',
     '^components/(.*)$': '<rootDir>/components/$1',
     '^@/pages/(.*)$': '<rootDir>/pages/$1',
-    'common/(.*)$': '<rootDir>/common/$1',
+    '^common/(.*)$': '<rootDir>/common/$1',
     '^context/(.*)$': '<rootDir>/context/$1',
   },
   testEnvironment: 'jest-environment-jsdom',


### PR DESCRIPTION
This has been pushed to staging, so please test this out [there](https://pirkkala-ilmasto.watch.staging.kausal.tech/indicators).

More of a bandaid than a rewrite, this essentially splits the hierarchical and flat indicators before sorting to ensure the tree structure isn't sorted incorrectly.

I started to refactor `processCommonIndicatorHierarchy` before realising the bug was within the sorting, but have committed the test case for that function in case we refactor in future. The large `mocks` file contains an input and expected output from that function.