### PR TITLE
Allow no goal value on (normalized) indicator showcase

### DIFF
--- a/components/common/Switch.js
+++ b/components/common/Switch.js
@@ -7,7 +7,13 @@ function Switch(props) {
   return (
     <Form>
       <FormGroup switch>
-        <Input type="switch" checked={state} onChange={onChange} id={id} />
+        <Input
+          type="switch"
+          checked={state}
+          onChange={onChange}
+          id={id}
+          role="switch"
+        />
         <Label check htmlFor={id}>
           {label}
         </Label>

--- a/components/indicators/IndicatorProgressBar.js
+++ b/components/indicators/IndicatorProgressBar.js
@@ -73,6 +73,10 @@ const NormalizerChooser = styled.div`
   margin-top: ${(props) => props.theme.spaces.s200};
   padding: ${(props) =>
     `${props.theme.spaces.s050} ${props.theme.spaces.s150}`};
+
+  .form-check-input {
+    border-color: ${({ theme }) => theme.section.indicatorShowcase.color};
+  }
 `;
 
 const formatValue = (value, locale) => {


### PR DESCRIPTION
<img width="820" alt="Screenshot 2024-01-17 at 17 20 16" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/83ac549c-b8a9-4b2f-afd0-45d1d058130d">

Handle edge case where goal value is not available:

<img width="822" alt="Screenshot 2024-01-17 at 17 20 26" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/fe355d77-dbbf-4f6e-a39f-2881ebb626e3">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206202710087677