### PR TITLE
Replace completed state for continuous actions

### DIFF
--- a/components/actions/ActionContent.tsx
+++ b/components/actions/ActionContent.tsx
@@ -404,7 +404,10 @@ function ActionContentProgressContainer({
 
       {!!action.implementationPhase && (
         <StyledProgressCard>
-          <PhaseTimeline activePhase={action.implementationPhase} />
+          <PhaseTimeline
+            activePhase={action.implementationPhase}
+            isContinuous={action.scheduleContinuous}
+          />
         </StyledProgressCard>
       )}
 

--- a/components/actions/PhaseTimeline.tsx
+++ b/components/actions/PhaseTimeline.tsx
@@ -14,6 +14,7 @@ type PhaseType = 'done' | 'current' | 'todo';
 type PhaseTimelineProps = {
   activePhase: NonNullable<ActionContentAction['implementationPhase']>;
   layout?: 'vertical' | 'horizontal' | 'mini';
+  isContinuous?: boolean;
 };
 
 type PhaseIndicatorProps = {
@@ -24,6 +25,7 @@ type PhaseIndicatorProps = {
   color: string;
   nextColor?: string;
   layout: PhaseTimelineProps['layout'];
+  isContinuous?: boolean;
 };
 
 const verticalContainerStyles = css`
@@ -155,9 +157,22 @@ const PHASE_CONFIG: {
   },
 };
 
-function getIconFromType(type: PhaseType, phaseIdentifier: string) {
+function getIconFromType(
+  type: PhaseType,
+  phaseIdentifier: string,
+  isContinuous: boolean = false
+) {
   const isCurrent = type === 'current';
   const isCompleted = phaseIdentifier === 'completed';
+
+  if (isContinuous) {
+    if (isCurrent && isCompleted) {
+      return 'caret-right';
+    }
+    if (isCompleted) {
+      return 'angle-right';
+    }
+  }
 
   if (isCurrent && isCompleted) {
     return 'check-circle';
@@ -196,6 +211,7 @@ function PhaseIndicator({
   color,
   nextColor,
   layout,
+  isContinuous = false,
 }: PhaseIndicatorProps) {
   const isVertical = layout === 'vertical';
   const iconSize = layout === 'mini' ? '16px' : '20px';
@@ -206,7 +222,7 @@ function PhaseIndicator({
         <StyledPhaseLine $hidden={index === 0} $color={color} />
       )}
       <Icon
-        name={getIconFromType(type, phaseIdentifier)}
+        name={getIconFromType(type, phaseIdentifier, isContinuous)}
         color={color}
         width={iconSize}
         height={iconSize}
@@ -271,9 +287,11 @@ function useOverrideLayout<T extends HTMLElement>(
 export function PhaseTimeline({
   activePhase,
   layout = 'horizontal',
+  isContinuous = false,
 }: PhaseTimelineProps) {
   const ref = useRef<HTMLUListElement>(null);
   const plan = usePlan();
+  console.log(plan, activePhase, layout, ref);
   const theme = useTheme();
   const phases = plan.actionImplementationPhases;
   const overriddenLayout = useOverrideLayout(layout, phases.length, ref);
@@ -292,10 +310,15 @@ export function PhaseTimeline({
             index + 1 < phases.length
               ? getPhaseType(index + 1, activePhaseIndex)
               : undefined;
+          const phaseName =
+            isContinuous && phase.identifier === 'completed'
+              ? 'Continuous'
+              : phase.name;
 
           return (
             <StyledPhase key={phase.id} $isVertical={isVertical}>
               <PhaseIndicator
+                isContinuous={isContinuous}
                 phaseIdentifier={phase.identifier}
                 layout={overriddenLayout}
                 index={index}
@@ -315,7 +338,7 @@ export function PhaseTimeline({
                   $type={phaseType}
                   $color={getColorFromType(phaseType, theme, 'textColorKey')}
                 >
-                  {phase.name}
+                  {phaseName}
                 </StyledPhaseName>
               )}
             </StyledPhase>

--- a/components/actions/PhaseTimeline.tsx
+++ b/components/actions/PhaseTimeline.tsx
@@ -7,6 +7,7 @@ import { ActionContentAction } from './ActionContent';
 import { Theme } from '@kausal/themes/types';
 import { RefObject, useEffect, useRef, useState } from 'react';
 import { debounce } from 'lodash';
+import { useTranslations } from 'next-intl';
 
 // Used to determine the style of icon visualizing a phase, not to be confused with phase identifiers
 type PhaseType = 'done' | 'current' | 'todo';
@@ -291,8 +292,8 @@ export function PhaseTimeline({
 }: PhaseTimelineProps) {
   const ref = useRef<HTMLUListElement>(null);
   const plan = usePlan();
-  console.log(plan, activePhase, layout, ref);
   const theme = useTheme();
+  const t = useTranslations();
   const phases = plan.actionImplementationPhases;
   const overriddenLayout = useOverrideLayout(layout, phases.length, ref);
   const isVertical = overriddenLayout === 'vertical';
@@ -312,7 +313,7 @@ export function PhaseTimeline({
               : undefined;
           const phaseName =
             isContinuous && phase.identifier === 'completed'
-              ? 'Continuous'
+              ? t('action-continuous')
               : phase.name;
 
           return (

--- a/components/dashboard/ActionTableTooltips.tsx
+++ b/components/dashboard/ActionTableTooltips.tsx
@@ -180,6 +180,7 @@ export const ImplementationPhaseTooltipContent = ({
           <PhaseTimeline
             layout="vertical"
             activePhase={action.implementationPhase}
+            isContinuous={action.scheduleContinuous}
           />
         )}
       </StyledPhaseTimelineContainer>

--- a/components/dashboard/cells/ImplementationPhaseCell.tsx
+++ b/components/dashboard/cells/ImplementationPhaseCell.tsx
@@ -25,7 +25,11 @@ const ImplementationPhaseCell = ({ action }: Props) => {
   return (
     <StatusDisplay>
       {!!action.implementationPhase && (
-        <PhaseTimeline layout="mini" activePhase={action.implementationPhase} />
+        <PhaseTimeline
+          layout="mini"
+          activePhase={action.implementationPhase}
+          isContinuous={action.scheduleContinuous}
+        />
       )}
     </StatusDisplay>
   );

--- a/locales/de/actions.json
+++ b/locales/de/actions.json
@@ -1,6 +1,6 @@
 {
     "action-completion-percentage": "Fertigstellung",
-    "action-continuous": "Laufend",
+    "action-continuous": "Fortlaufend",
     "action-description": "Beschreibung",
     "action-description-official": "Offizielle Beschreibung",
     "action-id": "ID",

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -1,6 +1,6 @@
 {
   "action-completion-percentage": "Completion",
-  "action-continuous": "Ongoing",
+  "action-continuous": "Continuous",
   "action-description": "Description",
   "action-description-official": "Official description",
   "action-id": "ID",
@@ -29,7 +29,7 @@
   "action-timeline-between": "Timeframe between",
   "action-what-effect-this-has": "{context, select, CASE_STUDY {How this case study contributes to the outcome} STRATEGY {How this strategy contributes to the outcome} other {How this action contributes to the outcome}}",
   "actions-phases": "Actions by phases",
-  "actions-phases-help": "Ongoing and completed actions",
+  "actions-phases-help": "Continuous and completed actions",
   "actions-status": "Actions by status",
   "actions-status-help": "Actions proceeding as planned",
   "actions-updated": "Active actions last updated",

--- a/stories/PhaseTimeline.stories.tsx
+++ b/stories/PhaseTimeline.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { PhaseTimeline } from '@/components/actions/PhaseTimeline';
+import { MOCK_ACTIONS } from './mocks/actions.mocks';
+
+const meta = {
+  title: 'Actions/PhaseTimeline',
+  component: PhaseTimeline,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {},
+} satisfies Meta<typeof PhaseTimeline>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    activePhase: {
+      id: '16',
+      identifier: 'implementation',
+      name: 'Implementation',
+      __typename: 'ActionImplementationPhase',
+    },
+  },
+};
+
+export const ContinousComplete: Story = {
+  args: {
+    activePhase: MOCK_ACTIONS[24].implementationPhase,
+    isContinuous: true,
+  },
+};
+
+export const ContinousIncomplete: Story = {
+  args: {
+    activePhase: MOCK_ACTIONS[16].implementationPhase,
+    isContinuous: true,
+  },
+};

--- a/stories/PhaseTimeline.stories.tsx
+++ b/stories/PhaseTimeline.stories.tsx
@@ -28,6 +28,13 @@ export const Default: Story = {
   },
 };
 
+export const NotContinousComplete: Story = {
+  args: {
+    activePhase: MOCK_ACTIONS[24].implementationPhase,
+    isContinuous: false,
+  },
+};
+
 export const ContinousComplete: Story = {
   args: {
     activePhase: MOCK_ACTIONS[24].implementationPhase,

--- a/stories/Timeline.stories.tsx
+++ b/stories/Timeline.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Timeline from '@/components/graphs/Timeline';
+
+const meta = {
+  title: 'Actions/Timeline',
+  component: Timeline,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {},
+} satisfies Meta<typeof Timeline>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    startDate: '2023-01-12T20:31:54.248974+00:00',
+    endDate: '2023-01-12T20:31:54.248974+00:00',
+    continuous: false,
+  },
+};
+
+export const OnlyStartDate: Story = {
+  args: {
+    startDate: '2023-01-12T20:31:54.248974+00:00',
+    continuous: false,
+  },
+};
+
+export const OnlyEndDate: Story = {
+  args: {
+    endDate: '2023-01-12T20:31:54.248974+00:00',
+    continuous: false,
+  },
+};
+
+export const ContinousWithStartDate: Story = {
+  args: {
+    startDate: '2023-01-12T20:31:54.248974+00:00',
+    continuous: true,
+  },
+};
+
+export const ContinousWithEndDate: Story = {
+  args: {
+    endDate: '2023-01-12T20:31:54.248974+00:00',
+    continuous: true,
+  },
+};
+
+export const ContinousWithStartAndEndDate: Story = {
+  args: {
+    startDate: '2023-01-12T20:31:54.248974+00:00',
+    endDate: '2023-01-12T20:31:54.248974+00:00',
+    continuous: true,
+  },
+};

--- a/stories/mocks/actions.mocks.ts
+++ b/stories/mocks/actions.mocks.ts
@@ -14,6 +14,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: 66,
+    scheduleContinuous: true,
     categories: [
       {
         id: '1416',
@@ -71,6 +72,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'yellow050',
     },
     completion: null,
+    scheduleContinuous: true,
     categories: [
       {
         id: '4293',
@@ -146,6 +148,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '261',
@@ -194,6 +197,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '1416',
@@ -251,6 +255,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: 61,
+    scheduleContinuous: true,
     categories: [
       {
         id: '1412',
@@ -317,6 +322,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: true,
     categories: [
       {
         id: '1412',
@@ -383,6 +389,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'yellow050',
     },
     completion: null,
+    scheduleContinuous: true,
     categories: [
       {
         id: '1412',
@@ -440,6 +447,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'yellow050',
     },
     completion: null,
+    scheduleContinuous: true,
     categories: [
       {
         id: '1412',
@@ -497,6 +505,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '1412',
@@ -563,6 +572,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '1412',
@@ -620,6 +630,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '1416',
@@ -677,6 +688,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '1416',
@@ -734,6 +746,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: true,
     categories: [
       {
         id: '1412',
@@ -791,6 +804,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '1412',
@@ -866,6 +880,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'yellow050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '1414',
@@ -923,6 +938,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'yellow050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '1416',
@@ -980,6 +996,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'yellow050',
     },
     completion: 12,
+    scheduleContinuous: false,
     categories: [
       {
         id: '264',
@@ -1028,6 +1045,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'yellow050',
     },
     completion: null,
+    scheduleContinuous: true,
     categories: [
       {
         id: '1418',
@@ -1085,6 +1103,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '267',
@@ -1133,6 +1152,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '1409',
@@ -1190,6 +1210,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '1418',
@@ -1256,6 +1277,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '3041',
@@ -1313,6 +1335,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '4293',
@@ -1370,6 +1393,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: true,
     categories: [
       {
         id: '1417',
@@ -1427,6 +1451,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '1414',
@@ -1484,6 +1509,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '3041',
@@ -1541,6 +1567,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '3041',
@@ -1598,6 +1625,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'yellow050',
     },
     completion: null,
+    scheduleContinuous: true,
     categories: [
       {
         id: '1361',
@@ -1631,9 +1659,9 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       identifier: 'LATE',
     },
     implementationPhase: {
-      id: '16',
-      identifier: 'implementation',
-      name: 'Implementation',
+      id: '17',
+      identifier: 'completed',
+      name: 'Completed',
     },
     primaryOrg: null,
     mergedWith: null,
@@ -1664,6 +1692,7 @@ export const MOCK_ACTIONS: ActionCardFragment[] = [
       color: 'green050',
     },
     completion: null,
+    scheduleContinuous: false,
     categories: [
       {
         id: '3041',


### PR DESCRIPTION
Replace completed phase with "Continuous" in the UI if `action.scheduleContinuous===true`

<img width="1044" alt="Screenshot 2024-04-09 at 16 29 16" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/5c717cdd-3857-4eb9-a3f5-09b0e4d22a23">
