### PR TITLE
Handle missing contentblock metadata

### DIFF
--- a/components/actions/ActionContent.tsx
+++ b/components/actions/ActionContent.tsx
@@ -487,8 +487,8 @@ function ActionContent(props: ActionContentProps) {
           allSections.push(
             <RestrictedBlockWrapper
               key={block.id}
-              isRestricted={block.meta.restricted}
-              isHidden={block.meta.hidden}
+              isRestricted={block.meta?.restricted}
+              isHidden={block.meta?.hidden}
             >
               <ActionContentBlock
                 key={block.id}


### PR DESCRIPTION
Do not error if action content block does not provide `meta.hidden` or `meta.restricted`