### PR TITLE
Improve action page block consistency

### DIFF
--- a/components/actions/blocks/ActionRelatedActionsBlock.tsx
+++ b/components/actions/blocks/ActionRelatedActionsBlock.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { Row, Col } from 'reactstrap';
-import { ActionSection, SectionHeader } from 'components/actions/ActionContent';
+import { SectionHeader } from 'components/actions/ActionContent';
 import PopoverTip from 'components/common/PopoverTip';
 import ActionCard from 'components/actions/ActionCard';
 import { useTranslations } from 'next-intl';

--- a/components/actions/blocks/action-dependencies/ActionDependenciesBlock.tsx
+++ b/components/actions/blocks/action-dependencies/ActionDependenciesBlock.tsx
@@ -13,6 +13,7 @@ import { useTranslations } from 'next-intl';
 import { getActionTermContext } from '@/common/i18n';
 import { usePlan } from '@/context/plan';
 import PopoverTip from '@/components/common/PopoverTip';
+import { SectionHeader } from '../../ActionContent';
 
 type ActionGroup = {
   id: string;
@@ -65,10 +66,6 @@ const StyledWrapper = styled.div<{ $isVertical: boolean; $isSmall: boolean }>`
             }
           }
         `}
-`;
-
-const StyledTitle = styled.h4`
-  font-size: ${({ theme }) => theme.fontSizeBase};
 `;
 
 function isActionGroupActive(
@@ -143,7 +140,7 @@ export function ActionDependenciesBlock({
   return (
     <div>
       {showTitle && (
-        <StyledTitle>
+        <SectionHeader>
           {title || t('action-dependencies', getActionTermContext(plan))}
           {helpText && (
             <PopoverTip
@@ -151,9 +148,13 @@ export function ActionDependenciesBlock({
               identifier="action-dependencies-help"
             />
           )}
-        </StyledTitle>
+        </SectionHeader>
       )}
-      <StyledWrapper $isVertical={size === 'small'} $isSmall={size === 'small'}>
+      <StyledWrapper
+        className="mb-5"
+        $isVertical={size === 'small'}
+        $isSmall={size === 'small'}
+      >
         {actionGroups.map((actionGroup, i) => (
           <React.Fragment key={actionGroup.id}>
             <ActionDependenciesGroup


### PR DESCRIPTION
Makes titles and spacing consistent with other blocks on the action page

![image](https://github.com/kausaltech/kausal-watch-ui/assets/15343658/d125da77-a293-4bbd-8dc5-9707470eb018)
