### PR TITLE
Reduce Sentry sample rate

### DIFF
--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -13,7 +13,7 @@ Sentry.init({
   ignoreErrors: ['NEXT_NOT_FOUND'],
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -12,7 +12,7 @@ Sentry.init({
   dsn: 'https://9b7a344624774da8a5aa5752baad826b@sentry.kausal.tech/2',
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -13,7 +13,7 @@ Sentry.init({
   ignoreErrors: ['NEXT_NOT_FOUND'],
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 1,
+  tracesSampleRate: 0.1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,


### PR DESCRIPTION
This will configure Sentry to send 10% of transactions, to avoid overloading our Sentry instance

https://docs.sentry.io/platforms/javascript/performance/
