### PR TITLE
Fix Sentry errors and update config

### DIFF
--- a/app/[domain]/[lang]/[plan]/(with-layout-elements)/actions/page.tsx
+++ b/app/[domain]/[lang]/[plan]/(with-layout-elements)/actions/page.tsx
@@ -19,7 +19,7 @@ export default async function ActionsPage({ params }: Props) {
   const { data } = await tryRequest(
     getActionsListPage(
       plan,
-      pageSettingsData.plan?.actionListPage?.includeRelatedPlans ?? false
+      pageSettingsData?.plan?.actionListPage?.includeRelatedPlans ?? false
     )
   );
 

--- a/app/[domain]/[lang]/[plan]/(with-layout-elements)/indicators/[id]/page.tsx
+++ b/app/[domain]/[lang]/[plan]/(with-layout-elements)/indicators/[id]/page.tsx
@@ -54,7 +54,9 @@ export default async function IndicatorPage({ params }: Props) {
   const { data, error } = await tryRequest(getIndicatorDetails(plan, id));
 
   if (error || !data?.indicator) {
-    captureException(error, { extra: { id, plan, domain } });
+    if (error) {
+      captureException(error, { extra: { id, plan, domain } });
+    }
 
     return notFound();
   }

--- a/components/actions/ActionCard.tsx
+++ b/components/actions/ActionCard.tsx
@@ -14,6 +14,7 @@ import PlanChip from 'components/plans/PlanChip';
 import { ActionCardFragment } from 'common/__generated__/graphql';
 import { useTranslations } from 'next-intl';
 import { ACTION_CARD_FRAGMENT } from '@/fragments/action-card.fragment';
+import { captureException } from '@sentry/nextjs';
 
 const StyledActionLink = styled.a`
   text-decoration: none;
@@ -201,6 +202,18 @@ function ActionCard(props: ActionCardProps) {
   const plan = usePlan();
   const t = useTranslations();
   const theme = useTheme();
+
+  if (!action || !action.name) {
+    /**
+     * action should always be defined but reading action.name.length has been
+     * throwing errors in Sentry. Check for an action to avoid uncaught errors.
+     */
+    captureException('Required prop `action` missing from ActionCard', {
+      extra: { action, plan: plan.identifier },
+    });
+
+    return null;
+  }
 
   let actionName = action.name;
 

--- a/components/indicators/IndicatorVisualisation.js
+++ b/components/indicators/IndicatorVisualisation.js
@@ -336,10 +336,10 @@ const generateGoalTraces = (indicator, planScenarios, i18n) => {
     if (!traceScenarios.has(scenarioId)) {
       const scenario = {
         goals: [],
-        config: planScenarios.find((sc) => sc.id === scenarioId),
+        config: planScenarios?.find((sc) => sc.id === scenarioId) ?? {},
       };
 
-      if (scenarioId) {
+      if (scenarioId && scenario.config?.name) {
         scenario.name = scenario.config.name;
       } else {
         scenario.name = i18n.t('goal');

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -3,7 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs';
-import { deploymentType } from './common/environment';
+import { deploymentType, gqlUrl } from './common/environment';
 
 Sentry.init({
   environment: deploymentType,
@@ -30,7 +30,7 @@ Sentry.init({
       maskAllText: false,
       // Additional Replay configuration goes in here, for example:
       blockAllMedia: false,
-      networkDetailAllowUrls: ['https://api.watch.kausal.tech/v1/graphql/'],
+      networkDetailAllowUrls: [gqlUrl],
     }),
   ],
 });

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -27,8 +27,10 @@ Sentry.init({
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [
     new Sentry.Replay({
+      maskAllText: false,
       // Additional Replay configuration goes in here, for example:
-      blockAllMedia: true,
+      blockAllMedia: false,
+      networkDetailAllowUrls: ['https://api.watch.kausal.tech/v1/graphql/'],
     }),
   ],
 });


### PR DESCRIPTION
1. Only report `inidicator/[id]` errors to Sentry if there's an error in the GraphQL response. This prevents unnecessary error logs for indicator 404s – [Sentry Error](https://sentry.kausal.tech/organizations/kausal/issues/4538/)
2. Fix error when `planScenarios` is undefined –  [Sentry Error](https://sentry.kausal.tech/organizations/kausal/issues/4537/events/bc175d1127e4461d9f5b019685be5178/)