### PR TITLE
Fix missing custom action dashboard table column names

### DIFF
--- a/fragments/action-list.fragment.ts
+++ b/fragments/action-list.fragment.ts
@@ -69,7 +69,34 @@ export const ACTION_TABLE_COLUMN_FRAGMENT = gql`
   fragment ActionTableColumnFragment on ActionListPage {
     dashboardColumns {
       __typename
-      ... on DashboardColumnInterface {
+      ... on IdentifierColumnBlock {
+        columnLabel
+      }
+      ... on NameColumnBlock {
+        columnLabel
+      }
+      ... on ImplementationPhaseColumnBlock {
+        columnLabel
+      }
+      ... on StatusColumnBlock {
+        columnLabel
+      }
+      ... on TasksColumnBlock {
+        columnLabel
+      }
+      ... on ResponsiblePartiesColumnBlock {
+        columnLabel
+      }
+      ... on IndicatorsColumnBlock {
+        columnLabel
+      }
+      ... on UpdatedAtColumnBlock {
+        columnLabel
+      }
+      ... on OrganizationColumnBlock {
+        columnLabel
+      }
+      ... on ImpactColumnBlock {
         columnLabel
       }
     }


### PR DESCRIPTION
There's an issue with the frontend querying on `DashboardColumnInterface` which means custom `columnLabel`s are ignored. For now, I've updated this query to query the column label on each block directly until we find the underlying issue.

Further discussion [in Slack](https://kausaltech.slack.com/archives/C01AZ2V3656/p1711356737098769)