### PR TITLE
Become compatible with the new theme builds

### DIFF
--- a/app/[domain]/[lang]/[plan]/embed/v1/[...slug]/page.tsx
+++ b/app/[domain]/[lang]/[plan]/embed/v1/[...slug]/page.tsx
@@ -29,8 +29,7 @@ const UnknownEmbedPlaceholder = () => {
   const theme = useTheme();
   return (
     <UnknownWrapper>
-      <Icon
-        name="exclamation-circle"
+      <Icon.ExclamationCircle
         color={theme.themeColors.light}
         width={theme.fontSizeXl}
         height={theme.fontSizeXl}

--- a/common/theme.ts
+++ b/common/theme.ts
@@ -25,6 +25,6 @@ export async function loadTheme(themeIdentifier: string): Promise<Theme> {
   }
 }
 
-export function getThemeCSS(themeIdentifier: string) {
-  return `/static/themes/${themeIdentifier}/main.css`;
+export function getThemeStaticURL(path: string) {
+  return `/static/themes/${path}`;
 }

--- a/components/actions/ActionCard.tsx
+++ b/components/actions/ActionCard.tsx
@@ -419,8 +419,7 @@ function ActionCard({
             <StyledActionDependencyIconWrapper
               id={getDependencyTooltipId(action.id)}
             >
-              <Icon
-                name="action-dependency"
+              <Icon.ActionDependency
                 width="24px"
                 height="24px"
                 role="presentation"

--- a/components/actions/ActionHero.tsx
+++ b/components/actions/ActionHero.tsx
@@ -293,8 +293,7 @@ function ActionHero(props: ActionHeroProps) {
                         {previousAction && (
                           <ActionLink action={previousAction}>
                             <a>
-                              <Icon
-                                name="arrowLeft"
+                              <Icon.ArrowLeft
                                 color={theme.linkColor}
                                 aria-hidden="true"
                               />{' '}
@@ -307,8 +306,7 @@ function ActionHero(props: ActionHeroProps) {
                           <ActionLink action={nextAction}>
                             <a>
                               {t('next')}
-                              <Icon
-                                name="arrowRight"
+                              <Icon.ArrowRight
                                 color={theme.linkColor}
                                 aria-hidden="true"
                               />

--- a/components/actions/ActionHighlightCard.tsx
+++ b/components/actions/ActionHighlightCard.tsx
@@ -158,7 +158,7 @@ function ActionHighlightCard(props: ActionHighlightCardProps) {
           <CardBody>
             {actionStatus && actionStatus.identifier === 'completed' && (
               <ReadyBadge pill>
-                <Icon name="check" color="#ffffff" width="2em" height="2em" />
+                <Icon.Check color="#ffffff" width="2em" height="2em" />
               </ReadyBadge>
             )}
             <StyledCardTitle tag="h3" className="card-title">

--- a/components/actions/ActionHighlightsList.tsx
+++ b/components/actions/ActionHighlightsList.tsx
@@ -144,7 +144,7 @@ function ActionCardList(props: ActionCardListProps) {
           <ActionListLink>
             <Button color="primary" tag="a">
               {t('see-all-actions', getActionTermContext(plan) || {})}{' '}
-              <Icon name="arrowRight" />
+              <Icon.ArrowRight />
             </Button>
           </ActionListLink>
         </Col>

--- a/components/actions/ActionPager.tsx
+++ b/components/actions/ActionPager.tsx
@@ -45,7 +45,7 @@ const ActionPager = ({ nextAction = null, previousAction = null }: Props) => {
           <ActionLink action={previousAction}>
             <a>
               <PageButton color="primary" outline>
-                <Icon name="arrowLeft" />
+                <Icon.ArrowLeft />
                 {t('action-previous', getActionTermContext(plan))}
               </PageButton>
             </a>
@@ -58,7 +58,7 @@ const ActionPager = ({ nextAction = null, previousAction = null }: Props) => {
             <a>
               <PageButton color="primary" outline>
                 {t('action-next', getActionTermContext(plan))}
-                <Icon name="arrowRight" />
+                <Icon.ArrowRight />
               </PageButton>
             </a>
           </ActionLink>

--- a/components/actions/PhaseTimeline.tsx
+++ b/components/actions/PhaseTimeline.tsx
@@ -139,7 +139,11 @@ const StyledPhaseLine = styled.div<{
 `;
 
 const PHASE_CONFIG: {
-  [key in PhaseType]: { icon: string; colorKey: string; textColorKey: string };
+  [key in PhaseType]: {
+    icon: 'circle-full' | 'circle-half' | 'circle-outline';
+    colorKey: string;
+    textColorKey: string;
+  };
 } = {
   done: {
     icon: 'circle-full',
@@ -174,7 +178,6 @@ function getIconFromType(
       return 'angle-right';
     }
   }
-
   if (isCurrent && isCompleted) {
     return 'check-circle';
   }

--- a/components/actions/TaskList.js
+++ b/components/actions/TaskList.js
@@ -136,8 +136,7 @@ const Task = (props) => {
     <TaskWrapper>
       {completed ? (
         <TaskMeta>
-          <Icon
-            name="check"
+          <Icon.Check
             color={theme.graphColors.green050}
             alt={t('action-task-done')}
           />
@@ -145,8 +144,7 @@ const Task = (props) => {
         </TaskMeta>
       ) : (
         <TaskMeta>
-          <Icon
-            name="calendar"
+          <Icon.Calendar
             color={theme.graphColors.blue070}
             alt={t('action-task-todo')}
           />

--- a/components/actions/blocks/ActionRelatedIndicatorsBlock.tsx
+++ b/components/actions/blocks/ActionRelatedIndicatorsBlock.tsx
@@ -84,7 +84,7 @@ function ActionIndicator(props) {
           <a>
             <h3>
               {indicator.name}
-              <Icon name="arrowRight" color="" />
+              <Icon.ArrowRight color="" />
             </h3>
           </a>
         </IndicatorLink>

--- a/components/common/Accordion.tsx
+++ b/components/common/Accordion.tsx
@@ -131,7 +131,7 @@ const LinkCopyButton = ({ identifier }: { identifier: string }) => {
           aria-label={t('copy-to-clipboard')}
           className="copy-link"
         >
-          <Icon name="link" />
+          <Icon.Link />
         </CopyLink>
       </CopyToClipboard>
     </>

--- a/components/common/CategoryCardContent.tsx
+++ b/components/common/CategoryCardContent.tsx
@@ -62,7 +62,7 @@ const CategoryCardContent = (props: CategoryCardContentProps) => {
         <Link href={category?.categoryPage?.urlPath} legacyBehavior>
           <a>
             {t('read-more')}
-            <Icon name="arrowRight" />
+            <Icon.ArrowRight />
           </a>
         </Link>
       ) : null}

--- a/components/common/GlobalNav.tsx
+++ b/components/common/GlobalNav.tsx
@@ -18,6 +18,7 @@ import { transparentize } from 'polished';
 import { NavigationLink, Link } from 'common/links';
 
 import type { Theme } from '@kausal/themes/types';
+import { getThemeStaticURL } from '@/common/theme';
 import Icon from './Icon';
 import PlanSelector from 'components/plans/PlanSelector';
 import PlanVersionSelector from 'components/versioning/PlanVersionSelector';
@@ -481,7 +482,7 @@ function GlobalNav(props) {
   const OrgLogo = () => {
     const logoElement = theme.navLogoVisible ? (
       <SVG
-        src={theme.themeLogoUrl}
+        src={getThemeStaticURL(theme.themeLogoUrl)}
         title={`${ownerName}, ${siteTitle} ${t('front-page')}`}
         preserveAspectRatio="xMinYMid meet"
       />

--- a/components/common/GlobalNav.tsx
+++ b/components/common/GlobalNav.tsx
@@ -544,9 +544,9 @@ function GlobalNav(props) {
             type="button"
           >
             {isOpen ? (
-              <Icon name="times" color={theme.brandNavColor} />
+              <Icon.Times color={theme.brandNavColor} />
             ) : (
-              <Icon name="bars" color={theme.brandNavColor} />
+              <Icon.Bars color={theme.brandNavColor} />
             )}
           </NavbarToggler>
         </TopNav>
@@ -579,7 +579,7 @@ function GlobalNav(props) {
                         }`}
                       >
                         {homeLink === 'icon' ? (
-                          <Icon name="home" width="1.5rem" height="1.5rem" />
+                          <Icon.Home width="1.5rem" height="1.5rem" />
                         ) : (
                           <span>{t('navigation-home')}</span>
                         )}
@@ -620,8 +620,7 @@ function GlobalNav(props) {
                   <NavLink>
                     <NavigationLink slug="/search" onClick={handleClose}>
                       <NavHighlighter className="highlighter">
-                        <Icon
-                          name="search"
+                        <Icon.Search
                           className="me-2"
                           width="1.75rem"
                           height="1.75rem"

--- a/components/common/Icon.tsx
+++ b/components/common/Icon.tsx
@@ -3,56 +3,98 @@
 import React from 'react';
 import SVG from 'react-inlinesvg';
 import { useTheme } from 'styled-components';
+import defaultTheme from '@/public/static/themes/default/theme.json';
+import { getThemeStaticURL } from '@/common/theme';
+
+const makeIconId = (name: string): string => `symbol-icon-${name}`;
+
+export function HiddenReusableIcon(props) {
+  // There needs to be one of these in the DOM for each available icon
+  // so they can be referenced through the SVG use mechanism at the
+  // site of use. Include the SharedIcons component to the layout add
+  // these to the DOM
+  const theme = useTheme();
+  const { name } = props;
+  const iconFilename = name
+    .replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2')
+    .toLowerCase();
+  const icon = defaultTheme.icons[iconFilename];
+  return (
+    <SVG
+      src={getThemeStaticURL(icon)}
+      id={makeIconId(name)}
+      onError={(error) => console.log(error.message)}
+      key={`${theme.name}-${name}`}
+    />
+  );
+}
+
+export function SharedIcons(props: React.PropsWithChildren) {
+  const iconReferences = Object.values(AvailableIcons);
+  const hiddenIcons = iconReferences.map((iconRef) => (
+    <HiddenReusableIcon key={iconRef} name={iconRef} />
+  ));
+  return (
+    <div id="shared-reusable-icons" style={{ display: 'none' }}>
+      {hiddenIcons}
+    </div>
+  );
+}
 
 const camelToKebabCase = (s) =>
   s.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
 
-type AvailableIcons =
-  | 'action-dependency'
-  | 'angle-down'
-  | 'angle-left'
-  | 'angle-right'
-  | 'angle-up'
-  | 'arrow-down'
-  | 'arrow-left'
-  | 'arrow-right'
-  | 'arrow-up-down'
-  | 'arrow-up-right-from-square'
-  | 'arrow-up'
-  | 'bars'
-  | 'bullseye'
-  | 'calendar'
-  | 'chart-line'
-  | 'check'
-  | 'caret-down'
-  | 'caret-left'
-  | 'caret-right'
-  | 'caret-up'
-  | 'circle-full'
-  | 'circle-outline'
-  | 'commenting'
-  | 'dot-circle'
-  | 'exclamation-circle'
-  | 'globe'
-  | 'heart'
-  | 'hidden'
-  | 'home'
-  | 'link'
-  | 'lock'
-  | 'pencil'
-  | 'scope-global'
-  | 'scope-local'
-  | 'search'
-  | 'sort-down'
-  | 'sort-up'
-  | 'sort'
-  | 'sync'
-  | 'tachometer'
-  | 'times'
-  | 'user';
+export enum AvailableIcons {
+  ActionDependency = 'action-dependency',
+  AngleDown = 'angle-down',
+  AngleLeft = 'angle-left',
+  AngleRight = 'angle-right',
+  AngleUp = 'angle-up',
+  ArrowDown = 'arrow-down',
+  ArrowLeft = 'arrow-left',
+  ArrowRight = 'arrow-right',
+  ArrowUpDown = 'arrow-up-down',
+  ArrowUpRightFromSquare = 'arrow-up-right-from-square',
+  ArrowUp = 'arrow-up',
+  Bars = 'bars',
+  Bullseye = 'bullseye',
+  Calendar = 'calendar',
+  ChartLine = 'chart-line',
+  Check = 'check',
+  CaretDown = 'caret-down',
+  CaretLeft = 'caret-left',
+  CaretRight = 'caret-right',
+  CaretUp = 'caret-up',
+  CheckCircle = 'check-circle',
+  CircleHalf = 'circle-half',
+  CircleFull = 'circle-full',
+  CircleOutline = 'circle-outline',
+  Commenting = 'commenting',
+  DotCircle = 'dot-circle',
+  ExclamationCircle = 'exclamation-circle',
+  Globe = 'globe',
+  Heart = 'heart',
+  Hidden = 'hidden',
+  Home = 'home',
+  Link = 'link',
+  Lock = 'lock',
+  Pencil = 'pencil',
+  ScopeGlobal = 'scope-global',
+  ScopeLocal = 'scope-local',
+  Search = 'search',
+  SortDown = 'sort-down',
+  SortUp = 'sort-up',
+  Sort = 'sort',
+  Sync = 'sync',
+  Tachometer = 'tachometer',
+  Times = 'times',
+  User = 'user',
+  Version = 'version',
+}
+
+type ValidIconName = `${AvailableIcons}`;
 
 type Props = {
-  name?: AvailableIcons;
   color?: string;
   width?: string;
   height?: string;
@@ -60,7 +102,11 @@ type Props = {
   alt?: string;
 } & React.SVGProps<SVGUseElement>;
 
-const Icon = ({
+type IconProps = {
+  name?: ValidIconName;
+} & Props;
+
+const IconComponent = ({
   name = 'circle-outline',
   color = 'inherit',
   width = '1em',
@@ -68,9 +114,8 @@ const Icon = ({
   className = '',
   alt,
   ...rest
-}: Props) => {
+}: IconProps) => {
   const theme = useTheme();
-
   return (
     <svg
       className={`icon ${className}`}
@@ -81,23 +126,21 @@ const Icon = ({
       focusable={alt ? 'true' : 'false'}
     >
       {alt ? <title>{alt}</title> : null}
-      <use
-        fill={color}
-        xlinkHref={`#symbol-icon-${camelToKebabCase(name)}`}
-        {...rest}
-      />
+      <use fill={color} xlinkHref={`#${makeIconId(name)}`} {...rest} />
     </svg>
   );
 };
 
-export const CombinedIconSymbols = () => {
-  const theme = useTheme();
-  /* Find the correct icon file from static folder for now */
-  /* TODO: Get themed icon url from API */
-  const iconFileName = camelToKebabCase(theme.combinedIconsFilename);
-  const icon = `${theme.iconsUrl}/${iconFileName}.svg`;
+type IconsInterface = {
+  [K in keyof typeof AvailableIcons]: (props: Props) => JSX.Element;
+} & typeof IconComponent;
 
-  return <SVG style={{ display: 'none' }} src={icon} />;
-};
+for (const [key, val] of Object.entries(AvailableIcons)) {
+  const fn = (props: Props) => (
+    <IconComponent name={AvailableIcons[key]} {...props} />
+  );
+  IconComponent[key] = fn;
+}
 
+const Icon = IconComponent as IconsInterface;
 export default Icon;

--- a/components/common/LanguageSelector.tsx
+++ b/components/common/LanguageSelector.tsx
@@ -162,7 +162,7 @@ const LanguageSelector = (props: LanguageSelectorProps) => {
     <LanguageSelectorListItem>
       <Selector inNavbar $mobile={mobile} className={mobile && 'd-md-none'}>
         <StyledDropdownToggle color="link" data-toggle="dropdown" tag="button">
-          <Icon name="globe" width="1.75rem" height="1.75rem" />
+          <Icon.Globe width="1.75rem" height="1.75rem" />
           <CurrentLanguage $mobile={mobile}>{languageCode}</CurrentLanguage>
         </StyledDropdownToggle>
         <StyledDropdownMenu end>

--- a/components/common/Modal.tsx
+++ b/components/common/Modal.tsx
@@ -91,7 +91,7 @@ const Modal = ({ isOpen, onClose, header, helpText, children }: ModalProps) => {
               aria-label={t('close')}
               onClick={() => onClose()}
             >
-              <Icon name="times" />
+              <Icon.Times />
             </CloseButton>
             {children}
           </ModalBody>

--- a/components/common/NavbarSearch.js
+++ b/components/common/NavbarSearch.js
@@ -295,13 +295,13 @@ const ResultList = (props) => {
           >
             <a>
               {t('see-all-results', { count: results.length })}
-              <Icon name="arrow-right" />
+              <Icon.ArrowRight />
             </a>
           </Link>
         ) : (
           <Link prefetch={false} href={`/search`} legacyBehavior>
             <a data-testId="search-advanced">
-              {t('search-advanced')} <Icon name="arrow-right" />
+              {t('search-advanced')} <Icon.ArrowRight />
             </a>
           </Link>
         )}
@@ -454,8 +454,7 @@ function Search({ isLoading, searchTerm, setSearchTerm, results }) {
               aria-label={t('search')}
               data-testid="nav-search-btn"
             >
-              <Icon
-                name="search"
+              <Icon.Search
                 width="1.75rem"
                 height="1.75rem"
                 aria-hidden="true"

--- a/components/common/RichText.tsx
+++ b/components/common/RichText.tsx
@@ -232,7 +232,7 @@ export default function RichText(props: RichTextProps) {
         // Assumed external link, open in new tab
         return (
           <a target="_blank" href={attribs.href} rel="noreferrer">
-            <Icon name="arrow-up-right-from-square" />
+            <Icon.ArrowUpRightFromSquare />
             {domToReact(children, options)}
           </a>
         );

--- a/components/common/SiteFooter.tsx
+++ b/components/common/SiteFooter.tsx
@@ -523,8 +523,7 @@ function SiteFooter(props: SiteFooterProps) {
                     <NavigationLink slug={page.slug} className="parent-item">
                       <>
                         {theme?.navLinkIcons && (
-                          <Icon
-                            name="angleRight"
+                          <Icon.AngleRight
                             color={theme.footerColor}
                             aria-hidden="true"
                             className="me-1"
@@ -543,8 +542,7 @@ function SiteFooter(props: SiteFooterProps) {
                             <NavigationLink slug={childPage.slug}>
                               <>
                                 {theme?.navLinkIcons && (
-                                  <Icon
-                                    name="angleRight"
+                                  <Icon.AngleRight
                                     color={theme.footerColor}
                                     aria-hidden="true"
                                     className="me-1"
@@ -569,8 +567,7 @@ function SiteFooter(props: SiteFooterProps) {
                 {ownerUrl ? (
                   <a href={ownerUrl} target="_blank" rel="noreferrer">
                     {theme?.navLinkIcons && (
-                      <Icon
-                        name="angleRight"
+                      <Icon.AngleRight
                         color={theme.footerColor}
                         aria-hidden="true"
                         className="me-1"
@@ -588,8 +585,7 @@ function SiteFooter(props: SiteFooterProps) {
                 <UtilityItem key={page.id}>
                   <NavigationLink slug={page.url}>
                     {theme?.navLinkIcons && (
-                      <Icon
-                        name="angleRight"
+                      <Icon.AngleRight
                         color={theme.footerColor}
                         aria-hidden="true"
                         className="me-1"
@@ -631,8 +627,7 @@ function SiteFooter(props: SiteFooterProps) {
                   {isAuthLoading ? (
                     <Spinner size="sm" color="light" />
                   ) : (
-                    <Icon
-                      name="lock"
+                    <Icon.Lock
                       color={theme.footerColor}
                       aria-hidden="true"
                       className="me-1"
@@ -645,8 +640,7 @@ function SiteFooter(props: SiteFooterProps) {
             <UtilityItem>
               <TopButton type="button" onClick={scrollToTop}>
                 {t('back-to-top')}{' '}
-                <Icon
-                  name="arrowUp"
+                <Icon.ArrowUp
                   color={theme.footerColor}
                   aria-hidden="true"
                   width="1.25em"

--- a/components/common/SiteFooter.tsx
+++ b/components/common/SiteFooter.tsx
@@ -13,6 +13,7 @@ import { usePlan } from '@/context/plan';
 import { signIn, useSession } from 'next-auth/react';
 import Button from './Button';
 import { useHandleSignOut } from '@/utils/auth.utils';
+import { getThemeStaticURL } from '@/common/theme';
 
 const StyledButton = styled(Button)`
   &.btn-link {
@@ -461,7 +462,7 @@ function SiteFooter(props: SiteFooterProps) {
   const OrgLogo = () => {
     return (
       <SVG
-        src={theme.themeLogoWhiteUrl}
+        src={getThemeStaticURL(theme.themeLogoWhiteUrl)}
         preserveAspectRatio="xMinYMid meet"
         title={`${ownerName}, ${siteTitle} ${t('front-page')}`}
         style={{ display: 'block' }}
@@ -709,7 +710,7 @@ function SiteFooter(props: SiteFooterProps) {
                   <FundingInstrumentContainer key={funder.id}>
                     <a href={funder.link} target="_blank" rel="noreferrer">
                       <SVG
-                        src={funder.logo}
+                        src={getThemeStaticURL(funder.logo)}
                         preserveAspectRatio="xMidYMid meet"
                         title={funder.name}
                       />

--- a/components/contentblocks/AttentionBannerBlock.js
+++ b/components/contentblocks/AttentionBannerBlock.js
@@ -51,7 +51,7 @@ const AttentionBannerBlock = (props) => {
           {buttons.map((button) => (
             <Button key={button.id} href={button.url} color="primary" outline>
               {button.label}
-              <Icon name="arrowRight" color="" />
+              <Icon.ArrowRight color="" />
             </Button>
           ))}
         </AttentionBox>

--- a/components/contentblocks/ExpandableFeedbackFormBlock.tsx
+++ b/components/contentblocks/ExpandableFeedbackFormBlock.tsx
@@ -60,7 +60,7 @@ const ExpandableFeedbackFormBlock = ({
   return (
     <FeedbackFormSection size={size}>
       <ContactTriggerButton color="link" onClick={toggle}>
-        <Icon name="commenting" width="2rem" height="2rem" />
+        <Icon.Commenting width="2rem" height="2rem" />
         <div>
           <h2>{heading || t('feedback-on-action')}</h2>
           {description || t('feedback-on-action-description')}

--- a/components/contentblocks/IndicatorGroupBlock.tsx
+++ b/components/contentblocks/IndicatorGroupBlock.tsx
@@ -55,7 +55,7 @@ const IndicatorItem = (props) => {
             <a>
               <h3>
                 {indicator.name}
-                <Icon name="arrowRight" color="" />
+                <Icon.ArrowRight color="" />
               </h3>
             </a>
           </IndicatorLink>
@@ -109,7 +109,7 @@ const IndicatorGroupBlock = ({ id = '', title, indicators }: Props) => {
           <StyledColCentered>
             <IndicatorListLink>
               <Button color="primary" tag="a">
-                {t('see-all-indicators')} <Icon name="arrowRight" />
+                {t('see-all-indicators')} <Icon.ArrowRight />
               </Button>
             </IndicatorListLink>
           </StyledColCentered>

--- a/components/contentblocks/RelatedIndicatorsBlock.js
+++ b/components/contentblocks/RelatedIndicatorsBlock.js
@@ -37,7 +37,7 @@ const IndicatorItem = (props) => {
           <Link href={`/indicators/${indicator}`} legacyBehavior>
             <a>
               {t('read-more')}
-              <Icon name="arrowRight" />
+              <Icon.ArrowRight />
             </a>
           </Link>
         </div>

--- a/components/dashboard/ActionTableTooltips.tsx
+++ b/components/dashboard/ActionTableTooltips.tsx
@@ -261,8 +261,7 @@ export const IndicatorsTooltipContent = ({ action }: TooltipProps) => {
   return (
     <div>
       <TooltipTitle>{t('indicators')}</TooltipTitle>
-      <Icon
-        name="tachometer"
+      <Icon.Tachometer
         color={
           hasIndicators ? theme.graphColors.green070 : theme.graphColors.grey030
         }
@@ -273,8 +272,7 @@ export const IndicatorsTooltipContent = ({ action }: TooltipProps) => {
         ? ` ${t('indicators')}: ${action.indicatorsCount}`
         : ` ${t('no-defined-indicators')}`}
       <br />
-      <Icon
-        name="bullseye"
+      <Icon.Bullseye
         color={
           hasGoals ? theme.graphColors.green070 : theme.graphColors.grey030
         }

--- a/components/dashboard/cells/IndicatorsCell.tsx
+++ b/components/dashboard/cells/IndicatorsCell.tsx
@@ -19,16 +19,14 @@ const IndicatorsCell = ({ action }: Props) => {
 
   return (
     <IndicatorsDisplay>
-      <Icon
-        name="tachometer"
+      <Icon.Tachometer
         color={
           hasIndicators ? theme.graphColors.green070 : theme.graphColors.grey030
         }
         height="1.2em"
         width="1.2em"
       />
-      <Icon
-        name="bullseye"
+      <Icon.Bullseye
         color={
           hasGoals ? theme.graphColors.green070 : theme.graphColors.grey030
         }

--- a/components/dashboard/cells/ResponsiblePartiesCell.tsx
+++ b/components/dashboard/cells/ResponsiblePartiesCell.tsx
@@ -27,9 +27,8 @@ const ResponsiblePartiesCell = ({ action }: Props) => {
       {Array(hasContactCount)
         .fill(null)
         .map((_, i) => (
-          <Icon
+          <Icon.DotCircle
             key={i}
-            name="dot-circle"
             color={theme.actionOnTimeColor}
             width=".8em"
             height=".8em"
@@ -39,8 +38,7 @@ const ResponsiblePartiesCell = ({ action }: Props) => {
       {Array(noContactCount)
         .fill(null)
         .map((_, i) => (
-          <Icon
-            name="circle-outline"
+          <Icon.CircleOutline
             color={theme.actionOnTimeColor}
             key={i}
             width=".8em"

--- a/components/graphs/StatusDonut.js
+++ b/components/graphs/StatusDonut.js
@@ -170,7 +170,7 @@ const StatusDonut = (props) => {
         <HelpText>{helpText}</HelpText>
         <PlotWrapper>
           <OpenModalButton onClick={openModal} aria-label={t('open')}>
-            <Icon name="arrowUpRightFromSquare" />
+            <Icon.ArrowUpRightFromSquare />
           </OpenModalButton>
           <Plot
             data={[pieData]}

--- a/components/indicators/IndicatorHighlightsList.tsx
+++ b/components/indicators/IndicatorHighlightsList.tsx
@@ -95,7 +95,7 @@ function IndicatorCardList(props: IndicatorCardListProps) {
       <Col xs="12" className="mt-5 mb-3">
         <IndicatorListLink>
           <Button color="primary" tag="a">
-            {t('see-all-indicators')} <Icon name="arrowRight" />
+            {t('see-all-indicators')} <Icon.ArrowRight />
           </Button>
         </IndicatorListLink>
       </Col>

--- a/components/orgs/OrgSelector.js
+++ b/components/orgs/OrgSelector.js
@@ -70,7 +70,7 @@ const OrgSelector = (props) => {
         <StyledDropdownToggle data-toggle="dropdown" tag="button">
           <OrgAvatar src={activeOrg.image} alt="" />
           <OrgTitle>{activeOrg.shortName}</OrgTitle>
-          <Icon name="angle-down" />
+          <Icon.AngleDown />
         </StyledDropdownToggle>
         <DropdownMenu role="menu">
           <DropdownContent>

--- a/components/plans/PlanSelector.tsx
+++ b/components/plans/PlanSelector.tsx
@@ -86,7 +86,7 @@ const PlanSelector = () => {
             alt=""
           />
           <PlanTitle>{plan.shortName || plan.name}</PlanTitle>
-          <Icon name="angle-down" />
+          <Icon.AngleDown />
         </StyledDropdownToggle>
         <DropdownMenu>
           {selectablePlans.map(

--- a/components/versioning/ActionVersionHistory.tsx
+++ b/components/versioning/ActionVersionHistory.tsx
@@ -90,12 +90,7 @@ const ActionVersionHistory = ({ action }: Props) => {
         className={isOpen ? 'open' : ''}
       >
         <VersionHistoryTitle>
-          <Icon
-            name="version"
-            className="me-2"
-            width="1.5rem"
-            height="1.5rem"
-          />
+          <Icon.Version className="me-2" width="1.5rem" height="1.5rem" />
           {t('version-history')}
           <Icon name={isOpen ? 'angle-down' : 'angle-right'} />
         </VersionHistoryTitle>

--- a/components/versioning/PlanVersionBanner.tsx
+++ b/components/versioning/PlanVersionBanner.tsx
@@ -36,12 +36,7 @@ const PlanVersionBanner = (props) => {
   return (
     <AnnouncementBanner>
       <VersionNote>
-        <Icon
-          name="version"
-          className="me-2"
-          width="2.25rem"
-          height="2.25rem"
-        />
+        <Icon.Version className="me-2" width="2.25rem" height="2.25rem" />
         <VersionName>
           {t('version-this-is-old')}
           <br />
@@ -58,12 +53,7 @@ const PlanVersionBanner = (props) => {
             {latestVersion?.versionName || latestVersion?.shortName}
           </LatestVersionName>
         </a>
-        <Icon
-          name="arrow-right"
-          className="ms-2"
-          width="2.25rem"
-          height="2.25rem"
-        />
+        <Icon.ArrowRight className="ms-2" width="2.25rem" height="2.25rem" />
       </LinkToLatestVersion>
     </AnnouncementBanner>
   );

--- a/components/versioning/PlanVersionSelector.tsx
+++ b/components/versioning/PlanVersionSelector.tsx
@@ -146,7 +146,7 @@ const PlanVersionSelector = (props) => {
             height="1.25rem"
           />
           {activeVersion.versionName}
-          <Icon name="angle-down" />
+          <Icon.AngleDown />
         </StyledDropdownToggle>
         <DropdownMenu>
           <DropdownItem header>{t('versions-list')}</DropdownItem>

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,7 @@ const customJestConfig = {
     '^@/pages/(.*)$': '<rootDir>/pages/$1',
     '^common/(.*)$': '<rootDir>/common/$1',
     '^context/(.*)$': '<rootDir>/context/$1',
+    '^@/public/static/themes/(.*)$': '<rootDir>/public/static/themes/$1',
   },
   testEnvironment: 'jest-environment-jsdom',
   testMatch: ['**/tests/**/*.test.[jt]s', '**/__tests__/**/*.test.[jt]s'],

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 const { secrets } = require('docker-secret');
+const { mkdir } = require('node:fs/promises');
+const lockfile = require('proper-lockfile');
 
 const path = require('path');
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
@@ -23,25 +25,34 @@ console.log(`
       ↝ NEXT_PUBLIC_API_URL: ${process.env.NEXT_PUBLIC_API_URL}
   `);
 
-function initializeThemes() {
-  console.log(`
-      ↝ Initialising themes
-  `);
-
-  const destPath = path.join(__dirname, 'public', 'static', 'themes');
-  const {
-    generateThemeSymlinks: generateThemeSymlinksPublic,
-  } = require('@kausal/themes/setup.cjs');
-
-  generateThemeSymlinksPublic(destPath, { verbose: false });
-
+async function initializeThemes() {
+  const staticPath = path.join(__dirname, 'public', 'static');
+  await mkdir(staticPath, { recursive: true });
+  const releaseThemeLock = await lockfile.lock('public/static');
   try {
-    const {
-      generateThemeSymlinks: generateThemeSymlinksPrivate,
-    } = require('@kausal/themes-private/setup.cjs');
-    generateThemeSymlinksPrivate(destPath, { verbose: false });
-  } catch (error) {
-    console.error(error);
+    const destPath = path.join(__dirname, 'public', 'static', 'themes');
+    let themesLinked = false;
+    try {
+      const {
+        generateThemeSymlinks: generateThemeSymlinksPrivate,
+      } = require('@kausal/themes-private/setup.cjs');
+      generateThemeSymlinksPrivate(destPath, { verbose: false });
+      themesLinked = true;
+    } catch (error) {
+      if (error.code !== 'MODULE_NOT_FOUND') {
+        console.error(error);
+        throw error;
+      }
+    }
+    if (!themesLinked) {
+      console.log('Private themes not found; using public themes');
+      const {
+        generateThemeSymlinks: generateThemeSymlinksPublic,
+      } = require('@kausal/themes/setup.cjs');
+      generateThemeSymlinksPublic(destPath, { verbose: false });
+    }
+  } finally {
+    await releaseThemeLock();
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "popper.js": "^1.16.1",
     "postinstall-postinstall": "^2.1.0",
     "prop-types": "^15.8.1",
+    "proper-lockfile": "^4.1.2",
     "react": "18.2.0",
     "react-bootstrap-typeahead": "^6.0.0-alpha.11",
     "react-copy-to-clipboard": "^5.1.0",
@@ -143,7 +144,7 @@
   },
   "packageManager": "yarn@3.2.1",
   "optionalDependencies": {
-    "@kausal/themes-private": "^0.4.17"
+    "@kausal/themes-private": "0.5.7"
   },
   "lint-staged": {
     "*.{tsx,ts,js,css,scss,md,json}": "prettier --write"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3612,10 +3612,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kausal/themes-private@npm:^0.4.17":
-  version: 0.4.17
-  resolution: "@kausal/themes-private@npm:0.4.17"
-  checksum: 282d8b2136b93b9df26ed255397afccd24d7c46110057b91cca10a57cc930432a71a4ad1ea53ebd5430444c8fc9b3d8b9ced2e5f531d58502d7a8c360be8b7e9
+"@kausal/themes-private@npm:0.5.7":
+  version: 0.5.7
+  resolution: "@kausal/themes-private@npm:0.5.7"
+  checksum: 6674ceb92a9ba56f07ab1e50795a6f8e163c4aeb1929af4dc5f4484f01e9503e4c3565560d559c4f660f01d4e373ac54380105372822ee3e9085905b1005f800
   languageName: node
   linkType: hard
 
@@ -16809,7 +16809,7 @@ __metadata:
     "@kausal/mapboxgl-legend": ^1.7.2
     "@kausal/plotly-custom": ^2.14.3
     "@kausal/themes": ^0.7.15
-    "@kausal/themes-private": ^0.4.17
+    "@kausal/themes-private": 0.5.7
     "@n8tb1t/use-scroll-position": ^2.0.3
     "@next/bundle-analyzer": ^12.1.6
     "@playwright/test": ^1.39.0
@@ -16875,6 +16875,7 @@ __metadata:
     postinstall-postinstall: ^2.1.0
     prettier: ^2.6.2
     prop-types: ^15.8.1
+    proper-lockfile: ^4.1.2
     react: 18.2.0
     react-bootstrap-typeahead: ^6.0.0-alpha.11
     react-color: ^2.19.3
@@ -19843,6 +19844,17 @@ __metadata:
     object-assign: ^4.1.1
     react-is: ^16.13.1
   checksum: c056d3f1c057cb7ff8344c645450e14f088a915d078dcda795041765047fa080d38e5d626560ccaac94a4e16e3aa15f3557c1a9a8d1174530955e992c675e459
+  languageName: node
+  linkType: hard
+
+"proper-lockfile@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "proper-lockfile@npm:4.1.2"
+  dependencies:
+    graceful-fs: ^4.2.4
+    retry: ^0.12.0
+    signal-exit: ^3.0.2
+  checksum: 00078ee6a61c216a56a6140c7d2a98c6c733b3678503002dc073ab8beca5d50ca271de4c85fca13b9b8ee2ff546c36674d1850509b84a04a5d0363bcb8638939
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Theme theme infra is changing between major versions 0.4 and 0.5,
and we need these changes to make the UI compatible

Review instructions:
The latter commit with the Icon usage changes is not strictly necessary, but I find it nice and it should only contain changes of the exact same type, while the former commit contains the actual real changes.

For the latter commit, notice that the old style name="xxx" still works too and is used in some places where it's more convenient. If the change feels unnecessary, we can just remove it and keep the old API.