### PR TITLE
Support lowercase locales in the pathname

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -13,6 +13,7 @@ import { UNPUBLISHED_PATH } from './constants/routes';
 import { httpLink, operationEnd, operationStart } from './utils/apollo.utils';
 import { captureException } from '@sentry/nextjs';
 import {
+  convertPathnameFromInvalidLocaleCasing,
   convertPathnameFromLegacy,
   getLocaleAndPlan,
   getSearchParamsString,
@@ -105,7 +106,7 @@ export async function middleware(request: NextRequest) {
     return NextResponse.rewrite(new URL('/404', request.url));
   }
 
-  const { parsedLocale, parsedPlan } = getLocaleAndPlan(
+  const { parsedLocale, parsedPlan, isLocaleCaseInvalid } = getLocaleAndPlan(
     pathname,
     data.plansForHostname
   );
@@ -119,6 +120,15 @@ export async function middleware(request: NextRequest) {
       pathname,
       parsedLocale,
       parsedPlan
+    );
+
+    return NextResponse.redirect(new URL(newPathname, request.url));
+  }
+
+  if (isLocaleCaseInvalid) {
+    const newPathname = convertPathnameFromInvalidLocaleCasing(
+      pathname,
+      parsedLocale
     );
 
     return NextResponse.redirect(new URL(newPathname, request.url));

--- a/utils/__tests__/middleware.test.ts
+++ b/utils/__tests__/middleware.test.ts
@@ -1,0 +1,64 @@
+import { PlanFromPlansQuery, getParsedLocale } from '../middleware.utils';
+
+const primaryLanguage = 'en-US';
+const otherLanguages = ['es-US', 'DOTHRAKI'];
+const MOCK_PLAN = {
+  id: 'foo',
+  identifier: 'foo',
+  otherLanguages,
+  primaryLanguage,
+} as PlanFromPlansQuery;
+
+describe('getParsedLocale', () => {
+  it('returns the plan primary language if no match is found in the path', () => {
+    expect(getParsedLocale([], MOCK_PLAN)).toMatchObject({
+      parsedLocale: primaryLanguage,
+      isCaseInvalid: false,
+    });
+    expect(getParsedLocale(['fi', 'bar'], MOCK_PLAN)).toMatchObject({
+      parsedLocale: primaryLanguage,
+      isCaseInvalid: false,
+    });
+  });
+
+  it('returns the plan primary language if it is found in the path', () => {
+    expect(getParsedLocale([primaryLanguage], MOCK_PLAN)).toMatchObject({
+      parsedLocale: primaryLanguage,
+      isCaseInvalid: false,
+    });
+    expect(
+      getParsedLocale([primaryLanguage, 'foo', 'bar'], MOCK_PLAN)
+    ).toMatchObject({
+      parsedLocale: primaryLanguage,
+      isCaseInvalid: false,
+    });
+  });
+
+  it("returns the plan's other language if it is found in the path", () => {
+    expect(getParsedLocale([otherLanguages[0]], MOCK_PLAN)).toMatchObject({
+      parsedLocale: otherLanguages[0],
+      isCaseInvalid: false,
+    });
+    expect(
+      getParsedLocale(['foo', otherLanguages[1]], MOCK_PLAN)
+    ).toMatchObject({
+      parsedLocale: otherLanguages[1],
+      isCaseInvalid: false,
+    });
+  });
+
+  it('returns the plan primary language or other language if a lowercase version is found in the path', () => {
+    expect(getParsedLocale(['en-us'], MOCK_PLAN)).toMatchObject({
+      parsedLocale: primaryLanguage,
+      isCaseInvalid: true,
+    });
+    expect(getParsedLocale(['plan', 'es-us', 'foo'], MOCK_PLAN)).toMatchObject({
+      parsedLocale: 'es-US',
+      isCaseInvalid: true,
+    });
+    expect(getParsedLocale(['dothraki', 'foo'], MOCK_PLAN)).toMatchObject({
+      parsedLocale: 'DOTHRAKI',
+      isCaseInvalid: true,
+    });
+  });
+});


### PR DESCRIPTION
Redirect visitors to the correct pathname with properly cased locale (e.g. `es-US`) even if they have an incorrectly cased locale in their original URL (e.g. `es-us`)

User need:

> We are having an issue that if someone does not capitalize the “US” in this version of our url: www.city.gov/es-US AND they have never navigated to the Spanish version of the page before, they get an error. 
> 
> Is it possible to add a version of the URL: www.city.gov/es-us. With the “us” lower case so if it is typed in that way, it will still work?