### PR TITLE
Show organization ancestors in contact person details only conditionally

### DIFF
--- a/components/actions/ContactPerson.js
+++ b/components/actions/ContactPerson.js
@@ -100,7 +100,7 @@ const GET_CONTACT_DETAILS = gql`
 `;
 
 function ContactDetails(props) {
-  const { id } = props;
+  const { id, plan } = props;
   const t = useTranslations();
   const { loading, error, data } = useQuery(GET_CONTACT_DETAILS, {
     variables: { id },
@@ -130,16 +130,17 @@ function ContactDetails(props) {
 
   return (
     <div className="mt-2">
-      {orgAncestors.length > 1 && (
-        <PersonOrg>
-          {orgAncestors.map((item, idx) => (
-            <span key={item.key}>
-              {item.name}
-              {idx < orgAncestors.length - 1 ? ' / ' : ''}
-            </span>
-          ))}
-        </PersonOrg>
-      )}
+      {plan.features.contactPersonsShowOrganizationAncestors &&
+        orgAncestors.length > 1 && (
+          <PersonOrg>
+            {orgAncestors.map((item, idx) => (
+              <span key={item.key}>
+                {item.name}
+                {idx < orgAncestors.length - 1 ? ' / ' : ''}
+              </span>
+            ))}
+          </PersonOrg>
+        )}
       <Address>
         {t('email')}: <a href={`mailto:${person.email}`}>{person.email}</a>
       </Address>
@@ -188,7 +189,7 @@ function ContactPerson(props) {
           </CollapseButton>
         )}
         <Collapse isOpen={collapse} id={`contact-${person.id}`}>
-          {collapse && <ContactDetails id={person.id} />}
+          {collapse && <ContactDetails id={person.id} plan={plan} />}
         </Collapse>
       </PersonDetails>
     </Person>

--- a/queries/get-plan.ts
+++ b/queries/get-plan.ts
@@ -166,6 +166,7 @@ const GET_PLAN_CONTEXT = gql`
       allowPublicSiteLogin
       hasActionContactPersonRoles
       contactPersonsPublicData
+      contactPersonsShowOrganizationAncestors
       enableSearch
       hasActionIdentifiers
       hasActionOfficialName


### PR DESCRIPTION
Hollywood wants this. (See [Asana task](https://app.asana.com/0/1205530220248804/1202900955351281/f).) This is the UI part that uses a new `PlanFeatures` field. The corresponding backend part is here: https://github.com/kausaltech/kausal-watch-private/pull/172
The backend must obviously be deployed before the UI.