### PR TITLE
Revert some changes made within the last months to the action dashboard status donut

### DIFF
--- a/common/preprocess.ts
+++ b/common/preprocess.ts
@@ -86,15 +86,12 @@ const getStatusData = (
   actions: ActionListAction[],
   actionStatusSummaries: ActionStatusSummary[],
   theme: Theme,
-  unknownLabelText: string = '',
-  language: string
+  unknownLabelText: string = ''
 ) => {
   const progress: Progress = {
     values: [],
     labels: [],
     colors: [],
-    texts: [],
-    hoverTexts: [],
     good: 0,
     total: '',
   };
@@ -125,30 +122,9 @@ const getStatusData = (
         progress.good += statusCount;
       }
     }
-    if (identifier !== ActionStatusSummaryIdentifier.Undefined) {
-      totalCount += statusCount;
-    }
+    totalCount += statusCount;
   });
   progress.total = `${Math.round((progress.good / totalCount) * 100)}%`;
-  const numberFormat = new Intl.NumberFormat(language, {
-    maximumSignificantDigits: 2,
-    style: 'percent',
-  });
-  for (let i = 0; i < progress.values.length; i++) {
-    const label = progress.labels[i];
-    let hoverText: string, text: string;
-    if (label === unknownLabelText) {
-      text = '';
-      hoverText = label;
-    } else {
-      const value = progress.values[i];
-      const formattedValue = numberFormat.format(value / totalCount);
-      text = formattedValue;
-      hoverText = `${label}<br>${value}<br>${formattedValue}`;
-    }
-    progress.hoverTexts.push(hoverText);
-    progress.texts.push(text);
-  }
   return progress;
 };
 

--- a/components/dashboard/ActionStatusGraphs.tsx
+++ b/components/dashboard/ActionStatusGraphs.tsx
@@ -185,18 +185,11 @@ const ActionsStatusGraphs = ({
   const theme = useTheme();
   const plan = usePlan();
   const t = useTranslations();
-  const language = useLocale();
   const showTotals = theme.settings.dashboard.showActionDonutTotals ?? true;
 
   const progressData =
     shownDatasets.progress &&
-    getStatusData(
-      actions,
-      plan.actionStatusSummaries,
-      theme,
-      t('no-status'),
-      language
-    );
+    getStatusData(actions, plan.actionStatusSummaries, theme, t('no-status'));
 
   const timelinessData =
     shownDatasets.timeliness && getTimelinessData(actions, plan, theme, t);

--- a/components/graphs/StatusDonut.js
+++ b/components/graphs/StatusDonut.js
@@ -118,7 +118,7 @@ const StatusDonut = (props) => {
     width: 175,
     showlegend: false,
     paper_bgcolor: 'rgba(0,0,0,0)',
-    margin: { t: 0, b: 0, l: 0, r: 0 },
+    margin: { t: 0, b: 20, l: 0, r: 0 },
   };
   const config = {
     displaylogo: false,


### PR DESCRIPTION
1. Revert back to counting undefined statuses in all numbers. (They are a "bad" state assuming that a plan wants to use statuses in the first place. This will incentivize adding status. If a plan doesn't want to use statuses, the donut can be hidden).
2. Also show the percentage of undefined statuses again.

(unrelated) fix the clipping of the hover text elements in the plotly graph when the mouse is near the bottom of the graph 