### PR TITLE
Support full width embed blocks

### DIFF
--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -889,6 +889,7 @@ export type AdaptiveEmbedBlock = StreamFieldInterface & {
   blocks: Array<StreamFieldInterface>;
   embed?: Maybe<EmbedHtmlValue>;
   field: Scalars['String'];
+  fullWidth?: Maybe<Scalars['Boolean']>;
   id?: Maybe<Scalars['String']>;
   rawValue: Scalars['String'];
 };
@@ -7585,7 +7586,7 @@ type StreamFieldFragment_ActionListBlock_Fragment = (
 );
 
 type StreamFieldFragment_AdaptiveEmbedBlock_Fragment = (
-  { id?: string | null, blockType: string, field: string, embed?: (
+  { fullWidth?: boolean | null, id?: string | null, blockType: string, field: string, embed?: (
     { html?: string | null }
     & { __typename?: 'EmbedHTMLValue' }
   ) | null }
@@ -9942,7 +9943,7 @@ export type GetPlanPageGeneralQuery = (
       ) | null }
       & { __typename?: 'ActionListBlock' }
     ) | (
-      { id?: string | null, blockType: string, field: string, embed?: (
+      { fullWidth?: boolean | null, id?: string | null, blockType: string, field: string, embed?: (
         { html?: string | null }
         & { __typename?: 'EmbedHTMLValue' }
       ) | null }
@@ -10614,7 +10615,7 @@ export type GetPlanPageGeneralQuery = (
       ) | null }
       & { __typename?: 'ActionListBlock' }
     ) | (
-      { id?: string | null, blockType: string, field: string, embed?: (
+      { fullWidth?: boolean | null, id?: string | null, blockType: string, field: string, embed?: (
         { html?: string | null }
         & { __typename?: 'EmbedHTMLValue' }
       ) | null }
@@ -10992,7 +10993,7 @@ export type GetPlanPageGeneralQuery = (
       ) | null }
       & { __typename?: 'ActionListBlock' }
     ) | (
-      { id?: string | null, blockType: string, field: string, embed?: (
+      { fullWidth?: boolean | null, id?: string | null, blockType: string, field: string, embed?: (
         { html?: string | null }
         & { __typename?: 'EmbedHTMLValue' }
       ) | null }
@@ -11496,7 +11497,7 @@ export type GetHomePageQuery = (
       ) | null }
       & { __typename?: 'ActionListBlock' }
     ) | (
-      { id?: string | null, blockType: string, field: string, embed?: (
+      { fullWidth?: boolean | null, id?: string | null, blockType: string, field: string, embed?: (
         { html?: string | null }
         & { __typename?: 'EmbedHTMLValue' }
       ) | null }

--- a/components/common/StreamField.tsx
+++ b/components/common/StreamField.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import { Container, Row, Col, ColProps } from 'reactstrap';
 import { gql } from '@apollo/client';
+import { ColumnProps } from 'reactstrap/types/lib/Col';
 import PlanContext from 'context/plan';
 import images, { getBgImageAlignment } from 'common/images';
 import RichText from 'components/common/RichText';
@@ -100,6 +101,7 @@ const STREAM_FIELD_FRAGMENT = gql`
       }
     }
     ... on AdaptiveEmbedBlock {
+      fullWidth
       embed {
         html
       }
@@ -575,19 +577,33 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
       return <CategoryTreeBlock {...block} id={id} hasSidebar={hasSidebar} />;
     }
     case 'AdaptiveEmbedBlock': {
+      const fullWidth = block.fullWidth || false;
+      const html = block.embed?.html;
+
+      function getColSize(defaultSize: ColumnProps): ColumnProps {
+        if (fullWidth) {
+          return hasSidebar ? { size: 11, offset: 1 } : { size: 12, offset: 0 };
+        }
+
+        return defaultSize;
+      }
+
       return (
         <Container id={id}>
           <Row>
             <Col
-              xl={{ size: hasSidebar ? 7 : 6, offset: hasSidebar ? 4 : 3 }}
-              lg={{ size: 8, offset: hasSidebar ? 4 : 2 }}
-              md={{ size: 10, offset: 1 }}
+              xl={getColSize({
+                size: hasSidebar ? 7 : 6,
+                offset: hasSidebar ? 4 : 3,
+              })}
+              lg={getColSize({ size: 8, offset: hasSidebar ? 4 : 2 })}
+              md={getColSize({ size: 10, offset: 1 })}
               className="my-4"
               {...columnProps}
             >
-              <ResponsiveStyles
-                dangerouslySetInnerHTML={{ __html: block.embed.html }}
-              ></ResponsiveStyles>
+              {!!html && (
+                <ResponsiveStyles dangerouslySetInnerHTML={{ __html: html }} />
+              )}
             </Col>
           </Row>
         </Container>


### PR DESCRIPTION
Depends on backend PR https://github.com/kausaltech/kausal-watch-private/pull/115

## Example

The first embed has "Full width" selected, the second doesn't

<img width="1001" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/6bb06796-dccb-4e44-850b-5720d549c7ce">
