### PR TITLE
Ensure global this polyfill is added before hydration

### DIFF
--- a/app/[domain]/[lang]/layout.tsx
+++ b/app/[domain]/[lang]/layout.tsx
@@ -28,7 +28,7 @@ export default function LangLayout({ params, children }: Props) {
   return (
     <html lang={params.lang}>
       <body>
-        <Script id="global-this-polyfill">
+        <Script id="global-this-polyfill" strategy="beforeInteractive">
           {/* https://github.com/vercel/next.js/discussions/58818 */}
           {`!function(t){function e(){var e=this||self;e.globalThis=e,delete t.prototype._T_}"object"!=typeof globalThis&&(this?e():(t.defineProperty(t.prototype,"_T_",{configurable:!0,get:e}),_T_))}(Object);`}
         </Script>


### PR DESCRIPTION
Some `globalThis is not defined` errors are still popping up in old browsers, there's a possibility that the polyfill is loaded after `globalThis` is used

[Sentry error](https://sentry.kausal.tech/organizations/kausal/issues/723/?alert_rule_id=4&alert_type=issue&environment=production&notification_uuid=45e01212-d11e-4656-9a56-4a3e4b1e4288&project=2&referrer=slack)