### PR TITLE
Add cron schedule for nightly e2e test

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -14,8 +14,8 @@ on:
         description: 'Base url for backend API'
         required: true
         default: 'https://api.watch.kausal.tech/v1'
-      schedule:
-        - cron: '0 22 * * *' # 22:00 UTC, 01:00 EEST
+  schedule:
+    - cron: '0 22 * * 1-5' # 22:00 UTC, 01:00 EEST
 
 jobs:
   e2e_test:

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -14,6 +14,8 @@ on:
         description: 'Base url for backend API'
         required: true
         default: 'https://api.watch.kausal.tech/v1'
+      schedule:
+        - cron: '0 22 * * *' # 22:00 UTC, 01:00 EEST
 
 jobs:
   e2e_test:


### PR DESCRIPTION
Implement nightly scheduled run of e2e tests via GitHub Actions workflow (01:00 EEST)