### PR TITLE
Contain floating elements in richtext

### DIFF
--- a/common/ThemedGlobalStyles.js
+++ b/common/ThemedGlobalStyles.js
@@ -155,17 +155,19 @@ const GlobalStyle = createGlobalStyle`
     }
 
     &.left {
-      display: inline-block;
+      float: left;
+      max-width: 100%;
+      height: auto;
       margin: ${(props) => props.theme.spaces.s150};
       margin-left: 0;
-      float: left;
     }
 
     &.right {
-      display: inline-block;
+      float: right;
+      max-width: 100%;
+      height: auto;
       margin: ${(props) => props.theme.spaces.s150};
       margin-right: 0;
-      float: right;
     }
   }
 

--- a/components/actions/ActionHero.tsx
+++ b/components/actions/ActionHero.tsx
@@ -126,7 +126,7 @@ const ImageCredit = styled.span`
 const ActionHeadline = styled.h1`
   hyphens: manual;
   margin: ${(props) => props.theme.spaces.s100} 0;
-  font-size: ${(props) => props.theme.fontSizeXl};
+  font-size: ${(props) => props.theme.fontSizeLg};
   color: ${(props) => props.theme.themeColors.black} !important;
 
   @media (min-width: ${(props) => props.theme.breakpointMd}) {
@@ -138,6 +138,7 @@ const ActionHeadline = styled.h1`
 const ActionNumber = styled.span`
   margin-right: ${(props) => props.theme.spaces.s100};
   white-space: nowrap;
+  display: block;
 
   &:after {
     content: '.';

--- a/components/common/Breadcrumbs.tsx
+++ b/components/common/Breadcrumbs.tsx
@@ -16,8 +16,12 @@ type Props = {
 };
 
 const StyledContainer = styled.div`
-  font-size: ${(props) => props.theme.fontSizeMd};
+  font-size: ${(props) => props.theme.fontSizeBase};
   margin-bottom: ${(props) => props.theme.spaces.s100};
+
+  @media (min-width: ${(props) => props.theme.breakpointMd}) {
+    font-size: ${(props) => props.theme.fontSizeMd};
+  }
 `;
 
 function Crumb({ crumb }: { crumb: TCrumb }) {

--- a/components/common/RichText.tsx
+++ b/components/common/RichText.tsx
@@ -254,7 +254,7 @@ export default function RichText(props: RichTextProps) {
     );
 
   return (
-    <div {...rest} className={`text-content ${className || ''}`}>
+    <div {...rest} className={`text-content clearfix ${className || ''}`}>
       <StyledRichText>{parsedContent}</StyledRichText>
     </div>
   );


### PR DESCRIPTION
Make sure floating (image)elements inside richtext do not mess the layout

Before
<img width="655" alt="Screenshot 2024-01-02 at 13 00 25" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/7badcad1-db49-46c9-b933-5a02fcd5d15d">

After
<img width="664" alt="Screenshot 2024-01-02 at 13 00 53" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/663336f1-73d7-473d-ab56-8121c84f55d5">

