### PR TITLE
Set margin for languageSelector on mobile

### DIFF
--- a/components/common/LanguageSelector.tsx
+++ b/components/common/LanguageSelector.tsx
@@ -78,7 +78,7 @@ const StyledDropdownToggle = styled(DropdownToggle)`
 
   @media (min-width: ${(props) => props.theme.breakpointMd}) {
     align-self: center;
-    margin: 0;
+    margin: 0 ${(props) => props.theme.spaces.s200} 0 0;
 
     svg.icon {
       fill: ${(props) => props.theme.brandNavColor} !important;


### PR DESCRIPTION
Minor visual bug: LanguageSelector slightly breaks the layout on mobile. Set the margin.
Before:
<img width="188" alt="Screen Shot 2024-02-13 at 13 15 35" src="https://github.com/kausaltech/kausal-watch-ui/assets/96352283/716ef389-2724-457c-ab10-b51f07a03dbc">
After:
<img width="197" alt="Screen Shot 2024-02-13 at 13 33 40" src="https://github.com/kausaltech/kausal-watch-ui/assets/96352283/fb5e61a6-6410-44d6-864e-ee195511a4bc">


