### PR TITLE
Improve partner logo placement and sizing

### DIFF
--- a/components/common/SiteFooter.tsx
+++ b/components/common/SiteFooter.tsx
@@ -328,20 +328,14 @@ const FooterStatement = styled.div`
   }
 `;
 
-const FundingInstruments = styled.div`
+const FundingInstruments = styled.div<{ $wrap?: boolean }>`
   width: 100%;
   flex: 1 0 auto;
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: ${(props) => (props.$wrap ? 'center' : 'flex-end')};
   padding: 0;
   margin-bottom: ${(props) => props.theme.spaces.s200};
-
-  @media (max-width: ${(props) => props.theme.breakpointMd}) {
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-  }
 `;
 
 const FundingHeader = styled.div`
@@ -353,16 +347,11 @@ const FundingHeader = styled.div`
   }
 `;
 
-const FundingInstrumentContainer = styled.div`
-  height: calc(2 * ${(props) => props.theme.spaces.s600});
-  width: calc(2 * ${(props) => props.theme.spaces.s800});
+const FundingInstrumentContainer = styled.div<{ $small?: boolean }>`
+  height: ${(props) => (props.$small ? '10rem' : '12rem')};
+  width: ${(props) => (props.$small ? '10rem' : '12rem')};
   margin-left: ${(props) => props.theme.spaces.s300};
   text-align: right;
-
-  &.small {
-    height: calc(2 * ${(props) => props.theme.spaces.s400});
-    width: calc(2 * ${(props) => props.theme.spaces.s400});
-  }
 
   svg {
     height: 100%;
@@ -642,12 +631,13 @@ function SiteFooter(props: SiteFooterProps) {
                 ))}
               </FundingInstruments>
             )}
+            {/* If we have more than 4 otherLogos render them smaller  */}
             {otherLogos?.length > 0 && (
-              <FundingInstruments>
+              <FundingInstruments $wrap={otherLogos.length > 4}>
                 {otherLogos.map((logo) => (
                   <FundingInstrumentContainer
                     key={logo.id}
-                    className={otherLogos.length > 3 ? 'small' : ''}
+                    $small={otherLogos.length > 4}
                   >
                     <a
                       href={logo.link ? logo.link : '#'}

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
   ],
   "packageManager": "yarn@3.2.1",
   "optionalDependencies": {
-    "@kausal/themes-private": "^0.4.0"
+    "@kausal/themes-private": "^0.4.1"
   },
   "lint-staged": {
     "*.{tsx,ts,js,css,scss,md,json}": "prettier --write"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3454,10 +3454,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kausal/themes-private@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "@kausal/themes-private@npm:0.4.0"
-  checksum: 7ddfd4f9690601ab8688dbc00aa163aae20f26b8ee191691b3cf184f2c63f69aabaa25450a63784dde8b48b65a28b77752c5f76e31064a7653042552b271ab57
+"@kausal/themes-private@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@kausal/themes-private@npm:0.4.1"
+  checksum: dc59fddc3d78263abef0943cdff7ea3346ca88fa4a0343e5d87778b24aa25243131bb97f798efd1fa5b5711aada47c6820df0ca8b2b3801f7a01ce87b5d17372
   languageName: node
   linkType: hard
 
@@ -17207,7 +17207,7 @@ __metadata:
     "@kausal/mapboxgl-legend": ^1.7.2
     "@kausal/plotly-custom": ^2.14.3
     "@kausal/themes": ^0.7.9
-    "@kausal/themes-private": ^0.4.0
+    "@kausal/themes-private": ^0.4.1
     "@n8tb1t/use-scroll-position": ^2.0.3
     "@next/bundle-analyzer": ^12.1.6
     "@playwright/test": ^1.39.0


### PR DESCRIPTION
Center partner logos (otherLogos) and render them smaller in footer if there are more than 4
<img width="1159" alt="Screenshot 2024-02-02 at 9 22 32" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/4401cfae-1c18-4d97-9a16-738051661e81">

And larger and right-aligned if there are less
<img width="1141" alt="Screenshot 2024-02-02 at 9 22 49" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/4d0e2c8e-50ab-44d0-a677-f973804fc960">

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206383173050598