### PR TITLE
Fix broken translation

### DIFF
--- a/components/actions/CategoryActionList.js
+++ b/components/actions/CategoryActionList.js
@@ -10,6 +10,7 @@ import ContentLoader from 'components/common/ContentLoader';
 import ErrorMessage from 'components/common/ErrorMessage';
 import { usePlan } from 'context/plan';
 import { useTranslations } from 'next-intl';
+import { getActionTermContext } from '@/common/i18n';
 
 const GET_ACTION_LIST = gql`
   query GetActionList($plan: ID!, $clientUrl: String!) {
@@ -150,7 +151,7 @@ const CategoryActionList = (props) => {
       </EmptyActionListHeader>
     );
   }
-  const heading = t('filter-result-actions');
+  const heading = t('filter-result-actions', getActionTermContext(plan));
 
   // const MotionCard = motion(ActionCard);
   return (


### PR DESCRIPTION
Just spotted this from a separate discussion in Slack. We need to pass translation context when needed otherwise next-intl will fail to resolve the translation

| Before | After |
| -- | -- |
| <img width="904" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/69209708-22e9-4e73-84e5-d1f364a996ef"> | <img width="904" alt="image" src="https://github.com/kausaltech/kausal-watch-ui/assets/15343658/cc6b6c59-5442-454f-897c-f0e36d41452d"> |