### PR TITLE
Add stream field error boundary

### DIFF
--- a/components/common/ErrorBoundary.tsx
+++ b/components/common/ErrorBoundary.tsx
@@ -1,0 +1,35 @@
+import { Component, ReactNode } from 'react';
+import { captureException } from '@sentry/nextjs';
+
+type Props = {
+  fallback: ReactNode;
+  children: ReactNode;
+  errorExtras?: { [key: string]: string };
+};
+
+type State = {
+  hasError: boolean;
+};
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error) {
+    captureException(error, { extra: this.props.errorExtras });
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}

--- a/components/common/ErrorPage.tsx
+++ b/components/common/ErrorPage.tsx
@@ -8,13 +8,13 @@ import { Card, CardBody, Container, Row, Col } from 'reactstrap';
 import Button from '@/components/common/Button';
 import Link from 'next/link';
 
-const ErrorBackground = styled.div`
+const ErrorBackground = styled.div<{ isFullPage?: boolean }>`
   background-color: ${(props) => props.theme.brandDark};
-  min-height: 800px;
+  min-height: ${({ isFullPage }) => (isFullPage ? '800px' : undefined)};
+  padding: 5rem 0;
 `;
 
 const StyledCard = styled(Card)`
-  margin-top: 5rem;
   text-align: center;
   width: 100%;
   transition: all 0.5s ease;
@@ -23,10 +23,6 @@ const StyledCard = styled(Card)`
   border-radius: ${(props) => props.theme.cardBorderRadius};
   background-color: ${(props) => props.theme.themeColors.white};
 
-  h2 {
-    margin-bottom: 2rem;
-  }
-
   svg {
     width: 4rem;
     margin-bottom: 2rem;
@@ -34,7 +30,21 @@ const StyledCard = styled(Card)`
   }
 `;
 
-export function ErrorPage({ message }: { message?: string }) {
+const StyledTitle = styled.h1`
+  margin-bottom: 1rem;
+`;
+
+const StyledSubtitle = styled.h4`
+  font-weight: ${({ theme }) => theme.fontWeightBase};
+  color: ${({ theme }) => theme.textColor.secondary};
+`;
+
+type Props = {
+  message?: string;
+  type?: 'page' | 'block';
+};
+
+export function ErrorPage({ message, type = 'page' }: Props) {
   const t = useTranslations();
 
   const errorIcon = (
@@ -47,19 +57,31 @@ export function ErrorPage({ message }: { message?: string }) {
   );
 
   return (
-    <ErrorBackground className="mb-5">
+    <ErrorBackground isFullPage={type === 'page'}>
       <Container>
         <Row>
           <Col md={{ size: 6, offset: 3 }}>
             <StyledCard>
               <CardBody>
                 {errorIcon}
-                <h1>{message || t('error-occurred')}</h1>
-                <Link href="/">
-                  <Button outline color="dark" size="sm">
-                    {t('return-to-front')}
-                  </Button>
-                </Link>
+
+                <StyledTitle as={type === 'page' ? 'h1' : 'h2'}>
+                  {message || t('error-occurred')}
+                </StyledTitle>
+
+                {type === 'page' && (
+                  <Link href="/">
+                    <Button outline color="dark" size="sm">
+                      {t('return-to-front')}
+                    </Button>
+                  </Link>
+                )}
+
+                {type === 'block' && (
+                  <StyledSubtitle>
+                    {t('content-could-not-be-displayed')}
+                  </StyledSubtitle>
+                )}
               </CardBody>
             </StyledCard>
           </Col>

--- a/components/common/StreamField.tsx
+++ b/components/common/StreamField.tsx
@@ -28,6 +28,8 @@ import type { StreamFieldFragmentFragment } from 'common/__generated__/graphql';
 import CartographyVisualisationBlock from 'components/contentblocks/CartographyVisualisationBlock';
 import styled, { useTheme } from 'styled-components';
 import { STREAM_FIELD_FRAGMENT } from '@/fragments/stream-field.fragment';
+import { ErrorBoundary } from './ErrorBoundary';
+import { ErrorPage } from './ErrorPage';
 
 enum EmbedProvider {
   YOUTUBE = 'YouTube',
@@ -394,15 +396,23 @@ function StreamField(props: StreamFieldProps) {
   return (
     <div className={`custom-${page.slug}`}>
       {blocks.map((block, index) => (
-        <StreamFieldBlock
-          id={`section-${index + 1}`}
-          block={block}
-          page={page}
+        <ErrorBoundary
           key={block.id}
-          color={color}
-          hasSidebar={hasSidebar}
-          columnProps={columnProps}
-        />
+          fallback={<ErrorPage type="block" />}
+          errorExtras={{
+            type: 'StreamFieldBlock',
+            block: JSON.stringify(block),
+          }}
+        >
+          <StreamFieldBlock
+            id={`section-${index + 1}`}
+            block={block}
+            page={page}
+            color={color}
+            hasSidebar={hasSidebar}
+            columnProps={columnProps}
+          />
+        </ErrorBoundary>
       ))}
     </div>
   );

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -162,5 +162,6 @@
     "open": "åben",
     "select-sector-for-actions": "Vælg en emissionssektor for at se relaterede handlinger",
     "no-phase": "Ingen fase",
-    "no-status": "Ingen status"
+    "no-status": "Ingen status",
+    "content-could-not-be-displayed": "Vi kan i øjeblikket ikke vise dette indhold. Prøv venligst at genindlæse siden. En rapport er blevet sendt til vores team for at undersøge problemet."
 }

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -171,5 +171,6 @@
     "expand-row": "Zeile erweitern",
     "ui-sign-in": "Anmelden",
     "ui-sign-out": "Abmelden",
-    "action-versions": "Maßnahmen-Versionen"
+    "action-versions": "Maßnahmen-Versionen",
+    "content-could-not-be-displayed": "Wir können diesen Inhalt im Moment nicht anzeigen. Bitte versuchen Sie, die Seite neu zu laden. Ein Bericht wurde an unser Team gesendet, um das Problem zu untersuchen."
 }

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -171,5 +171,6 @@
     "expand-row": "Expand row",
     "ui-sign-in": "Sign in",
     "ui-sign-out": "Sign out",
-    "action-versions": "Action versions"
+    "action-versions": "Action versions",
+    "content-could-not-be-displayed": "We're unable to display this content at the moment. Please try refreshing the page. A report has been sent to our team to investigate the issue."
 }

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -161,5 +161,6 @@
     "no-action-data-for-report": "El informe no contiene datos para esta acción.",
     "select-sector-for-actions": "Seleccione un sector de emisión para ver acciones relacionadas",
     "no-phase": "Sin fase",
-    "no-status": "Sin estado"
+    "no-status": "Sin estado",
+    "content-could-not-be-displayed": "No podemos mostrar este contenido en este momento. Por favor, intente actualizar la página. Se ha enviado un informe a nuestro equipo para investigar el problema."
 }

--- a/locales/fi/common.json
+++ b/locales/fi/common.json
@@ -158,5 +158,6 @@
     "definition": "Selite",
     "select-sector-for-actions": "Valitse päästösektori nähdäksesi siihen liittyvät toimenpiteet",
     "no-phase": "Ei vaihetta",
-    "no-status": "Ei tilaa"
+    "no-status": "Ei tilaa",
+    "content-could-not-be-displayed": "Emme voi näyttää tätä sisältöä tällä hetkellä. Yritä päivittää sivu. Raportti on lähetetty tiimillemme ongelman selvittämiseksi."
 }

--- a/locales/sv/common.json
+++ b/locales/sv/common.json
@@ -165,5 +165,6 @@
     "no-phase": "Ingen fas",
     "filter-all-statuses": "Alla statusar",
     "filter-status": "Status",
-    "filter-status-help": "Visa åtgärder med vald status"
+    "filter-status-help": "Visa åtgärder med vald status",
+    "content-could-not-be-displayed": "Vi kan inte visa detta innehåll för tillfället. Försök att uppdatera sidan. En rapport har skickats till vårt team för att undersöka problemet."
 }


### PR DESCRIPTION
This wraps all stream field blocks in an error boundary to ensure errors don't bubble up to the page error boundary. 

|  Before | After |
| -- | -- |
| ![image](https://github.com/kausaltech/kausal-watch-ui/assets/15343658/247aa565-e1a9-4b42-9c6d-36c9ce54da7b) | ![image](https://github.com/kausaltech/kausal-watch-ui/assets/15343658/9965327e-43c4-4961-9dfa-1db77d3f151e) |


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206977791925325