### PR TITLE
Add missing cache headers

### DIFF
--- a/app/[domain]/[lang]/[plan]/UpdateApolloContext.tsx
+++ b/app/[domain]/[lang]/[plan]/UpdateApolloContext.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { PropsWithChildren } from 'react';
+import { useApolloClient } from '@apollo/client';
+import { usePlan } from '@/context/plan';
+
+type Props = { domain: string } & PropsWithChildren;
+
+/**
+ * Ensure Apollo context is up to date with the current plan to
+ * allow necessary headers to be set in Apollo links.
+ */
+export function UpdateApolloContext({ children, domain }: Props) {
+  const apolloClient = useApolloClient();
+  const plan = usePlan();
+
+  apolloClient.defaultContext.planIdentifier = plan.identifier;
+  apolloClient.defaultContext.planDomain = domain;
+
+  return children;
+}

--- a/app/[domain]/[lang]/[plan]/layout.tsx
+++ b/app/[domain]/[lang]/[plan]/layout.tsx
@@ -13,6 +13,7 @@ import { CombinedIconSymbols } from '@/components/common/Icon';
 import { MatomoAnalytics } from '@/components/MatomoAnalytics';
 import { getMetaTitles } from '@/utils/metadata';
 import { tryRequest } from '@/utils/api.utils';
+import { UpdateApolloContext } from './UpdateApolloContext';
 
 type Props = {
   params: { plan: string; domain: string; lang: string };
@@ -111,6 +112,7 @@ export default async function PlanLayout({ params, children }: Props) {
       <ThemeProvider theme={theme}>
         <GlobalStyles />
         <PlanProvider plan={data.plan}>
+          <UpdateApolloContext domain={domain} />
           <CombinedIconSymbols />
           {children}
         </PlanProvider>

--- a/components/providers/ApolloWrapper.tsx
+++ b/components/providers/ApolloWrapper.tsx
@@ -13,6 +13,7 @@ import {
   errorLink,
   localeMiddleware,
   httpLink,
+  headersMiddleware,
 } from '../../utils/apollo.utils';
 import { isServer } from '@/common/environment';
 
@@ -25,6 +26,7 @@ function makeClient(initialLocale: string) {
     link: ApolloLink.from([
       errorLink,
       localeMiddleware,
+      headersMiddleware,
       ...(isServer
         ? [
             new SSRMultipartLink({

--- a/middleware.ts
+++ b/middleware.ts
@@ -146,7 +146,13 @@ export async function middleware(request: NextRequest) {
       request.url
     );
 
-    return rewriteUrl(request, response, hostUrl, rewrittenUrl);
+    return rewriteUrl(
+      request,
+      response,
+      hostUrl,
+      rewrittenUrl,
+      parsedPlan.identifier
+    );
   }
 
   const searchParams = getSearchParamsString(request);
@@ -156,5 +162,11 @@ export async function middleware(request: NextRequest) {
     request.url
   );
 
-  return rewriteUrl(request, response, hostUrl, rewrittenUrl);
+  return rewriteUrl(
+    request,
+    response,
+    hostUrl,
+    rewrittenUrl,
+    parsedPlan.identifier
+  );
 }

--- a/utils/apollo-rsc-client.ts
+++ b/utils/apollo-rsc-client.ts
@@ -9,6 +9,7 @@ import {
   httpLink,
   operationEnd,
   operationStart,
+  headersMiddleware,
 } from './apollo.utils';
 
 /**
@@ -18,10 +19,14 @@ import {
 export const { getClient } = registerApolloClient(() => {
   const headers = getHeaders();
   const locale = headers.get('x-next-intl-locale') ?? undefined;
+  const plan = headers.get('x-plan-identifier') ?? undefined;
+  const domain = headers.get('x-plan-domain') ?? undefined;
 
   return new ApolloClient({
     defaultContext: {
       locale,
+      planDomain: domain,
+      planIdentifier: plan,
     },
     connectToDevTools: false,
     cache: new InMemoryCache({
@@ -32,6 +37,7 @@ export const { getClient } = registerApolloClient(() => {
       operationStart,
       errorLink,
       localeMiddleware,
+      headersMiddleware,
       operationEnd,
       httpLink,
     ]),

--- a/utils/middleware.utils.ts
+++ b/utils/middleware.utils.ts
@@ -187,13 +187,21 @@ export function rewriteUrl(
   request: NextRequest,
   response: NextResponse,
   hostUrl: URL,
-  rewrittenUrl: URL
+  rewrittenUrl: URL,
+  plan: string
 ) {
   // The user facing URL, provided via the x-url header to be used in metadata
   const url = new URL(request.nextUrl.pathname, hostUrl).toString();
 
   response.headers.set('x-url', url);
   response.headers.set('x-middleware-rewrite', rewrittenUrl.toString());
+
+  /**
+   * Support reading plan details from headers while creating the RSC Apollo client. This
+   * allows us to add cache headers to GraphQL requests from RSC queries.
+   */
+  response.headers.set('x-plan-domain', hostUrl.hostname);
+  response.headers.set('x-plan-identifier', plan);
 
   return response;
 }


### PR DESCRIPTION
The `x-cache-plan-domain` and `x-cache-plan-identifier` headers were missing from GQL queries post Next.js upgrade. 

- To support setting cache headers from the RSC Apollo client, headers are set in middleware, read upon Apollo client initialisation and set as initial context
- To support setting cache headers from the client-side Apollo client, Apollo context is updated while rendering the plan page
- `headersMiddleware` reads the domain and plan ID from Apollo context and sets the query headers