### PR TITLE
Fix several problems with dashboard action status donuts

### DIFF
--- a/common/preprocess.ts
+++ b/common/preprocess.ts
@@ -85,12 +85,15 @@ const getStatusData = (
   actions: ActionListAction[],
   actionStatusSummaries: ActionStatusSummary[],
   theme: Theme,
-  unknownLabelText: string = ''
+  unknownLabelText: string = '',
+  language: string
 ) => {
   const progress: Progress = {
     values: [],
     labels: [],
     colors: [],
+    texts: [],
+    hoverTexts: [],
     good: 0,
     total: '',
   };
@@ -117,7 +120,7 @@ const getStatusData = (
           : label || unknownLabelText
       );
       progress.colors.push(theme.graphColors[colors.get(identifier) ?? color]);
-      if (sentiment == Sentiment.Positive || identifier == 'NOT_STARTED') {
+      if (sentiment === Sentiment.Positive || identifier === 'NOT_STARTED') {
         progress.good += statusCount;
       }
     }
@@ -126,6 +129,25 @@ const getStatusData = (
     }
   });
   progress.total = `${Math.round((progress.good / totalCount) * 100)}%`;
+  const numberFormat = new Intl.NumberFormat(language, {
+    maximumSignificantDigits: 2,
+    style: 'percent',
+  });
+  for (let i = 0; i < progress.values.length; i++) {
+    const label = progress.labels[i];
+    let hoverText: string, text: string;
+    if (label === unknownLabelText) {
+      text = '';
+      hoverText = label;
+    } else {
+      const value = progress.values[i];
+      const formattedValue = numberFormat.format(value / totalCount);
+      text = formattedValue;
+      hoverText = `${label}<br>${value}<br>${formattedValue}`;
+    }
+    progress.hoverTexts.push(hoverText);
+    progress.texts.push(text);
+  }
   return progress;
 };
 

--- a/components/dashboard/ActionStatusGraphs.tsx
+++ b/components/dashboard/ActionStatusGraphs.tsx
@@ -183,12 +183,21 @@ const ActionsStatusGraphs = ({
 }: ActionsStatusGraphsProps) => {
   const theme = useTheme();
   const plan = useContext(PlanContext);
-  const { t } = useTranslation(['common']);
+  const {
+    t,
+    i18n: { language },
+  } = useTranslation(['common']);
   const showTotals = theme.settings.dashboard.showActionDonutTotals ?? true;
 
   const progressData =
     shownDatasets.progress &&
-    getStatusData(actions, plan.actionStatusSummaries, theme, t('no-status'));
+    getStatusData(
+      actions,
+      plan.actionStatusSummaries,
+      theme,
+      t('no-status'),
+      language
+    );
 
   const timelinessData =
     shownDatasets.timeliness && getTimelinessData(actions, plan, theme, t);

--- a/components/dashboard/ActionStatusGraphs.tsx
+++ b/components/dashboard/ActionStatusGraphs.tsx
@@ -56,6 +56,8 @@ export type Progress = {
   values: number[];
   labels: string[];
   colors: string[];
+  texts?: string[];
+  hoverTexts?: string[];
   good: number;
   total: string;
 };
@@ -226,7 +228,12 @@ const ActionsStatusGraphs = ({
 
       {!plan.features.minimalStatuses && progressData && (
         <StatusDonut
-          data={{ values: progressData.values, labels: progressData.labels }}
+          data={{
+            values: progressData.values,
+            labels: progressData.labels,
+            texts: progressData.texts,
+            hoverTexts: progressData.hoverTexts,
+          }}
           currentValue={showTotals ? progressData.total : undefined}
           colors={progressData.colors.length > 0 ? progressData.colors : []}
           header={t('actions-status')}

--- a/components/graphs/StatusDonut.js
+++ b/components/graphs/StatusDonut.js
@@ -133,10 +133,23 @@ const StatusDonut = (props) => {
     },
   };
 
-  const pieDataWithPercent = {
+  if (
+    data.hoverTexts != null &&
+    data.hoverTexts.length === data.values.length
+  ) {
+    pieData.hoverinfo = 'text';
+    pieData.text = data.hoverTexts;
+    pieData.hovertemplate = null;
+  }
+  const pieDataWithTextOnGraph = {
     ...pieData,
     textinfo: 'percent',
   };
+  if (data.texts != null && data.texts.length === data.values.length) {
+    pieDataWithTextOnGraph.textinfo = 'text';
+    pieDataWithTextOnGraph.text = data.texts;
+  }
+
   const pieLayoutWithLegend = {
     ...pieLayout,
     height: 350,
@@ -175,7 +188,7 @@ const StatusDonut = (props) => {
         helpText={helpText}
       >
         <Plot
-          data={[pieDataWithPercent]}
+          data={[pieDataWithTextOnGraph]}
           layout={pieLayoutWithLegend}
           config={config}
         />

--- a/tests/preprocess.test.ts
+++ b/tests/preprocess.test.ts
@@ -1,0 +1,164 @@
+import { getPhaseData } from '../common/preprocess';
+
+const defaultPhases = [
+  {
+    identifier: 'not_started',
+    name: 'Not started',
+  },
+  {
+    identifier: 'in_progress',
+    name: 'In progress',
+  },
+  {
+    identifier: 'completed',
+    name: 'Completed',
+  },
+];
+
+const defaultActions = [1, 2, 5]
+  .map((count, idx) =>
+    new Array(count).fill(null).map((count) => ({
+      implementationPhase: defaultPhases[idx],
+      statusSummary: {
+        identifier: 'ON_TIME',
+        isActive: true,
+        isCompleted: idx == 2,
+      },
+    }))
+  )
+  .flat();
+
+const actionsWithInActiveActions = defaultActions
+  .concat(
+    defaultActions.map((a) =>
+      Object.assign({}, a, {
+        statusSummary: {
+          identifier: 'OUT_OF_SCOPE',
+          isActive: false,
+          isCompleted: false,
+        },
+      })
+    )
+  )
+  .concat({
+    implementationPhase: null,
+    statusSummary: {
+      identifier: 'UNDEFINED',
+      isActive: true,
+      isCompleted: false,
+    },
+  });
+
+const defaultPlan = {
+  actionStatusSummaries: [
+    {
+      isActive: false,
+      identifier: 'COMPLETED',
+      isCompleted: true,
+      label: 'Completed',
+    },
+    {
+      isActive: true,
+      identifier: 'ON_TIME',
+      isCompleted: false,
+      label: 'On time',
+    },
+    {
+      isActive: true,
+      identifier: 'IN_PROGRESS',
+      isCompleted: false,
+      label: 'In progress',
+    },
+    {
+      isActive: true,
+      identifier: 'NOT_STARTED',
+      isCompleted: false,
+      label: 'Not started',
+    },
+    {
+      isActive: true,
+      identifier: 'LATE',
+      isCompleted: false,
+      label: 'Late',
+    },
+    {
+      isActive: false,
+      identifier: 'CANCELLED',
+      isCompleted: false,
+      label: 'Cancelled or postponed',
+    },
+    {
+      isActive: false,
+      identifier: 'OUT_OF_SCOPE',
+      isCompleted: false,
+      label: 'Out of scope',
+    },
+    {
+      isActive: false,
+      identifier: 'MERGED',
+      isCompleted: true,
+      label: 'Merged',
+    },
+    {
+      isActive: false,
+      identifier: 'POSTPONED',
+      isCompleted: false,
+      label: 'Postponed',
+    },
+    {
+      isActive: true,
+      identifier: 'UNDEFINED',
+      isCompleted: false,
+      label: 'Unknown',
+    },
+  ],
+  actionImplementationPhases: defaultPhases,
+};
+
+const mockT = (x) => x;
+
+describe('getPhaseData', () => {
+  it('returns null for no actions', () => {
+    expect(
+      getPhaseData(
+        [],
+        { actionImplementationPhases: [] },
+        { graphColors: {} },
+        mockT
+      )
+    ).toEqual(null);
+  });
+  it('returns the correct series with default actions', () => {
+    expect(
+      getPhaseData(defaultActions, defaultPlan, { graphColors: {} }, mockT)
+    ).toMatchObject({
+      labels: ['Completed', 'In progress', 'Not started'],
+      values: [5, 2, 1],
+      colors: [undefined, undefined, undefined],
+      good: 0,
+      total: '7', // substract 1 for the not_started action
+    });
+  });
+  it('returns the correct series with actions that have an inactive status', () => {
+    expect(
+      getPhaseData(
+        actionsWithInActiveActions,
+        defaultPlan,
+        { graphColors: {} },
+        mockT
+      )
+    ).toMatchObject({
+      labels: [
+        'Completed',
+        'In progress',
+        'Not started',
+        'no-phase',
+        'actions:inactive-actions',
+      ],
+      values: [5, 2, 1, 1, 8],
+      colors: [undefined, undefined, undefined, undefined, undefined],
+      good: 0,
+      total: '7',
+    });
+  });
+});


### PR DESCRIPTION

![Screenshot from 2024-01-22 17-28-02](https://github.com/kausaltech/kausal-watch-ui/assets/659611/47d30d1a-20ba-48e0-801d-346ce7aea18f)
![Screenshot from 2024-01-22 17-27-55](https://github.com/kausaltech/kausal-watch-ui/assets/659611/99c9c72f-de60-433b-be1b-9ebe60f9c3d4)
![Screenshot from 2024-01-22 17-27-44](https://github.com/kausaltech/kausal-watch-ui/assets/659611/86cc44d9-0e7a-4fe6-a77d-04d50ea6c37b)
![Screenshot from 2024-01-22 17-27-33](https://github.com/kausaltech/kausal-watch-ui/assets/659611/438edb6e-79b5-4773-ab99-353acd0fdf28)


0. Refactor the phase donut implementation.

1. Don't count "inactive" actions as "no phase set"

2. Try to display in a clearer way that the percentage in the status donut does take into account the actions without any status set (not counted towards 100%, a question mark is displayed for that sector.) So the 73% in the example means that of all actions with a status set, 73% are not late or otherwise. Still, of all the actions, 1/4 doesn't have a status set at all.