### PR TITLE
Show action.status in places where that is explicitly desired

### DIFF
--- a/components/actions/ActionContent.tsx
+++ b/components/actions/ActionContent.tsx
@@ -397,7 +397,7 @@ function ActionContentProgressContainer({
     plan,
     statusName: action.mergedWith
       ? t('action-status-merged', getActionTermContext(plan))
-      : action.statusSummary.label,
+      : action.status.name,
   };
 
   return (

--- a/components/dashboard/cells/StatusCell.tsx
+++ b/components/dashboard/cells/StatusCell.tsx
@@ -18,7 +18,7 @@ const StatusDisplay = styled.div`
 const StatusCell = ({ action, plan }: Props) => {
   const t = useTranslations();
 
-  if (action.statusSummary.identifier === 'UNDEFINED') {
+  if (action.status == null) {
     return null;
   }
 
@@ -31,7 +31,7 @@ const StatusCell = ({ action, plan }: Props) => {
         statusName={
           action.mergedWith
             ? t('action-status-merged', getActionTermContext(plan))
-            : action.statusSummary.label
+            : action.status.name
         }
       />
     </StatusDisplay>


### PR DESCRIPTION
The action dashboard status column and the action details page should show just the plain action status in locations designed to show it.

Action.statusSummary should be reserved for places with no room to separate status/phase, like ActionCards, and also the action tables in indicator pages.