### PR TITLE
Fix missing categories from multiplan action page filters

### DIFF
--- a/app/[domain]/[lang]/[plan]/(with-layout-elements)/actions/page.tsx
+++ b/app/[domain]/[lang]/[plan]/(with-layout-elements)/actions/page.tsx
@@ -16,11 +16,20 @@ export default async function ActionsPage({ params }: Props) {
   const { data: pageSettingsData } = await tryRequest(
     getIncludeRelatedActions(plan)
   );
+
+  /**
+   * TODO:  The backend returns no categories for a CategoryTypeFilterBlock for multi-plans.
+   *        Here we set onlyWithActions to false if the includeRelatedPlans setting is active to ensure
+   *        categories are displayed. This can be removed once the backend is updated to return
+   *        multi-plan categories when onlyWithActions is true.
+   */
+  const excludeFilterCategoriesWithoutActions = pageSettingsData?.plan
+    ?.actionListPage?.includeRelatedPlans
+    ? false
+    : true;
+
   const { data } = await tryRequest(
-    getActionsListPage(
-      plan,
-      pageSettingsData?.plan?.actionListPage?.includeRelatedPlans ?? false
-    )
+    getActionsListPage(plan, excludeFilterCategoriesWithoutActions)
   );
 
   if (data?.plan?.actionListPage?.__typename !== 'ActionListPage') {

--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -3512,6 +3512,11 @@ export type QuerySearchArgs = {
   query?: InputMaybe<Scalars['String']>;
 };
 
+
+export type QueryWorkflowStatesArgs = {
+  plan: Scalars['ID'];
+};
+
 export type QuestionAnswerBlock = StreamFieldInterface & {
   __typename?: 'QuestionAnswerBlock';
   blockType: Scalars['String'];
@@ -4181,7 +4186,7 @@ export enum WorkflowState {
 export type WorkflowStateDescription = {
   __typename?: 'WorkflowStateDescription';
   description?: Maybe<Scalars['String']>;
-  id?: Maybe<WorkflowState>;
+  id?: Maybe<Scalars['String']>;
 };
 
 export type GetSitemapQueryVariables = Exact<{
@@ -4556,12 +4561,14 @@ export type SearchQueryQuery = (
   & { __typename?: 'Query' }
 );
 
-export type GetWorkflowsQueryVariables = Exact<{ [key: string]: never; }>;
+export type GetWorkflowsQueryVariables = Exact<{
+  plan: Scalars['ID'];
+}>;
 
 
 export type GetWorkflowsQuery = (
   { workflowStates?: Array<(
-    { id?: WorkflowState | null, description?: string | null }
+    { id?: string | null, description?: string | null }
     & { __typename?: 'WorkflowStateDescription' }
   ) | null> | null }
   & { __typename?: 'Query' }
@@ -9172,7 +9179,7 @@ export type GetActionListPageIncludeRelatedQuery = (
 
 export type GetActionListPageQueryVariables = Exact<{
   plan: Scalars['ID'];
-  singlePlan: Scalars['Boolean'];
+  onlyWithActions: Scalars['Boolean'];
 }>;
 
 

--- a/fragments/action-list.fragment.ts
+++ b/fragments/action-list.fragment.ts
@@ -16,7 +16,7 @@ const ACTION_LIST_FILTER = gql`
         hideCategoryIdentifiers
         selectionType
         helpText
-        categories(onlyWithActions: $singlePlan) {
+        categories(onlyWithActions: $onlyWithActions) {
           id
           identifier
           name

--- a/queries/get-actions-list-page.ts
+++ b/queries/get-actions-list-page.ts
@@ -29,7 +29,7 @@ export const getIncludeRelatedActions = async (plan: string) =>
   });
 
 const GET_ACTIONS_LIST_PAGE = gql`
-  query GetActionListPage($plan: ID!, $singlePlan: Boolean!) {
+  query GetActionListPage($plan: ID!, $onlyWithActions: Boolean!) {
     plan(id: $plan) {
       actionListPage {
         __typename
@@ -50,7 +50,10 @@ const GET_ACTIONS_LIST_PAGE = gql`
   ${ALL_ACTION_LIST_FILTERS}
 `;
 
-export const getActionsListPage = async (plan: string, isSinglePlan: boolean) =>
+export const getActionsListPage = async (
+  plan: string,
+  excludeCategoriesWithoutActions: boolean
+) =>
   await getClient().query<
     GetActionListPageQuery,
     GetActionListPageQueryVariables
@@ -58,7 +61,7 @@ export const getActionsListPage = async (plan: string, isSinglePlan: boolean) =>
     query: GET_ACTIONS_LIST_PAGE,
     variables: {
       plan,
-      singlePlan: isSinglePlan,
+      onlyWithActions: excludeCategoriesWithoutActions,
     },
     fetchPolicy: 'no-cache',
   });


### PR DESCRIPTION
It seems the core issue is on the backend, but this provides an urgent fix for a hard deadline tomorrow (US customer demo & launch).

The backend seems to only include categories associated with actions for the current plan when querying the action list page with `onlyWithActions`, it should also consider categories that are assigned to actions in subplans. This quick fix ensures that the `onlyWithActions` boolean in the `ActionListFilter` fragment is `false` if the action list page includes subplan actions.

This also renames the variables passed around for clarity.

| Before | After |
| --- | --- |
| ![Screenshot 2024-03-04 at 15 52 39](https://github.com/kausaltech/kausal-watch-ui/assets/15343658/c9fffd25-948e-46e3-b685-6d449d2b4ea4) |  ![image](https://github.com/kausaltech/kausal-watch-ui/assets/15343658/593e732d-8deb-4a19-88cb-7912f151c000) |