### PR TITLE
Fix actions page with invalid filters

### DIFF
--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -343,6 +343,14 @@ type ActionListFilterBadgesProps = {
   onReset: (id: string, value: SingleFilterValue) => void;
 };
 
+type Badge = {
+  key: string;
+  id: string;
+  value: SingleFilterValue;
+  label: string;
+  onReset: () => void;
+};
+
 function ActionListFilterBadges({
   plan,
   allFilters,
@@ -355,7 +363,10 @@ function ActionListFilterBadges({
 
   const enabled = allFilters.filter((item) => activeFilters[item.id]);
 
-  const createBadge = (item: ActionListFilter, value: SingleFilterValue) => {
+  function createBadge(
+    item: ActionListFilter,
+    value: SingleFilterValue
+  ): Badge | null {
     let label: string;
     if (item.id === 'name') {
       label = value ?? '';
@@ -369,6 +380,11 @@ function ActionListFilterBadges({
         ) as ActionListFilterOption;
         if (activeOption !== undefined) break;
       }
+
+      if (!activeOption) {
+        return null;
+      }
+
       label = activeOption.label;
     } else {
       return null;
@@ -382,7 +398,8 @@ function ActionListFilterBadges({
         onReset(item.id, value);
       },
     };
-  };
+  }
+
   const seenFilterKeyValues = new Set();
   const badgesToCreate = enabled.filter((item: ActionListFilter) => {
     const uniqueKey = `${item.id}-${activeFilters[item.id]}`;
@@ -398,7 +415,7 @@ function ActionListFilterBadges({
       );
     })
     .flat()
-    .filter((item) => item != null);
+    .filter((item): item is Badge => item != null);
 
   return (
     <FiltersList aria-live="assertive">


### PR DESCRIPTION
Fixes a bug where visiting the actions page with an unknown filter value in the search params crashes the entire page. 

| Before | After |
| --- | --- |
| <img width="1057" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/9a2942f1-9fda-4731-8e1e-82f6be6dbe8e"> | <img width="1058" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/b12caece-bdaf-41bf-b0bd-edce018faf36"> |

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206475155503892