### PR TITLE
Add continuous actions to phase summary graphs

### DIFF
--- a/common/preprocess.ts
+++ b/common/preprocess.ts
@@ -150,6 +150,7 @@ const getPhaseData = (
      palette usable for the full graph.  Hence we use these default
      colors for all phases.
    */
+  phaseColors.reverse();
   if (phaseColors.length != phases.length) {
     phaseColors = [
       theme.graphColors.green090,
@@ -196,6 +197,12 @@ const getPhaseData = (
     theme.graphColors.grey010,
     false
   );
+  const continuousActionsDonutSector: DonutSector = new DonutSector(
+    // Donut sector for completed actions with scheduleContinuous = Continuous phase actions
+    t('action-continuous'),
+    theme.graphColors.grey090,
+    true
+  );
 
   for (const action of actions) {
     const statusSummary = getStatusSummary(plan, action.statusSummary);
@@ -208,12 +215,19 @@ const getPhaseData = (
       phaselessActionsDonutSector.increment();
       continue;
     }
-    phaseDonutSectorsByIdentifier
-      .get(action.implementationPhase.identifier)
-      ?.increment();
+    if (
+      action.scheduleContinuous === true &&
+      action.implementationPhase.identifier === 'completed'
+    )
+      continuousActionsDonutSector.increment();
+    else
+      phaseDonutSectorsByIdentifier
+        .get(action.implementationPhase.identifier)
+        ?.increment();
   }
 
   const allSectors: DonutSector[] = [
+    continuousActionsDonutSector,
     ...phaseDonutSectorsByIdentifier.values(),
     phaselessActionsDonutSector,
     inactiveActionsDonutSector,

--- a/components/contentblocks/ActionStatusGraphsBlock.tsx
+++ b/components/contentblocks/ActionStatusGraphsBlock.tsx
@@ -19,6 +19,7 @@ const GET_ACTION_LIST_FOR_GRAPHS = gql`
   query GetActionListForGraphs($plan: ID!, $categoryId: ID) {
     planActions(plan: $plan, category: $categoryId) {
       color
+      scheduleContinuous
       statusSummary {
         identifier
       }
@@ -39,12 +40,8 @@ interface Props
   categoryId?: string;
 }
 
-const ActionStatusGraphsBlock = ({
-  id = '',
-  categoryId,
-  columnProps,
-  ...graphsProps
-}: Props) => {
+const ActionStatusGraphsBlock = (props: Props) => {
+  const { id = '', categoryId, columnProps, ...graphsProps } = props;
   const plan = usePlan();
   const t = useTranslations();
   const theme = useTheme();


### PR DESCRIPTION
Add completed continuous actions to phase summary graphs
Fix reversed phase color order in some phase status bars

<img width="256" alt="Screenshot 2024-04-19 at 17 21 35" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/6800dd2f-b83b-4866-bfd0-7c5ffdc03f56">
<img width="734" alt="Screenshot 2024-04-19 at 17 21 17" src="https://github.com/kausaltech/kausal-watch-ui/assets/664877/3e1a6579-6822-4f72-b33d-5d1140045c7f">
