### PR TITLE
Append locale to URL when navigating from relative links

### DIFF
--- a/components/common/GlobalNav.tsx
+++ b/components/common/GlobalNav.tsx
@@ -26,6 +26,7 @@ import NavbarSearch from './NavbarSearch';
 import { usePlan } from 'context/plan';
 import { isServer } from 'common/environment';
 import { useTranslations } from 'next-intl';
+import { useLocale } from 'next-intl';
 
 const baseFixedNavStyles = css`
   @keyframes slide-in {
@@ -487,7 +488,17 @@ function GlobalNav(props) {
   );
   const hideLogoOnMobile = !!(theme.navTitleVisible && siblings.length);
 
-  const rootLink = plan.parent ? plan.parent?.viewUrl : '/';
+  const locale = useLocale();
+  let rootLink = '/';
+
+  if (plan.parent && plan.parent?.viewUrl) {
+    rootLink = plan.parent?.viewUrl;
+    const shouldAppendLocale = locale !== plan.primaryLanguage;
+    if (shouldAppendLocale) {
+      rootLink = `${plan.parent?.viewUrl}/${locale}/`;
+    }
+  }
+
   const logoLink = theme?.footerLogoLink || rootLink;
 
   return (

--- a/components/common/GlobalNav.tsx
+++ b/components/common/GlobalNav.tsx
@@ -25,8 +25,18 @@ import LanguageSelector from './LanguageSelector';
 import NavbarSearch from './NavbarSearch';
 import { usePlan } from 'context/plan';
 import { isServer } from 'common/environment';
-import { useTranslations } from 'next-intl';
-import { useLocale } from 'next-intl';
+import { useTranslations, useLocale } from 'next-intl';
+
+const getRootLink = (plan, locale, primaryLanguage) => {
+  if (plan.parent && plan.parent.viewUrl) {
+    const shouldAppendLocale = locale !== primaryLanguage;
+    if (shouldAppendLocale) {
+      return `${plan.parent.viewUrl}/${locale}/`;
+    }
+    return plan.parent.viewUrl;
+  }
+  return '/';
+};
 
 const baseFixedNavStyles = css`
   @keyframes slide-in {
@@ -445,7 +455,9 @@ const useStickyNavigation = (isStickyEnabled: boolean = false) => {
 function GlobalNav(props) {
   const t = useTranslations();
   const theme = useTheme();
+  const locale = useLocale();
   const plan = usePlan();
+  const rootLink = getRootLink(plan, locale, plan.primaryLanguage);
   const {
     siteTitle,
     ownerName = '',
@@ -487,17 +499,6 @@ function GlobalNav(props) {
     (pl) => pl.id !== plan.parent?.id
   );
   const hideLogoOnMobile = !!(theme.navTitleVisible && siblings.length);
-
-  const locale = useLocale();
-  let rootLink = '/';
-
-  if (plan.parent && plan.parent?.viewUrl) {
-    rootLink = plan.parent?.viewUrl;
-    const shouldAppendLocale = locale !== plan.primaryLanguage;
-    if (shouldAppendLocale) {
-      rootLink = `${plan.parent?.viewUrl}/${locale}/`;
-    }
-  }
 
   const logoLink = theme?.footerLogoLink || rootLink;
 


### PR DESCRIPTION
A bug occurs in a multiplan with language selection: when navigating from child plans (where a language other than the primary is selected) to the parent plan via the home link, the locale is dropped from the URL, causing users to revert to the primary language.

Appended the locale to the absolute URL path when navigating from relative links.

Related Asana task https://app.asana.com/0/1203773030383185/1206977267986284/f