### PR TITLE
Exclude current plan from dropdown selection

### DIFF
--- a/components/plans/PlanSelector.tsx
+++ b/components/plans/PlanSelector.tsx
@@ -68,8 +68,9 @@ const PlanSelector = () => {
   if (!allRelatedPlans.length) return null;
 
   const selectablePlans = [
-    { ...plan, viewUrl: '/' },
-    ...plan.allRelatedPlans.filter((pl) => pl?.id !== plan.parent?.id),
+    ...plan.allRelatedPlans.filter(
+      (pl) => pl?.id !== plan.id && pl?.id !== plan.parent?.id
+    ),
   ];
 
   return (


### PR DESCRIPTION
Modified PlanSelector to exclude the current plan that's displayed in the dropdown title from the dropdown menu.
Related Asana task https://app.asana.com/0/1206017643443542/1206474860552270/f

Before:
<img width="717" alt="Screen Shot 2024-02-14 at 18 35 34" src="https://github.com/kausaltech/kausal-watch-ui/assets/96352283/e17289cc-6e79-4684-8a54-52cd1bcf681e">
After:
<img width="672" alt="Screen Shot 2024-02-14 at 18 34 51" src="https://github.com/kausaltech/kausal-watch-ui/assets/96352283/8b767d4f-1cc4-4700-bca6-2ed561093b82">
