### PR TITLE
Make minor improvements regarding accessibility

### DIFF
--- a/components/actions/ContactPerson.js
+++ b/components/actions/ContactPerson.js
@@ -36,13 +36,13 @@ const PersonDetails = styled.div`
   }
 `;
 
-const Name = styled.p`
+const Name = styled.div`
   line-height: ${(props) => props.theme.lineHeightSm};
   margin-bottom: 0.5em;
   font-weight: ${(props) => props.theme.fontWeightBold};
 `;
 
-const PersonRole = styled.p`
+const PersonRole = styled.div`
   margin-bottom: 0.5em;
   color: ${(props) => props.theme.themeColors.dark};
   font-size: ${(props) => props.theme.fontSizeSm};
@@ -51,7 +51,7 @@ const PersonRole = styled.p`
   line-height: ${(props) => props.theme.lineHeightSm};
 `;
 
-const PersonOrg = styled.p`
+const PersonOrg = styled.div`
   margin-bottom: 1em;
   color: ${(props) => props.theme.themeColors.dark};
   font-size: ${(props) => props.theme.fontSizeSm};

--- a/components/actions/PhaseTimeline.tsx
+++ b/components/actions/PhaseTimeline.tsx
@@ -68,7 +68,7 @@ const StyledPhaseIndicatorContainer = styled.div<{ $isVertical: boolean }>`
     $isVertical ? verticalIndicatorStyles : horizontalIndicatorStyles}
 `;
 
-const StyledMiniPhaseName = styled.p`
+const StyledMiniPhaseName = styled.div`
   font-size: ${({ theme }) => theme.fontSizeSm};
   line-height: ${({ theme }) => theme.lineHeightSm};
   font-family: ${({ theme }) => theme.fontFamilyTiny};

--- a/components/dashboard/ActionStatusTable.tsx
+++ b/components/dashboard/ActionStatusTable.tsx
@@ -117,6 +117,7 @@ interface SortableTableHeaderProps {
   headerKey: Sort['key'];
   onClick: React.MouseEventHandler;
   sort: Sort;
+  className?: string;
 }
 
 const SortableTableHeader = ({
@@ -124,6 +125,7 @@ const SortableTableHeader = ({
   headerKey,
   sort,
   onClick,
+  className,
 }: SortableTableHeaderProps) => {
   const selected = sort.key == headerKey;
   const iconName = selected
@@ -139,6 +141,7 @@ const SortableTableHeader = ({
       aria-sort={
         selected ? (sort.direction === 1 ? 'ascending' : 'descending') : 'none'
       }
+      className={className}
     >
       <HeaderContentWrapper $selected={selected}>
         <div>{children}</div>
@@ -275,20 +278,24 @@ const ActionStatusTable = (props: Props) => {
 
                 if (columnConfig.sortable && columnConfig.headerKey) {
                   return (
-                    <th key={i} className={columnConfig.headerClassName}>
-                      <SortableTableHeader
-                        sort={sort}
-                        headerKey={columnConfig.headerKey}
-                        onClick={sortHandler(columnConfig.headerKey)}
-                      >
-                        {columnConfig.renderHeader(t, plan, column.columnLabel)}
-                      </SortableTableHeader>
-                    </th>
+                    <SortableTableHeader
+                      key={i}
+                      sort={sort}
+                      headerKey={columnConfig.headerKey}
+                      onClick={sortHandler(columnConfig.headerKey)}
+                      className={columnConfig.headerClassName}
+                    >
+                      {columnConfig.renderHeader(t, plan, column.columnLabel)}
+                    </SortableTableHeader>
                   );
                 }
 
                 return (
-                  <th key={i} className={columnConfig.headerClassName}>
+                  <th
+                    key={i}
+                    scope="col"
+                    className={columnConfig.headerClassName}
+                  >
                     {columnConfig.renderHeader(t, plan, column.columnLabel)}
                   </th>
                 );


### PR DESCRIPTION
Nothing exciting, just stuff I noticed during my BITV accessibility testing.
- `<p>` elements were used for things that are clearly not paragraphs; replaced by `<div>`
- Sometimes `<th>` elements were nested in `<th>` elements. I un-nested them.
- Some column headers didn't have `scope="col"` set.

I also noticed that in the table on the indicator list page, there are no row headers. But I was too lazy to fix that now.