### PR TITLE
Fix links to cross-plan merged actions

### DIFF
--- a/components/actions/ActionCard.tsx
+++ b/components/actions/ActionCard.tsx
@@ -442,12 +442,16 @@ function ActionCard({
     return actionCard;
   }
 
+  const fromOtherPlan = action.plan.id !== plan.id;
+  const mergedWithActionFromOtherPlan =
+    mergedWith != null && mergedWith.plan.id !== plan.id;
+
   return (
     <ActionLink
       action={action}
-      viewUrl={action.viewUrl}
+      viewUrl={action.mergedWith?.viewUrl ?? action.viewUrl}
       planUrl={getPlanUrl(mergedWith, action.plan, plan.id)}
-      crossPlan={action?.plan && action.plan.id !== plan.id}
+      crossPlan={fromOtherPlan || mergedWithActionFromOtherPlan}
     >
       <StyledActionLink>{actionCard}</StyledActionLink>
     </ActionLink>

--- a/components/dashboard/ActionList.tsx
+++ b/components/dashboard/ActionList.tsx
@@ -317,6 +317,7 @@ const actionFragment = gql`
     mergedWith {
       id
       identifier
+      viewUrl
       plan {
         id
         shortName


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/1206017643443542/1207112938358823/f)

Unfortunately this creates links to whatever the view URL of an action is, so in a development deployment it will not point to localhost. But this seemed to be the case already before for cross-plan action links in general.