### PR TITLE
Fix 'no unit' indicator unit being displayed

### DIFF
--- a/components/indicators/IndicatorHighlightCard.tsx
+++ b/components/indicators/IndicatorHighlightCard.tsx
@@ -117,7 +117,7 @@ function IndicatorHighlightCard({
           <CardImgOverlay>
             <IndicatorValue level={level} className="action-number">
               {typeof value === 'number' ? beautifyValue(value) : '-'}
-              <IndicatorUnit>{unit}</IndicatorUnit>
+              <IndicatorUnit>{unit === 'no unit' ? '' : unit}</IndicatorUnit>
             </IndicatorValue>
           </CardImgOverlay>
         </a>

--- a/components/indicators/IndicatorValueSummary.js
+++ b/components/indicators/IndicatorValueSummary.js
@@ -65,9 +65,12 @@ function IndicatorValueSummary(props) {
   const t = useTranslations();
   const locale = useLocale();
   const theme = useTheme();
-  const { timeResolution, values, goals, unit, i18n } = props;
+  const { timeResolution, values, goals, unit } = props;
   const desirableDirection = determineDesirableDirection(values, goals);
-  const shortUnitName = unit.shortName || unit.name;
+  const shortUnitName =
+    (unit.shortName || unit.name) === 'no unit'
+      ? ''
+      : unit.shortName || unit.name;
   const diffUnitName =
     unit.name === '%' ? t('percent-point-abbreviation') : shortUnitName;
   const now = dayjs();


### PR DESCRIPTION
Hide the unit completely if "no unit" for an indicator is chosen.

## Before

<img width="1385" alt="Screenshot 2024-02-15 at 16 51 16" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/246d6cdd-2580-4471-9276-9367ec2f5eda">


## After

<img width="1359" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/409ecca2-66e1-4fc6-a91e-49a5f42c337d">


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206593636246602