### PR TITLE
Fix actions with special characters in their ID

### DIFF
--- a/app/[domain]/[lang]/[plan]/(with-layout-elements)/actions/[id]/page.tsx
+++ b/app/[domain]/[lang]/[plan]/(with-layout-elements)/actions/[id]/page.tsx
@@ -27,11 +27,12 @@ export async function generateMetadata(
   const t = await getTranslations({ locale: params.lang });
 
   const { id, plan, domain } = params;
+  const decodedId = decodeURIComponent(id);
   const headersList = headers();
   const protocol = headersList.get('x-forwarded-proto');
 
   const { data } = await tryRequest(
-    getActionDetails(plan, id, `${protocol}://${domain}`)
+    getActionDetails(plan, decodedId, `${protocol}://${domain}`)
   );
 
   if (!data?.action) {
@@ -66,9 +67,10 @@ export default async function ActionPage({ params }: Props) {
   const { id, plan, domain } = params;
   const headersList = headers();
   const protocol = headersList.get('x-forwarded-proto');
+  const decodedId = decodeURIComponent(id);
 
   const { data, error } = await tryRequest(
-    getActionDetails(plan, id, `${protocol}://${domain}`)
+    getActionDetails(plan, decodedId, `${protocol}://${domain}`)
   );
 
   if (error || !data?.action || !data.plan) {

--- a/app/[domain]/[lang]/[plan]/embed/v1/[...slug]/page.tsx
+++ b/app/[domain]/[lang]/[plan]/embed/v1/[...slug]/page.tsx
@@ -77,7 +77,7 @@ type Props = {
 };
 
 const EmbeddablePage = ({ params }: Props) => {
-  const { slug } = params;
+  const slug = params.slug.map(decodeURIComponent);
   const wrapperElement = useRef<HTMLDivElement>(null);
   const query = useSearchParams();
   const queryEmbId = query.get('embId');


### PR DESCRIPTION
The action ID is encoded by Next, which then led to the action not being found when querying GQL. Decode:
- Action IDs
- Embed slugs