### PR TITLE
Use Next.js' default browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,10 +134,6 @@
   "engines": {
     "node": "20.x"
   },
-  "browserslist": [
-    "> 1%",
-    "last 4 versions"
-  ],
   "packageManager": "yarn@3.2.1",
   "optionalDependencies": {
     "@kausal/themes-private": "^0.4.2"


### PR DESCRIPTION
Use Next.js default browser support rather than our quite restrictive config, no major changes to the final bundle size.

> Next.js supports modern browsers with zero configuration.
> 
> - Chrome 64+
> - Edge 79+
> - Firefox 67+
> - Opera 51+
> - Safari 12+

https://nextjs.org/docs/architecture/supported-browsers