### PR TITLE
Fix action dependencies rendered by action list blocks

### DIFF
--- a/components/actions/ActionCard.tsx
+++ b/components/actions/ActionCard.tsx
@@ -325,6 +325,10 @@ function ActionCard({
     return 'IN_HERO';
   }
 
+  const actionDependencyGroups = showActionDependencies
+    ? mapActionToDependencyGroups(action, plan.actionDependencyRoles)
+    : [];
+
   const identifierPosition = getidentifierPosition(showPlan, variant, plan);
   const statusColor = getStatusColorForAction(action, plan, theme);
 
@@ -404,34 +408,33 @@ function ActionCard({
         />
       )}
 
-      {variant === 'primary' && showActionDependencies && (
-        <>
-          <StyledActionDependencyIconWrapper
-            id={getDependencyTooltipId(action.id)}
-          >
-            <Icon name="action-dependency" width="24px" height="24px" />
-          </StyledActionDependencyIconWrapper>
-          <StyledTooltip
-            target={getDependencyTooltipId(action.id)}
-            role="tooltip"
-            autohide={false}
-            placement="top"
-            id={`tt-content-${getDependencyTooltipId(action.id)}`}
-            isOpen={tooltipOpen}
-            toggle={toggle}
-          >
-            <ActionDependenciesBlock
-              size="small"
-              activeActionId={action.id}
-              actionGroups={mapActionToDependencyGroups(
-                action,
-                plan.actionDependencyRoles
-              )}
-              showTitle
-            />
-          </StyledTooltip>
-        </>
-      )}
+      {variant === 'primary' &&
+        showActionDependencies &&
+        !!actionDependencyGroups.length && (
+          <>
+            <StyledActionDependencyIconWrapper
+              id={getDependencyTooltipId(action.id)}
+            >
+              <Icon name="action-dependency" width="24px" height="24px" />
+            </StyledActionDependencyIconWrapper>
+            <StyledTooltip
+              target={getDependencyTooltipId(action.id)}
+              role="tooltip"
+              autohide={false}
+              placement="top"
+              id={`tt-content-${getDependencyTooltipId(action.id)}`}
+              isOpen={tooltipOpen}
+              toggle={toggle}
+            >
+              <ActionDependenciesBlock
+                size="small"
+                activeActionId={action.id}
+                actionGroups={actionDependencyGroups}
+                showTitle
+              />
+            </StyledTooltip>
+          </>
+        )}
     </ActionCardElement>
   );
 

--- a/components/contentblocks/ActionListBlock.tsx
+++ b/components/contentblocks/ActionListBlock.tsx
@@ -12,6 +12,7 @@ import ContentLoader from 'components/common/ContentLoader';
 import ErrorMessage from 'components/common/ErrorMessage';
 import PlanContext, { usePlan } from 'context/plan';
 import { useTranslations } from 'next-intl';
+import { mapActionsToExpandDependencies } from '@/utils/actions.utils';
 
 const GET_ACTION_LIST_FOR_BLOCK = gql`
   query GetActionListForBlock($plan: ID!, $category: ID, $clientUrl: String) {
@@ -62,13 +63,16 @@ const ActionListBlock = (props) => {
   }
   const groupBy = plan.primaryOrgs.length > 0 ? 'primaryOrg' : 'none';
 
+  const actionsWithDependencies =
+    planActions?.map(mapActionsToExpandDependencies) ?? [];
+
   const heading = t('actions', getActionTermContext(plan));
   return (
     <ActionListSection id={id}>
       <Container>
         {heading && <SectionHeader>{heading}</SectionHeader>}
         <ActionCardList
-          actions={planActions}
+          actions={actionsWithDependencies}
           groupBy={groupBy}
           showOtherCategory={false}
         />

--- a/components/dashboard/ActionList.tsx
+++ b/components/dashboard/ActionList.tsx
@@ -45,6 +45,7 @@ import {
   ALL_ACTION_LIST_FILTERS,
 } from '@/fragments/action-list.fragment';
 import { useSuspenseQuery } from '@apollo/experimental-nextjs-app-support/ssr';
+import { mapActionsToExpandDependencies } from '@/utils/actions.utils';
 
 // Legacy exports preserved after migrating types to dashboard.types
 export * from './dashboard.types';
@@ -474,30 +475,8 @@ const ActionList = (props: ActionListProps) => {
     [onFilterChange]
   );
 
-  /**
-   * Map over all action dependency relationships and add the action object to
-   * the relationship. Required because we only query the id of an action in a relationship.
-   */
-  const actionsWithDependencies = actions?.map((action) =>
-    !!action.dependencyRole && !!action.allDependencyRelationships?.length
-      ? {
-          ...action,
-          allDependencyRelationships: action.allDependencyRelationships.map(
-            (relationship) => ({
-              ...relationship,
-              preceding:
-                actions.find(
-                  (action) => action.id === relationship.preceding.id
-                ) ?? null,
-              dependent:
-                actions.find(
-                  (action) => action.id === relationship.dependent.id
-                ) ?? null,
-            })
-          ),
-        }
-      : action
-  );
+  const actionsWithDependencies =
+    actions?.map(mapActionsToExpandDependencies) ?? [];
 
   const actionsWithRps = mapResponsibleParties<
     ActionListAction,

--- a/utils/actions.utils.ts
+++ b/utils/actions.utils.ts
@@ -1,0 +1,30 @@
+import { ActionListAction } from '@/components/dashboard/dashboard.types';
+
+/**
+ * Map over all action dependency relationships and add the action object to
+ * the relationship. Required because we only query the id of an action in a relationship.
+ */
+export function mapActionsToExpandDependencies(
+  action: ActionListAction,
+  index: number,
+  actions: ActionListAction[]
+) {
+  return action.dependencyRole && action.allDependencyRelationships?.length
+    ? {
+        ...action,
+        allDependencyRelationships: action.allDependencyRelationships.map(
+          (relationship) => ({
+            ...relationship,
+            preceding:
+              actions.find(
+                (action) => action.id === relationship.preceding.id
+              ) ?? null,
+            dependent:
+              actions.find(
+                (action) => action.id === relationship.dependent.id
+              ) ?? null,
+          })
+        ),
+      }
+    : action;
+}


### PR DESCRIPTION
Fixes an issue where action dependencies aren't rendered in `ActionListBlock`s. We only query the action id on action dependencies and we then need to add the entire action object from the actions array by id – this part was missing from the `ActionListBlock`.

| Before | After |
| -- | -- |
| <img width="831" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/e56dc353-720f-4134-a0ac-0e7293e648b0"> | <img width="830" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/33d7ee13-9600-41c7-8c07-12df55635702"> |

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206999596040643