### PR TITLE
Add mini version of action dependencies for action cards

### DIFF
--- a/components/actions/blocks/action-dependencies/ActionDependenciesBlock.tsx
+++ b/components/actions/blocks/action-dependencies/ActionDependenciesBlock.tsx
@@ -3,6 +3,9 @@ import { ActionCardFragment } from '@/common/__generated__/graphql';
 import { ActionDependenciesGroup } from './ActionDependenciesGroup';
 import Icon from '@/components/common/Icon';
 import { ACTION_CONTENT_MAIN_BOTTOM } from '@/constants/containers';
+import { useTranslations } from 'next-intl';
+import { getActionTermContext } from '@/common/i18n';
+import { usePlan } from '@/context/plan';
 
 type ActionGroup = {
   id: string;
@@ -12,34 +15,51 @@ type ActionGroup = {
 
 type Props = {
   activeActionId?: string;
+  size?: 'default' | 'small';
   actionGroups: ActionGroup[];
+  showTitle?: boolean;
 };
 
 const StyledIcon = styled(Icon)``;
 
-const StyledWrapper = styled.div`
+const StyledWrapper = styled.div<{ $isVertical: boolean; $isSmall: boolean }>`
   display: flex;
   width: 100%;
-  gap: ${({ theme }) => theme.spaces.s025};
+  gap: ${({ theme, $isSmall }) =>
+    $isSmall ? theme.spaces.s000 : theme.spaces.s025};
   color: ${({ theme }) => theme.graphColors.grey020};
 
-  ${({ theme }) => css`
-    @media (max-width: ${theme.breakpointMd}) {
-      flex-direction: column;
+  ${({ theme, $isVertical }) =>
+    $isVertical
+      ? css`
+          flex-direction: column;
+          align-items: center;
 
-      ${StyledIcon} {
-        transform: rotate(90deg);
-      }
-    }
+          ${StyledIcon} {
+            transform: rotate(90deg);
+          }
+        `
+      : css`
+          @media (max-width: ${theme.breakpointMd}) {
+            flex-direction: column;
 
-    @container ${ACTION_CONTENT_MAIN_BOTTOM} (max-width: ${theme.breakpointSm}) {
-      flex-direction: column;
+            ${StyledIcon} {
+              transform: rotate(90deg);
+            }
+          }
 
-      ${StyledIcon} {
-        transform: rotate(90deg);
-      }
-    }
-  `}
+          @container ${ACTION_CONTENT_MAIN_BOTTOM} (max-width: ${theme.breakpointSm}) {
+            flex-direction: column;
+
+            ${StyledIcon} {
+              transform: rotate(90deg);
+            }
+          }
+        `}
+`;
+
+const StyledTitle = styled.h4`
+  font-size: ${({ theme }) => theme.fontSizeBase};
 `;
 
 function isActionGroupActive(
@@ -52,9 +72,19 @@ function isActionGroupActive(
 export function ActionDependenciesBlock({
   activeActionId,
   actionGroups,
+  size = 'default',
+  showTitle = false,
 }: Props) {
+  const t = useTranslations();
+  const plan = usePlan();
+
   return (
-    <StyledWrapper>
+    <StyledWrapper $isVertical={size === 'small'} $isSmall={size === 'small'}>
+      {showTitle && (
+        <StyledTitle>
+          {t('action-dependencies', getActionTermContext(plan))}
+        </StyledTitle>
+      )}
       {actionGroups.map((actionGroup, i) => (
         <>
           <ActionDependenciesGroup
@@ -65,6 +95,7 @@ export function ActionDependenciesBlock({
               activeActionId
             )}
             actions={actionGroup.actions}
+            size={size}
           />
 
           {i !== actionGroups.length - 1 && (

--- a/components/actions/blocks/action-dependencies/ActionDependenciesGroup.tsx
+++ b/components/actions/blocks/action-dependencies/ActionDependenciesGroup.tsx
@@ -1,18 +1,24 @@
 import styled from 'styled-components';
 import { ActionCardFragment } from '@/common/__generated__/graphql';
 import ActionCard from '../../ActionCard';
+import { useTranslations } from 'next-intl';
+import { usePlan } from '@/context/plan';
+import { getActionTermContext } from '@/common/i18n';
 
-const StyledActionGroup = styled.div<{ $isHighlighted: boolean }>`
+const StyledActionGroup = styled.div<{ $isSmall: boolean }>`
   border: 2px solid currentColor;
   border-radius: ${({ theme }) => theme.cardBorderRadius};
   padding: ${({ theme }) => theme.spaces.s050};
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spaces.s100};
+  gap: ${({ theme, $isSmall }) =>
+    $isSmall ? theme.spaces.s050 : theme.spaces.s100};
+  text-align: ${({ $isSmall }) => ($isSmall ? 'center' : 'left')};
+  width: 100%;
 `;
 
-const StyledGroupTitle = styled.h4`
+const StyledGroupTitle = styled.h5`
   margin: 0;
   font-size: ${({ theme }) => theme.fontSizeSm};
   text-transform: uppercase;
@@ -20,8 +26,17 @@ const StyledGroupTitle = styled.h4`
   font-weight: ${({ theme }) => theme.fontWeightBold};
 `;
 
+const StyledHelpText = styled.p`
+  color: ${({ theme }) => theme.textColor.secondary};
+  font-size: ${({ theme }) => theme.fontSizeSm};
+  font-style: italic;
+  margin: 0;
+  line-height: 1;
+`;
+
 type Props = {
   title: string;
+  size?: 'default' | 'small';
   isHighlighted?: boolean;
   actions: ActionCardFragment[];
 };
@@ -29,21 +44,46 @@ type Props = {
 export function ActionDependenciesGroup({
   title,
   actions,
+  size = 'default',
   isHighlighted = false,
 }: Props) {
+  const t = useTranslations();
+  const plan = usePlan();
+
   return (
-    <StyledActionGroup $isHighlighted={isHighlighted}>
+    <StyledActionGroup $isSmall={size === 'small'}>
       <StyledGroupTitle>{title}</StyledGroupTitle>
 
-      {actions.map((action) => (
-        <ActionCard
-          key={action.id}
-          action={action}
-          variant="mini"
-          isLink={!isHighlighted}
-          isHighlighted={isHighlighted}
-        />
-      ))}
+      {size === 'small' && actions.length > 0 ? (
+        <>
+          <ActionCard
+            action={actions[0]}
+            variant="text-only"
+            isLink={!isHighlighted}
+            isHighlighted={isHighlighted}
+          />
+          {actions.length > 1 && (
+            <StyledHelpText>
+              {t('n-more-actions', {
+                count: actions.length - 1,
+                ...getActionTermContext(plan),
+              })}
+            </StyledHelpText>
+          )}
+        </>
+      ) : (
+        <>
+          {actions.map((action) => (
+            <ActionCard
+              key={action.id}
+              action={action}
+              variant="mini"
+              isLink={!isHighlighted}
+              isHighlighted={isHighlighted}
+            />
+          ))}
+        </>
+      )}
     </StyledActionGroup>
   );
 }

--- a/components/common/Icon.tsx
+++ b/components/common/Icon.tsx
@@ -7,52 +7,52 @@ import { useTheme } from 'styled-components';
 const camelToKebabCase = (s) =>
   s.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
 
-const AVAILABLE_ICONS = [
-  'angle-down.svg',
-  'angle-left.svg',
-  'angle-right.svg',
-  'angle-up.svg',
-  'arrow-down.svg',
-  'arrow-left.svg',
-  'arrow-right.svg',
-  'arrow-up-down.svg',
-  'arrow-up-right-from-square.svg',
-  'arrow-up.svg',
-  'bars.svg',
-  'bullseye.svg',
-  'calendar.svg',
-  'chart-line.svg',
-  'check.svg',
-  'caret-down.svg',
-  'caret-left.svg',
-  'caret-right.svg',
-  'caret-up.svg',
-  'circle-full.svg',
-  'circle-outline.svg',
-  'commenting.svg',
-  'dot-circle.svg',
-  'exclamation-circle.svg',
-  'globe.svg',
-  'heart.svg',
-  'hidden.svg',
-  'home.svg',
-  'link.svg',
-  'lock.svg',
-  'pencil.svg',
-  'scope-global.svg',
-  'scope-local.svg',
-  'search.svg',
-  'sort-down.svg',
-  'sort-up.svg',
-  'sort.svg',
-  'sync.svg',
-  'tachometer.svg',
-  'times.svg',
-  'user.svg',
-];
+type AvailableIcons =
+  | 'action-dependency'
+  | 'angle-down'
+  | 'angle-left'
+  | 'angle-right'
+  | 'angle-up'
+  | 'arrow-down'
+  | 'arrow-left'
+  | 'arrow-right'
+  | 'arrow-up-down'
+  | 'arrow-up-right-from-square'
+  | 'arrow-up'
+  | 'bars'
+  | 'bullseye'
+  | 'calendar'
+  | 'chart-line'
+  | 'check'
+  | 'caret-down'
+  | 'caret-left'
+  | 'caret-right'
+  | 'caret-up'
+  | 'circle-full'
+  | 'circle-outline'
+  | 'commenting'
+  | 'dot-circle'
+  | 'exclamation-circle'
+  | 'globe'
+  | 'heart'
+  | 'hidden'
+  | 'home'
+  | 'link'
+  | 'lock'
+  | 'pencil'
+  | 'scope-global'
+  | 'scope-local'
+  | 'search'
+  | 'sort-down'
+  | 'sort-up'
+  | 'sort'
+  | 'sync'
+  | 'tachometer'
+  | 'times'
+  | 'user';
 
 type Props = {
-  name?: string;
+  name?: AvailableIcons;
   color?: string;
   width?: string;
   height?: string;
@@ -61,7 +61,7 @@ type Props = {
 } & React.SVGProps<SVGUseElement>;
 
 const Icon = ({
-  name = 'circleOutline',
+  name = 'circle-outline',
   color = 'inherit',
   width = '1em',
   height = '1em',

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -53,5 +53,7 @@
   "feedback-on-action-description": "You can leave a comment or feedback on this action",
   "action-draft": "Draft",
   "logo": "Logo",
-  "other": "Other"
+  "other": "Other",
+  "n-more-actions": "Plus {count} other {context, select, CASE_STUDY {{count, plural, =1 {case study} other {case studies}}} STRATEGY {{count, plural, =1 {strategy} other {strategies}}} other {{count, plural, =1 {action} other {actions}}}}",
+  "action-dependencies": "{context, select, CASE_STUDY {Case study dependencies} STRATEGY {Strategy dependencies} other {Action dependencies}}"
 }

--- a/stories/ActionCard.stories.tsx
+++ b/stories/ActionCard.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import ActionCard from '@/components/actions/ActionCard';
+import { MOCK_ACTIONS } from './mocks/actions.mocks';
+
+const MOCK_PROPS: Story['args'] = {
+  action: MOCK_ACTIONS[0],
+};
+
+const meta = {
+  title: 'Actions/ActionCard',
+  component: ActionCard,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {},
+} satisfies Meta<typeof ActionCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: MOCK_PROPS,
+};
+
+export const Highlighted: Story = {
+  args: { ...MOCK_PROPS, isHighlighted: true },
+};
+
+export const WithoutLink: Story = {
+  args: { ...MOCK_PROPS, isLink: false },
+};
+
+export const WithActionDependencies: Story = {
+  args: { ...MOCK_PROPS, showActionDependencies: true },
+};

--- a/stories/ActionDependenciesBlock.stories.tsx
+++ b/stories/ActionDependenciesBlock.stories.tsx
@@ -27,6 +27,9 @@ const MOCK_PROPS: Story['args'] = {
 const meta = {
   title: 'Actions/ActionDependenciesBlock',
   component: ActionDependenciesBlock,
+  parameters: {
+    layout: 'centered',
+  },
   tags: ['autodocs'],
   argTypes: {},
 } satisfies Meta<typeof ActionDependenciesBlock>;
@@ -37,4 +40,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: MOCK_PROPS,
+};
+
+export const Small: Story = {
+  args: { ...MOCK_PROPS, size: 'small' },
 };

--- a/stories/RestrictedBlockWrapper.stories.tsx
+++ b/stories/RestrictedBlockWrapper.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import RestrictedBlockWrapper from '../components/actions/blocks/RestrictedBlockWrapper';
+
+const meta = {
+  title: 'Blocks/RestrictedBlockWrapper',
+  component: RestrictedBlockWrapper,
+  tags: ['autodocs'],
+  argTypes: {},
+} satisfies Meta<typeof RestrictedBlockWrapper>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    isHidden: false,
+    isRestricted: true,
+    children: (
+      <>
+        <h4>This is a restricted block</h4>
+        <p>
+          Restricted blocks are used to indicate that content is hidden from the
+          public UI to unauthenticated users.
+        </p>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat.
+        </p>
+      </>
+    ),
+  },
+};


### PR DESCRIPTION
Note, the icon in the screenshot is specific to San Diego. This should be demoed to and test by San Diego on Monday, I'm a bit concerned about the usability of such heavy popup tooltips.

![image](https://github.com/kausaltech/kausal-watch-ui/assets/15343658/166bdc3e-e55c-4946-b5f9-473ae3e995f6)
