### PR TITLE
Implement conditional visibility for ActionDescriptionBlock header

### DIFF
--- a/components/actions/blocks/ActionDescriptionBlock.tsx
+++ b/components/actions/blocks/ActionDescriptionBlock.tsx
@@ -1,14 +1,21 @@
 import { ActionSection } from 'components/actions/ActionContent';
 import RichText from 'components/common/RichText';
 import { useTranslations } from 'next-intl';
+import { useTheme } from 'styled-components';
 
 const ActionDescriptionBlock = (props) => {
   const { content } = props;
   const t = useTranslations();
+  const theme = useTheme();
+
+  const headerClass =
+    content && theme.settings.showActionDescriptionHeader
+      ? ''
+      : 'visually-hidden';
 
   return (
     <ActionSection className="text-content">
-      <h2 className="visually-hidden">{t('action-description')}</h2>
+      <h2 className={headerClass}>{t('action-description')}</h2>
       <RichText html={content} />
     </ActionSection>
   );


### PR DESCRIPTION
Requested by Ludwigsburg

Added logic to ActionDescriptionBlock to control visibility of the header based on content presence and theme. 

Related Asana task https://app.asana.com/0/1206017643443542/1207020415902010/f
Corresponding PR https://github.com/kausaltech/kausal-themes/pull/28