### PR TITLE
Fix uncaught error accessing meta

### DIFF
--- a/components/common/AttributesBlock.tsx
+++ b/components/common/AttributesBlock.tsx
@@ -103,9 +103,13 @@ function AttributesBlock(props: AttributesBlockProps) {
             <RestrictedBlockWrapper
               key={item.id}
               isRestricted={
-                typesById && typesById.get(item.type.id).meta.restricted
+                (typesById && typesById.get(item.type.id)?.meta?.restricted) ??
+                false
               }
-              isHidden={typesById && typesById.get(item.type.id).meta.hidden}
+              isHidden={
+                (typesById && typesById.get(item.type.id)?.meta?.hidden) ??
+                false
+              }
             >
               <AttributeItem tag="li" key={item.id} md={vertical ? 12 : 6}>
                 <ActionAttribute


### PR DESCRIPTION
Fixes a production bug triggering an uncaught `Cannot read properties of undefined (reading 'meta')` error. 

Link to reproduce: https://ilmastovahti.tampere.fi/teema/kest%C3%A4v%C3%A4-kulutus/kest%C3%A4v%C3%A4-liiketoiminta-ja-tapahtumat
Link to initial error trace: https://sentry.kausal.tech/organizations/kausal/issues/4741/events/8daf98ce984345c6afe9143c1aa7d69a/