### PR TITLE
Add analytics on site searches

### DIFF
--- a/common/search.ts
+++ b/common/search.ts
@@ -1,5 +1,6 @@
 import { ApolloClient, InMemoryCache, gql } from '@apollo/client';
 import { PlanContextFragment } from './__generated__/graphql';
+import { trackSearch } from '@/components/MatomoAnalytics';
 
 const GET_AUTOCOMPLETE_RESULTS = gql`
   query GetAutocompleteResults($plan: ID!, $term: String!) {
@@ -62,6 +63,9 @@ class WatchSearchAPIConnector {
       },
     });
     const hits = res?.data?.search?.hits;
+
+    trackSearch(searchTerm, false, hits?.length ?? 0);
+
     if (!hits) return [];
     const results = hits.map((hit) => {
       return {

--- a/components/MatomoAnalytics.tsx
+++ b/components/MatomoAnalytics.tsx
@@ -46,6 +46,27 @@ function getMatomoConfig(matomoAnalyticsUrl?: string) {
   return null;
 }
 
+export function trackSearch(
+  query: string,
+  isSearchingOtherPlans: boolean,
+  results: number
+) {
+  if (!window._paq) {
+    return;
+  }
+
+  // https://developer.matomo.org/guides/tracking-javascript-guide#internal-search-tracking
+  window._paq.push([
+    'trackSiteSearch',
+    // Search keyword searched for
+    query,
+    // Search category selected in your search engine. If you do not need this, set to false
+    isSearchingOtherPlans ? 'Other plans' : false,
+    // Number of results in the Search results page. Zero indicates a 'No Result Search Keyword'. Set to false if you don't know
+    results,
+  ]);
+}
+
 export function MatomoAnalytics({ matomoAnalyticsUrl }: Props) {
   const pathname = usePathname();
   const searchParams = useSearchParams().toString();

--- a/components/common/NavbarSearch.js
+++ b/components/common/NavbarSearch.js
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import { InputGroup } from 'reactstrap';
 import { usePopper } from 'react-popper';

--- a/components/common/SearchView.js
+++ b/components/common/SearchView.js
@@ -21,6 +21,7 @@ import PlanChip from 'components/plans/PlanChip';
 import { usePlan } from 'context/plan';
 import ContentLoader from './ContentLoader';
 import { useTranslations } from 'next-intl';
+import { trackSearch } from '../MatomoAnalytics';
 
 const SEARCH_QUERY = gql`
   query SearchQuery(
@@ -251,6 +252,17 @@ function SearchResults({ search }) {
       clientUrl: plan.viewUrl,
     },
   });
+
+  useEffect(() => {
+    if (search.q && data?.search?.hits) {
+      trackSearch(
+        search.q,
+        search.onlyOtherPlans,
+        data.search.hits.length || 0
+      );
+    }
+  }, [search, data]);
+
   if (error) {
     return (
       <ResultsHeader>


### PR DESCRIPTION
This fires a search event in Matomo whenever a visitor uses the plan search functionality

https://developer.matomo.org/guides/tracking-javascript-guide#internal-search-tracking



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206034053800035