### PR TITLE
Support debugging server side queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ run the following commands:
     npm run custom-bundle -- --traces ${TRACES}
     npm publish --access public
 
+#### Debugging
+
+Debug server side GraphQL queries by setting the `LOG_GRAPHQL_QUERIES=true` environment variable. This will log all outgoing queries and variables in your dev server console.
+
 ## Building and deploying in production
 
 To run the app in production mode:

--- a/common/environment.ts
+++ b/common/environment.ts
@@ -19,3 +19,6 @@ export const apiUrl =
 export const gqlUrl = `${apiUrl}/graphql/`;
 
 export const authIssuer = process.env.NEXT_PUBLIC_AUTH_ISSUER;
+
+export const logGraphqlQueries =
+  isServer && process.env.LOG_GRAPHQL_QUERIES === 'true';


### PR DESCRIPTION
Debugging queries from React Server Components is a pain, with this we can set `LOG_GRAPHQL_QUERIES=true` to log all outgoing queries server side.

Example log:
```
📡 14:38:29.493Z 📡 Sending query GetPlansByHostname with variables:
{
  "hostname": "sunnydale.localhost"
}

query GetPlansByHostname($hostname: String) {
  plansForHostname(hostname: $hostname) {
    domain {
      hostname
      basePath
      status
      statusMessage
      __typename
    }
    domains {
      hostname
      basePath
      status
      statusMessage
      __typename
    }
    primaryLanguage
    ... on Plan {
      id
      identifier
      otherLanguages
      __typename
    }
    __typename
  }
}

🎬 End of query GetPlansByHostname
```