### PR TITLE
Feat/gh secrets for e2e tests

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -5,7 +5,7 @@ on:
       plan_identifiers:
         description: 'Comma separated list of plan identifiers'
         required: true
-        default: ' akaa-ilmasto, boroondara-cap, bremen-klima, carmel-cap, denmark-sap, durham-ca-cap, espoo-ilmasto, fi-covid, fl-hollywood-sap, greentransition, hame-ilmasto, helsinki-kierto, helsinki-kierto-2023, helsinki-lumo, holbaek-cap, indigoshire-erp, kingston-cap, klima-potsdam, klima-winterthur, konstanz-klima, lahti-ilmasto, leichlingen, leichlingen-klima, leichlingen-mobilitaet, liiku, longmont-bbe, longmont-carr, longmont-envision, longmont-indicators, longmont-sca, longmont-transportation, lpr-ilmasto, lpr-kestavyys, lpr-kierto, palkane-ilmasto, pirkkala-ilmasto, riga-secap, san-diego-cap, saskatoon-lec, sca-cli, stevenage-cap, stpaul-carp, sunnydale, surrey-ccas, tampere-ilmasto, tampere-lumo, urjala-ilmasto, valkeakoski-ilmasto, viitasaari-ilmasto, waterloo-twr'
+        default: ${{ secrets.TEST_PLAN_IDENTIFIERS }}
       frontend_base_url:
         description: 'Base url for environment to run tests against'
         required: true
@@ -56,9 +56,9 @@ jobs:
       - name: Running Playwright e2e tests
         run: node_modules/.bin/playwright test
         env:
-          TEST_PLAN_IDENTIFIERS: ${{ github.event.inputs.plan_identifiers }}
-          TEST_PAGE_BASE_URL: ${{ github.event.inputs.frontend_base_url }}
-          APLANS_API_BASE_URL: ${{ github.event.inputs.backend_base_url }}
+          TEST_PLAN_IDENTIFIERS: ${{ secrets.TEST_PLAN_IDENTIFIERS }}
+          TEST_PAGE_BASE_URL: ${{ github.event.inputs.frontend_base_url || 'http://{planId}.watch.staging.kausal.tech'}}
+          APLANS_API_BASE_URL: ${{ github.event.inputs.backend_base_url || 'https://api.watch.kausal.tech/v1'}}
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -5,7 +5,7 @@ on:
       plan_identifiers:
         description: 'Comma separated list of plan identifiers'
         required: true
-        default: ${{ secrets.TEST_PLAN_IDENTIFIERS }}
+        default: 'sunnydale'
       frontend_base_url:
         description: 'Base url for environment to run tests against'
         required: true
@@ -52,6 +52,17 @@ jobs:
 
       - name: Playwright install
         run: node_modules/.bin/playwright install --with-deps
+
+      - name: Set dynamic environment variables
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "PLAN_IDENTIFIERS=${{ secrets.TEST_PLAN_IDENTIFIERS }}" >> $GITHUB_ENV
+            echo "FRONTEND_BASE_URL=http://{plan_id}.watch.staging.kausal.tech" >> $GITHUB_ENV
+          else
+            echo "PLAN_IDENTIFIERS=${{ github.event.inputs.plan_identifiers }}" >> $GITHUB_ENV
+            echo "FRONTEND_BASE_URL=${{ github.event.inputs.frontend_base_url }}" >> $GITHUB_ENV
+          fi
+          echo "APLANS_API_BASE_URL=${{ github.event.inputs.backend_base_url || 'https://api.watch.kausal.tech/v1' }}" >> $GITHUB_ENV
 
       - name: Running Playwright e2e tests
         run: node_modules/.bin/playwright test

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -53,23 +53,21 @@ jobs:
       - name: Playwright install
         run: node_modules/.bin/playwright install --with-deps
 
-      - name: Set dynamic environment variables
+      - name: Set TEST_PLAN_IDENTIFIERS for each job
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            echo "PLAN_IDENTIFIERS=${{ secrets.TEST_PLAN_IDENTIFIERS }}" >> $GITHUB_ENV
-            echo "FRONTEND_BASE_URL=http://{plan_id}.watch.staging.kausal.tech" >> $GITHUB_ENV
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "TEST_PLAN_IDENTIFIERS=${{ github.event.inputs.plan_identifiers || 'sunnydale' }}" >> $GITHUB_ENV
           else
-            echo "PLAN_IDENTIFIERS=${{ github.event.inputs.plan_identifiers }}" >> $GITHUB_ENV
-            echo "FRONTEND_BASE_URL=${{ github.event.inputs.frontend_base_url }}" >> $GITHUB_ENV
+            echo "TEST_PLAN_IDENTIFIERS=${{ secrets.TEST_PLAN_IDENTIFIERS }}" >> $GITHUB_ENV
           fi
+          echo "FRONTEND_BASE_URL=${{ github.event.inputs.frontend_base_url || 'http://sunnydale.watch.staging.kausal.tech' }}" >> $GITHUB_ENV
           echo "APLANS_API_BASE_URL=${{ github.event.inputs.backend_base_url || 'https://api.watch.kausal.tech/v1' }}" >> $GITHUB_ENV
 
       - name: Running Playwright e2e tests
-        run: node_modules/.bin/playwright test
+        run: node_modules/.bin/playwright test --plan-identifiers="${{ env.TEST_PLAN_IDENTIFIERS }}"
         env:
-          TEST_PLAN_IDENTIFIERS: ${{ secrets.TEST_PLAN_IDENTIFIERS }}
-          TEST_PAGE_BASE_URL: ${{ github.event.inputs.frontend_base_url || 'http://{planId}.watch.staging.kausal.tech'}}
-          APLANS_API_BASE_URL: ${{ github.event.inputs.backend_base_url || 'https://api.watch.kausal.tech/v1'}}
+          TEST_PAGE_BASE_URL: ${{ env.FRONTEND_BASE_URL }}
+          APLANS_API_BASE_URL: ${{ env.APLANS_API_BASE_URL }}
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -15,7 +15,7 @@ on:
         required: true
         default: 'https://api.watch.kausal.tech/v1'
   schedule:
-    - cron: '0 22 * * 1-5' # 22:00 UTC, 01:00 EEST
+    - cron: '0 21 * * 1-5' # 21:00 UTC, 00:00 EEST
 
 jobs:
   e2e_test:

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -64,8 +64,9 @@ jobs:
           echo "APLANS_API_BASE_URL=${{ github.event.inputs.backend_base_url || 'https://api.watch.kausal.tech/v1' }}" >> $GITHUB_ENV
 
       - name: Running Playwright e2e tests
-        run: node_modules/.bin/playwright test --plan-identifiers="${{ env.TEST_PLAN_IDENTIFIERS }}"
+        run: node_modules/.bin/playwright test
         env:
+          TEST_PLAN_IDENTIFIERS: ${{ env.TEST_PLAN_IDENTIFIERS }}
           TEST_PAGE_BASE_URL: ${{ env.FRONTEND_BASE_URL }}
           APLANS_API_BASE_URL: ${{ env.APLANS_API_BASE_URL }}
 

--- a/e2e-tests/context.ts
+++ b/e2e-tests/context.ts
@@ -322,7 +322,9 @@ export function getIdentifiersToTest(): string[] {
 }
 
 export function getPageBaseUrlToTest(planId: string): string {
-  const val =
-    process.env.TEST_PAGE_BASE_URL || `http://{planId}.localhost:3000`;
-  return val.replace('{planId}', planId);
+  let baseUrl =
+    process.env.TEST_PAGE_BASE_URL ||
+    `http://{planId}.watch.staging.kausal.tech`;
+  baseUrl = baseUrl.replace('{planId}', planId);
+  return baseUrl;
 }


### PR DESCRIPTION
* Added a GitHub Secret to securely store the list of plan identificators;
* Updated the getPageBaseUrlToTest function to dynamically construct the base URL for each plan;
* Updated the scheduled test time to run at midnight