### PR TITLE
Revert "Migrate Sentry DSN to env variable"

### DIFF
--- a/common/environment.ts
+++ b/common/environment.ts
@@ -17,6 +17,3 @@ export const apiUrl =
   process.env.NEXT_PUBLIC_API_URL || 'https://api.watch.kausal.tech/v1';
 
 export const gqlUrl = `${apiUrl}/graphql/`;
-
-export const sentryDsn =
-  process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;

--- a/next.config.js
+++ b/next.config.js
@@ -12,8 +12,6 @@ if (process.env.DOTENV_CONFIG_PATH) {
   require('dotenv').config({ path: process.env.DOTENV_CONFIG_PATH });
 }
 
-const sentryDsn = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN;
-
 const sentryAuthToken =
   secrets.SENTRY_AUTH_TOKEN || process.env.SENTRY_AUTH_TOKEN;
 
@@ -91,14 +89,8 @@ let config = {
 
 module.exports = withNextIntl(config);
 
-console.log(' >>>> sentryDsn', sentryDsn);
-
-if (sentryAuthToken && sentryDsn) {
+if (sentryAuthToken) {
   const { withSentryConfig } = require('@sentry/nextjs');
-
-  console.log(`
-      ↝ Initialising Sentry
-  `);
 
   // Injected content via Sentry wizard below
   module.exports = withSentryConfig(

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,12 +3,12 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
-import { deploymentType, sentryDsn } from './common/environment';
+import { deploymentType } from './common/environment';
 
 Sentry.init({
   environment: deploymentType,
 
-  dsn: sentryDsn,
+  dsn: 'https://9b7a344624774da8a5aa5752baad826b@sentry.kausal.tech/2',
 
   ignoreErrors: ['NEXT_NOT_FOUND'],
 
@@ -27,9 +27,8 @@ Sentry.init({
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [
     new Sentry.Replay({
-      maskAllInputs: false,
-      maskAllText: false,
-      blockAllMedia: false,
+      // Additional Replay configuration goes in here, for example:
+      blockAllMedia: true,
     }),
   ],
 });

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -4,12 +4,12 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
-import { deploymentType, sentryDsn } from './common/environment';
+import { deploymentType } from './common/environment';
 
 Sentry.init({
   environment: deploymentType,
 
-  dsn: sentryDsn,
+  dsn: 'https://9b7a344624774da8a5aa5752baad826b@sentry.kausal.tech/2',
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -3,12 +3,12 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
-import { deploymentType, sentryDsn } from './common/environment';
+import { deploymentType } from './common/environment';
 
 Sentry.init({
   environment: deploymentType,
 
-  dsn: sentryDsn,
+  dsn: 'https://9b7a344624774da8a5aa5752baad826b@sentry.kausal.tech/2',
 
   ignoreErrors: ['NEXT_NOT_FOUND'],
 


### PR DESCRIPTION
The reverted commit was to test using a runtime environment variable in the Sentry config with the new Next.js setup. It doesn't work and seems like we'll need to convert the Sentry DSN env variable to a build-time variable, reverting this until then.

Reverts kausaltech/kausal-watch-ui#276