### PR TITLE
Add support for custom action date formats

### DIFF
--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -155,6 +155,7 @@ export type AccessibilityStatementPreparationInformationBlock = StreamFieldInter
 /** One action/measure tracked in an action plan. */
 export type Action = {
   __typename?: 'Action';
+  actionDateFormat?: Maybe<DateFormatOptions>;
   adminButtons: Array<AdminButton>;
   attributes: Array<AttributeInterface>;
   categories: Array<Category>;
@@ -162,6 +163,8 @@ export type Action = {
   /** The completion percentage for this action */
   completion?: Maybe<Scalars['Int']>;
   contactPersons: Array<ActionContactPerson>;
+  /** Format of action start and end dates shown in the public UI.             The default for all actions can be specified on the actions page. */
+  dateFormat?: Maybe<ActionDateFormat>;
   /** What does this action involve in more detail? */
   description?: Maybe<Scalars['String']>;
   editUrl?: Maybe<Scalars['String']>;
@@ -209,6 +212,7 @@ export type Action = {
   supersededActions: Array<Action>;
   /** Set if this action is superseded by another action */
   supersededBy?: Maybe<Action>;
+  taskDateFormat?: Maybe<DateFormatOptions>;
   tasks: Array<ActionTask>;
   timeliness: ActionTimeliness;
   updatedAt: Scalars['DateTime'];
@@ -370,6 +374,15 @@ export type ActionContentSectionBlock = StreamFieldInterface & {
 
 export type ActionDashboardColumnBlock = IdentifierColumnBlock | ImpactColumnBlock | ImplementationPhaseColumnBlock | IndicatorsColumnBlock | NameColumnBlock | OrganizationColumnBlock | ResponsiblePartiesColumnBlock | StatusColumnBlock | TasksColumnBlock | UpdatedAtColumnBlock;
 
+export enum ActionDateFormat {
+  /** Day, month and year (31.12.2020) */
+  Full = 'FULL',
+  /** Month and year (12.2020) */
+  MonthYear = 'MONTH_YEAR',
+  /** Year (2020) */
+  Year = 'YEAR'
+}
+
 export type ActionDescriptionBlock = StreamFieldInterface & {
   __typename?: 'ActionDescriptionBlock';
   blockType: Scalars['String'];
@@ -493,6 +506,7 @@ export type ActionListFilterBlock = ActionAttributeTypeFilterBlock | ActionImple
 
 export type ActionListPage = PageInterface & {
   __typename?: 'ActionListPage';
+  actionDateFormat?: Maybe<Scalars['String']>;
   advancedFilters?: Maybe<Array<ActionListFilterBlock>>;
   aliasOf?: Maybe<Page>;
   ancestors: Array<PageInterface>;
@@ -538,6 +552,7 @@ export type ActionListPage = PageInterface & {
   showInMenus: Scalars['Boolean'];
   siblings: Array<PageInterface>;
   slug: Scalars['String'];
+  taskDateFormat?: Maybe<Scalars['String']>;
   title: Scalars['String'];
   translationKey: Scalars['UUID'];
   url?: Maybe<Scalars['String']>;
@@ -822,6 +837,8 @@ export type ActionTask = {
   /** The date when the task was completed */
   completedAt?: Maybe<Scalars['Date']>;
   createdAt: Scalars['DateTime'];
+  /** Format of action task due dates shown in the public UI.             The default for all actions can be specified on the actions page. */
+  dateFormat?: Maybe<ActionTaskDateFormat>;
   /** The date by which the task should be completed (deadline) */
   dueAt: Scalars['Date'];
   i18n?: Maybe<Scalars['JSONString']>;
@@ -844,6 +861,15 @@ export type ActionTask = {
   nameSv: Scalars['String'];
   state: ActionTaskState;
 };
+
+export enum ActionTaskDateFormat {
+  /** Day, month and year (31.12.2020) */
+  Full = 'FULL',
+  /** Month and year (12.2020) */
+  MonthYear = 'MONTH_YEAR',
+  /** Year (2020) */
+  Year = 'YEAR'
+}
 
 export enum ActionTaskState {
   /** cancelled */
@@ -1688,6 +1714,12 @@ export type DateBlock = StreamFieldInterface & {
 export type DateBlockValueArgs = {
   format?: InputMaybe<Scalars['String']>;
 };
+
+export enum DateFormatOptions {
+  Full = 'FULL',
+  MonthYear = 'MONTH_YEAR',
+  Year = 'YEAR'
+}
 
 export type DateTimeBlock = StreamFieldInterface & {
   __typename?: 'DateTimeBlock';
@@ -6710,7 +6742,7 @@ export type GetActionDetailsQueryVariables = Exact<{
 
 export type GetActionDetailsQuery = (
   { action?: (
-    { id: string, identifier: string, name: string, officialName?: string | null, leadParagraph: string, description?: string | null, completion?: number | null, color?: string | null, updatedAt: any, manualStatusReason?: string | null, scheduleContinuous: boolean, startDate?: any | null, endDate?: any | null, image?: (
+    { id: string, identifier: string, name: string, officialName?: string | null, leadParagraph: string, description?: string | null, completion?: number | null, color?: string | null, updatedAt: any, manualStatusReason?: string | null, scheduleContinuous: boolean, startDate?: any | null, endDate?: any | null, dateFormat?: ActionDateFormat | null, image?: (
       { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX?: number | null, focalPointY?: number | null, full?: (
         { id: string, width: number, height: number, src: string }
         & { __typename?: 'ImageRendition' }
@@ -6912,7 +6944,7 @@ export type GetActionDetailsQuery = (
       ) }
       & { __typename?: 'ActionResponsibleParty' }
     )>, tasks: Array<(
-      { id: string, name: string, dueAt: any, completedAt?: any | null, comment?: string | null, state: ActionTaskState }
+      { id: string, name: string, dueAt: any, dateFormat?: ActionTaskDateFormat | null, completedAt?: any | null, comment?: string | null, state: ActionTaskState }
       & { __typename?: 'ActionTask' }
     )>, status?: (
       { id: string, identifier: string, name: string, color?: string | null }
@@ -7281,7 +7313,7 @@ export type GetActionDetailsQuery = (
     & { __typename?: 'Action' }
   ) | null, plan?: (
     { actionListPage?: (
-      { detailsMainTop?: Array<(
+      { actionDateFormat?: string | null, taskDateFormat?: string | null, detailsMainTop?: Array<(
         { id?: string | null }
         & { __typename: 'ActionContactFormBlock' | 'ActionDescriptionBlock' | 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionMergedActionsBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionTasksBlock' }
       ) | (
@@ -11645,7 +11677,7 @@ export type GetPlanContextQuery = (
       ) | null> }
       & { __typename?: 'AdditionalLinks' }
     ) | null, actionListPage?: (
-      { includeRelatedPlans?: boolean | null }
+      { includeRelatedPlans?: boolean | null, actionDateFormat?: string | null, taskDateFormat?: string | null }
       & { __typename?: 'ActionListPage' }
     ) | null }
     & { __typename?: 'Plan' }
@@ -11829,7 +11861,7 @@ export type PlanContextFragment = (
     ) | null> }
     & { __typename?: 'AdditionalLinks' }
   ) | null, actionListPage?: (
-    { includeRelatedPlans?: boolean | null }
+    { includeRelatedPlans?: boolean | null, actionDateFormat?: string | null, taskDateFormat?: string | null }
     & { __typename?: 'ActionListPage' }
   ) | null }
   & { __typename?: 'Plan' }

--- a/components/actions/TaskList.js
+++ b/components/actions/TaskList.js
@@ -11,9 +11,11 @@ import { useTheme } from 'styled-components';
 import dayjs from 'common/dayjs';
 import Icon from 'components/common/Icon';
 import RichText from 'components/common/RichText';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
+import { usePlan } from 'context/plan';
+import { getDateFormat } from 'utils/dates.utils';
 
-const Date = styled.span`
+const StyledDate = styled.span`
   font-size: ${(props) => props.theme.fontSizeSm};
   font-family: ${(props) => props.theme.fontFamilyTiny};
   margin-left: ${(props) => props.theme.spaces.s025};
@@ -118,9 +120,17 @@ function parseTimestamp(timestamp) {
 
 const Task = (props) => {
   const t = useTranslations();
+  const locale = useLocale();
   const { task, theme, completed } = props;
   const [isOpen, setIsOpen] = useState(false);
   const toggle = () => setIsOpen(!isOpen);
+  const plan = usePlan();
+
+  const dateFormat = task.dateFormat || plan.actionListPage.taskDateFormat;
+  const formattedDueAt = new Date(task.dueAt).toLocaleDateString(
+    locale,
+    getDateFormat(dateFormat)
+  );
 
   return (
     <TaskWrapper>
@@ -131,7 +141,7 @@ const Task = (props) => {
             color={theme.graphColors.green050}
             alt={t('action-task-done')}
           />
-          <Date>{parseTimestamp(task.completedAt)}</Date>
+          <StyledDate>{parseTimestamp(task.completedAt)}</StyledDate>
         </TaskMeta>
       ) : (
         <TaskMeta>
@@ -140,7 +150,7 @@ const Task = (props) => {
             color={theme.graphColors.blue070}
             alt={t('action-task-todo')}
           />
-          <Date>{parseTimestamp(task.dueAt)}</Date>
+          <StyledDate>{formattedDueAt}</StyledDate>
         </TaskMeta>
       )}
       <TaskContent>

--- a/components/actions/blocks/ActionScheduleBlock.tsx
+++ b/components/actions/blocks/ActionScheduleBlock.tsx
@@ -3,15 +3,28 @@ import styled from 'styled-components';
 import { ActionSection } from 'components/actions/ActionContent';
 import Timeline from 'components/graphs/Timeline';
 import ScheduleTimeline from 'components/graphs/ScheduleTimeline';
+import {
+  ActionDateFormat,
+  GetActionDetailsQuery,
+  PlanContextFragment,
+} from 'common/__generated__/graphql';
+import { getDateFormat } from 'utils/dates.utils';
 import { useTranslations } from 'next-intl';
 
 const SideHeader = styled.h3`
   font-size: ${(props) => props.theme.fontSizeBase};
 `;
 
-const ActionScheduleBlock = (props) => {
-  const { action, plan } = props;
+type Props = {
+  action: NonNullable<GetActionDetailsQuery['action']>;
+  plan: PlanContextFragment;
+};
+
+const ActionScheduleBlock = ({ action, plan }: Props) => {
   const t = useTranslations();
+
+  const dateFormat =
+    action.dateFormat || plan.actionListPage?.actionDateFormat || undefined;
 
   return (
     <>
@@ -28,6 +41,9 @@ const ActionScheduleBlock = (props) => {
         <ActionSection>
           <SideHeader>{t('action-timeline')}</SideHeader>
           <Timeline
+            formatOptions={getDateFormat(
+              dateFormat as ActionDateFormat | undefined
+            )}
             startDate={action.startDate}
             endDate={action.endDate}
             continuous={action.scheduleContinuous}

--- a/queries/get-action.ts
+++ b/queries/get-action.ts
@@ -118,6 +118,7 @@ export const GET_ACTION_DETAILS = gql`
         id
         name
         dueAt
+        dateFormat
         completedAt
         comment
         state
@@ -143,6 +144,7 @@ export const GET_ACTION_DETAILS = gql`
       scheduleContinuous
       startDate
       endDate
+      dateFormat
       impact {
         id
         identifier
@@ -219,6 +221,8 @@ export const GET_ACTION_DETAILS = gql`
     }
     plan(id: $plan) {
       actionListPage {
+        actionDateFormat
+        taskDateFormat
         detailsMainTop {
           ...ActionMainContentBlocksFragment
         }

--- a/queries/get-plan.ts
+++ b/queries/get-plan.ts
@@ -270,6 +270,8 @@ const GET_PLAN_CONTEXT = gql`
     }
     actionListPage {
       includeRelatedPlans
+      actionDateFormat
+      taskDateFormat
     }
   }
   ${images.fragments.multiUseImage}

--- a/utils/dates.utils.ts
+++ b/utils/dates.utils.ts
@@ -1,0 +1,15 @@
+import { ActionDateFormat } from 'common/__generated__/graphql';
+
+export function getDateFormat(
+  format?: ActionDateFormat
+): Intl.DateTimeFormatOptions {
+  switch (format) {
+    case 'YEAR':
+      return { year: 'numeric' };
+    case 'MONTH_YEAR':
+      return { month: 'numeric', year: 'numeric' };
+    case 'FULL':
+    default:
+      return { day: 'numeric', month: 'numeric', year: 'numeric' };
+  }
+}


### PR DESCRIPTION
Related backend PR: https://github.com/kausaltech/kausal-watch-private/pull/118

Allows users to customise the date format of:
- Action start and end dates (both globally under `actionListPage.actionDateFormat` and per action under `action.dateFormat`)
- Action task due dates (both globally under `actionListPage.taskDateFormat` and per action under `task.dateFormat`)

Users can choose to display the full date, month and year, or just the year.


### Example start date formatted as `MONTH_YEAR`

<img width="340" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/9fdd5c3f-0636-4412-a36f-9d081cdc4c1a">


### Example single task due date formatted as `YEAR`

<img width="658" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/7577d7b6-773b-45cf-a745-770276879b7a">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205726733412166
  - https://app.asana.com/0/0/1206004551588327