### PR TITLE
Prevent uncaught error if matchingVersion is null

### DIFF
--- a/components/actions/ActionLogBanner.tsx
+++ b/components/actions/ActionLogBanner.tsx
@@ -45,7 +45,7 @@ const ActionLogBanner = (props) => {
   );
   if (loading) {
     info = `${selectedWorkflow.description}: ${t('loading')}`;
-  } else if (selectedWorkflowID !== matchingVersion.id) {
+  } else if (selectedWorkflowID !== matchingVersion?.id) {
     info = t('no-action-version-available', {
       versionType: selectedWorkflow.description,
     });
@@ -55,7 +55,7 @@ const ActionLogBanner = (props) => {
     <DraftBanner>
       <DraftBannerTitle>
         {loading && <Spinner size="sm" className="me-3" />}
-        {matchingVersion.description}
+        {matchingVersion?.description}
         <DraftBannerInfo>{info && ` (${info})`} </DraftBannerInfo>
       </DraftBannerTitle>
       <DraftBannerDate>{dayjs(updatedAt).format('l')}</DraftBannerDate>


### PR DESCRIPTION
Raúl reported that the action pages are throwing errors when signed in to the public UI. @tituomin is it valid that `matchingVersion` can be `null` or should that be fixed on the backend?

https://sentry.kausal.tech/organizations/kausal/issues/804/