### PR TITLE
Hide avatar based on plan feature setting

### DIFF
--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -3184,6 +3184,8 @@ export type PlanFeatures = {
   contactPersonsPublicData: PlanFeaturesContactPersonsPublicData;
   /** When displaying a contact person's contact details, should the contact person's organization be displayed along with all its ancestors? */
   contactPersonsShowOrganizationAncestors: Scalars['Boolean'];
+  /** Should profile pictures be shown for contact persons in the public UI? */
+  contactPersonsShowPicture: Scalars['Boolean'];
   /** Set to enable comparing indicators between organizations */
   enableIndicatorComparison: Scalars['Boolean'];
   enableModerationWorkflow?: Maybe<Scalars['Boolean']>;
@@ -12189,7 +12191,7 @@ export type GetPlanContextQuery = (
       ) | null> }
       & { __typename?: 'Footer' }
     ) | null, features: (
-      { allowPublicSiteLogin: boolean, hasActionContactPersonRoles: boolean, contactPersonsPublicData: PlanFeaturesContactPersonsPublicData, contactPersonsShowOrganizationAncestors: boolean, enableSearch: boolean, hasActionIdentifiers: boolean, hasActionOfficialName: boolean, hasActionLeadParagraph: boolean, hasActionPrimaryOrgs: boolean, showAdminLink: boolean, enableIndicatorComparison: boolean, minimalStatuses: boolean }
+      { allowPublicSiteLogin: boolean, hasActionContactPersonRoles: boolean, contactPersonsPublicData: PlanFeaturesContactPersonsPublicData, contactPersonsShowPicture: boolean, contactPersonsShowOrganizationAncestors: boolean, enableSearch: boolean, hasActionIdentifiers: boolean, hasActionOfficialName: boolean, hasActionLeadParagraph: boolean, hasActionPrimaryOrgs: boolean, showAdminLink: boolean, enableIndicatorComparison: boolean, minimalStatuses: boolean }
       & { __typename?: 'PlanFeatures' }
     ), allRelatedPlans: Array<(
       { id: string, identifier: string, name: string, shortName?: string | null, viewUrl?: string | null, image?: (
@@ -12379,7 +12381,7 @@ export type PlanContextFragment = (
     ) | null> }
     & { __typename?: 'Footer' }
   ) | null, features: (
-    { allowPublicSiteLogin: boolean, hasActionContactPersonRoles: boolean, contactPersonsPublicData: PlanFeaturesContactPersonsPublicData, contactPersonsShowOrganizationAncestors: boolean, enableSearch: boolean, hasActionIdentifiers: boolean, hasActionOfficialName: boolean, hasActionLeadParagraph: boolean, hasActionPrimaryOrgs: boolean, showAdminLink: boolean, enableIndicatorComparison: boolean, minimalStatuses: boolean }
+    { allowPublicSiteLogin: boolean, hasActionContactPersonRoles: boolean, contactPersonsPublicData: PlanFeaturesContactPersonsPublicData, contactPersonsShowPicture: boolean, contactPersonsShowOrganizationAncestors: boolean, enableSearch: boolean, hasActionIdentifiers: boolean, hasActionOfficialName: boolean, hasActionLeadParagraph: boolean, hasActionPrimaryOrgs: boolean, showAdminLink: boolean, enableIndicatorComparison: boolean, minimalStatuses: boolean }
     & { __typename?: 'PlanFeatures' }
   ), allRelatedPlans: Array<(
     { id: string, identifier: string, name: string, shortName?: string | null, viewUrl?: string | null, image?: (

--- a/components/actions/ContactPerson.js
+++ b/components/actions/ContactPerson.js
@@ -25,6 +25,10 @@ const Person = styled.div`
       border: 4px solid ${(props) => props.theme.brandDark};
     }
   }
+
+  &.leader-no-avatar {
+    border-left: 5px solid ${(props) => props.theme.brandDark};
+  }
 `;
 
 const PersonDetails = styled.div`
@@ -154,21 +158,28 @@ function ContactPerson(props) {
   const t = useTranslations();
   const [collapse, setCollapse] = useState(false);
   const isLeader = leader ? 'leader' : '';
+  const isLeaderNoAvatar =
+    leader && !plan.features.contactPersonsShowPicture
+      ? 'leader-no-avatar'
+      : '';
   const fullName = `${person.firstName} ${person.lastName}`;
   const role = isLeader ? t('contact-person-main') : '';
-
   return (
-    <Person className={isLeader}>
-      <div>
-        <Avatar
-          src={
-            person.avatarUrl ||
-            '/static/themes/default/images/default-avatar-user.png'
-          }
-          className={`rounded-circle ${isLeader}`}
-          alt={`${role} ${fullName}`}
-        />
-      </div>
+    <Person className={`${isLeader} ${isLeaderNoAvatar}`}>
+      {plan.features.contactPersonsShowPicture ? (
+        <div>
+          <Avatar
+            src={
+              person.avatarUrl ||
+              '/static/themes/default/images/default-avatar-user.png'
+            }
+            className={`rounded-circle ${isLeader}`}
+            alt={`${role} ${fullName}`}
+          />
+        </div>
+      ) : (
+        <span className="visually-hidden">{`${role} ${fullName}`}</span>
+      )}
       <PersonDetails>
         <Name>{fullName}</Name>
         <PersonRole>{person.title}</PersonRole>

--- a/components/actions/ContactPerson.tsx
+++ b/components/actions/ContactPerson.tsx
@@ -1,34 +1,45 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+
 import { gql } from '@apollo/client';
 import { useQuery } from '@apollo/experimental-nextjs-app-support/ssr';
 
 import { Button, Collapse } from 'reactstrap';
 import Icon from 'components/common/Icon';
 import { usePlan } from 'context/plan';
-import { PlanFeaturesContactPersonsPublicData } from 'common/__generated__/graphql';
+import {
+  PlanContextFragment,
+  PlanFeaturesContactPersonsPublicData,
+} from 'common/__generated__/graphql';
 import { useTranslations } from 'next-intl';
 
-const Person = styled.div`
+const Person = styled.div<{
+  $isLeader: boolean;
+  $withoutAvatar: boolean;
+}>`
   display: flex;
   margin-top: 1em;
   padding-bottom: 1em;
   border-bottom: 2px solid ${(props) => props.theme.themeColors.light};
-
   img {
     border: 2px solid ${(props) => props.theme.themeColors.light};
   }
 
-  &.leader {
-    img {
-      border: 4px solid ${(props) => props.theme.brandDark};
-    }
-  }
+  ${(props) =>
+    props.$isLeader &&
+    css`
+      img {
+        border: 4px solid ${(props) => props.theme.brandDark};
+      }
+    `}
 
-  &.leader-no-avatar {
-    border-left: 5px solid ${(props) => props.theme.brandDark};
-  }
+  ${(props) =>
+    props.$withoutAvatar &&
+    props.$isLeader &&
+    css`
+      border-left: 5px solid ${(props) => props.theme.brandDark};
+    `}
 `;
 
 const PersonDetails = styled.div`
@@ -103,8 +114,12 @@ const GET_CONTACT_DETAILS = gql`
   }
 `;
 
-function ContactDetails(props) {
-  const { id, plan } = props;
+interface ContactDetailsProps {
+  id: string;
+  plan: PlanContextFragment;
+}
+
+function ContactDetails({ id, plan }: ContactDetailsProps) {
   const t = useTranslations();
   const { loading, error, data } = useQuery(GET_CONTACT_DETAILS, {
     variables: { id },
@@ -138,7 +153,7 @@ function ContactDetails(props) {
         orgAncestors.length > 1 && (
           <PersonOrg>
             {orgAncestors.map((item, idx) => (
-              <span key={item.key}>
+              <span key={item.id}>
                 {item.name}
                 {idx < orgAncestors.length - 1 ? ' / ' : ''}
               </span>
@@ -152,20 +167,30 @@ function ContactDetails(props) {
   );
 }
 
-function ContactPerson(props) {
-  const { person, leader = false } = props;
+interface ContactPersonProps {
+  person: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    avatarUrl?: string;
+    title: string;
+    organization?: {
+      name: string;
+    };
+  };
+  leader?: boolean;
+}
+
+function ContactPerson({ person, leader = false }: ContactPersonProps) {
   const plan = usePlan();
   const t = useTranslations();
   const [collapse, setCollapse] = useState(false);
-  const isLeader = leader ? 'leader' : '';
-  const isLeaderNoAvatar =
-    leader && !plan.features.contactPersonsShowPicture
-      ? 'leader-no-avatar'
-      : '';
   const fullName = `${person.firstName} ${person.lastName}`;
-  const role = isLeader ? t('contact-person-main') : '';
+  const role = leader ? t('contact-person-main') : '';
+  const withoutAvatar = !plan.features.contactPersonsShowPicture;
+
   return (
-    <Person className={`${isLeader} ${isLeaderNoAvatar}`}>
+    <Person $isLeader={leader} $withoutAvatar={withoutAvatar}>
       {plan.features.contactPersonsShowPicture ? (
         <div>
           <Avatar
@@ -173,7 +198,7 @@ function ContactPerson(props) {
               person.avatarUrl ||
               '/static/themes/default/images/default-avatar-user.png'
             }
-            className={`rounded-circle ${isLeader}`}
+            className="rounded-circle"
             alt={`${role} ${fullName}`}
           />
         </div>

--- a/queries/get-plan.ts
+++ b/queries/get-plan.ts
@@ -170,6 +170,7 @@ const GET_PLAN_CONTEXT = gql`
       allowPublicSiteLogin
       hasActionContactPersonRoles
       contactPersonsPublicData
+      contactPersonsShowPicture
       contactPersonsShowOrganizationAncestors
       enableSearch
       hasActionIdentifiers


### PR DESCRIPTION
Hide avatars if plan feature setting requires it.
To signal "leader" we show a left border instead of the circle around the avatar.

![image](https://github.com/kausaltech/kausal-watch-ui/assets/6697396/bd0d8f3d-58cd-4a7c-b3c9-7e806070a356)

Depends on:
Backend: https://github.com/kausaltech/kausal-watch-private/pull/206

Asana: https://app.asana.com/0/1206017643443542/1207437856881925
