### PR TITLE
Replace avatar image paths with theme variables

### DIFF
--- a/components/actions/ActionCard.tsx
+++ b/components/actions/ActionCard.tsx
@@ -8,6 +8,7 @@ import { getStatusColorForAction } from 'common/ActionStatusSummary';
 import { ActionLink } from 'common/links';
 import { useTheme } from 'styled-components';
 import { getActionTermContext } from 'common/i18n';
+import { getThemeStaticURL } from '@/common/theme';
 import { usePlan } from 'context/plan';
 import PlanChip from 'components/plans/PlanChip';
 import {
@@ -375,7 +376,7 @@ function ActionCard({
             <OrgLogo
               src={
                 primaryOrg?.logo?.rendition?.src ||
-                '/static/themes/default/images/default-avatar-org.png'
+                getThemeStaticURL(theme.defaultAvatarOrgImage)
               }
               alt=""
             />

--- a/components/actions/ActionHero.tsx
+++ b/components/actions/ActionHero.tsx
@@ -13,6 +13,7 @@ import { Category } from 'common/__generated__/graphql';
 import { Breadcrumbs } from 'components/common/Breadcrumbs';
 import { useTranslations } from 'next-intl';
 import ActionLogBanner from './ActionLogBanner';
+import { getThemeStaticURL } from '@/common/theme';
 
 const Hero = styled.header<{ $bgColor: string }>`
   position: relative;
@@ -270,7 +271,7 @@ function ActionHero(props: ActionHeroProps) {
                         <OrgLogo
                           src={
                             primaryOrg.logo?.rendition?.src ||
-                            '/static/themes/default/images/default-avatar-org.png'
+                            getThemeStaticURL(theme.defaultAvatarOrgImage)
                           }
                           alt=""
                         />

--- a/components/actions/ActionUpdatesList.js
+++ b/components/actions/ActionUpdatesList.js
@@ -8,6 +8,7 @@ import dayjs from '../../common/dayjs';
 import { usePlan } from '../../context/plan';
 import { useTranslations } from 'next-intl';
 import { useQuery } from '@apollo/experimental-nextjs-app-support/ssr';
+import { getThemeStaticURL } from '@/common/theme';
 
 const ActionUpdate = styled.article`
   padding: ${(props) => props.theme.spaces.s100};
@@ -63,8 +64,7 @@ const GET_ACTION_UPDATES = gql`
 function ActionStatusUpdate(props) {
   const { author = null, date, title, content } = props;
 
-  const defaultAvatarUrl =
-    '/static/themes/default/images/default-avatar-user.png';
+  const defaultAvatarUrl = getThemeStaticURL(theme.defaultAvatarOrgImage);
 
   return (
     <ActionUpdate>

--- a/components/actions/ContactPerson.tsx
+++ b/components/actions/ContactPerson.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
+import styled, { css, useTheme } from 'styled-components';
 
 import { gql } from '@apollo/client';
 import { useQuery } from '@apollo/experimental-nextjs-app-support/ssr';
@@ -13,6 +13,7 @@ import {
   PlanFeaturesContactPersonsPublicData,
 } from 'common/__generated__/graphql';
 import { useTranslations } from 'next-intl';
+import { getThemeStaticURL } from '@/common/theme';
 
 const Person = styled.div<{
   $isLeader: boolean;
@@ -188,6 +189,7 @@ function ContactPerson({ person, leader = false }: ContactPersonProps) {
   const fullName = `${person.firstName} ${person.lastName}`;
   const role = leader ? t('contact-person-main') : '';
   const withoutAvatar = !plan.features.contactPersonsShowPicture;
+  const theme = useTheme();
 
   return (
     <Person $isLeader={leader} $withoutAvatar={withoutAvatar}>
@@ -196,7 +198,7 @@ function ContactPerson({ person, leader = false }: ContactPersonProps) {
           <Avatar
             src={
               person.avatarUrl ||
-              '/static/themes/default/images/default-avatar-user.png'
+              getThemeStaticURL(theme.defaultAvatarUserImage)
             }
             className="rounded-circle"
             alt={`${role} ${fullName}`}

--- a/components/dashboard/cells/OrganizationCell.tsx
+++ b/components/dashboard/cells/OrganizationCell.tsx
@@ -1,5 +1,6 @@
 import { ActionListAction } from '../dashboard.types';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
+import { getThemeStaticURL } from '@/common/theme';
 
 interface Props {
   action: ActionListAction;
@@ -15,12 +16,13 @@ const OrganizationCell = ({ action }: Props) => {
   if (!action.primaryOrg) {
     return null;
   }
+  const theme = useTheme();
 
   return (
     <OrgLogo
       src={
         action.primaryOrg.logo?.rendition?.src ??
-        '/static/themes/default/images/default-avatar-org.png'
+        getThemeStaticURL(theme.defaultAvatarOrgImage)
       }
       alt={action.primaryOrg.name}
       id={`L${action.primaryOrg.id}`}

--- a/components/plans/PlanChip.tsx
+++ b/components/plans/PlanChip.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { transparentize } from 'polished';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { Theme } from '@kausal/themes/types';
+import { getThemeStaticURL } from '@/common/theme';
 
 const Tag = styled.div<{ $minWidth: string }>`
   display: flex;
@@ -110,13 +111,12 @@ const PlanChip = React.forwardRef<HTMLDivElement, PlanChipProps>(
       size = 'md',
       negative = false,
     } = props;
+    const theme = useTheme();
 
     return (
       <Tag ref={ref} $minWidth={MIN_WIDTH[size]}>
         <PlanAvatar
-          src={
-            planImage ?? '/static/themes/default/images/default-avatar-org.png'
-          }
+          src={planImage ?? getThemeStaticURL(theme.defaultAvatarOrgImage)}
           size={IMAGE_SIZES[size]}
           alt=""
         />

--- a/components/plans/PlanSelector.tsx
+++ b/components/plans/PlanSelector.tsx
@@ -1,8 +1,9 @@
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { transparentize } from 'polished';
 import { UncontrolledDropdown, DropdownToggle, DropdownMenu } from 'reactstrap';
 import { usePlan } from 'context/plan';
 import Icon from 'components/common/Icon';
+import { getThemeStaticURL } from '@/common/theme';
 
 import PlanLink from './PlanLink';
 
@@ -66,6 +67,7 @@ const PlanSelector = () => {
   const plan = usePlan();
   const { allRelatedPlans } = plan;
   if (!allRelatedPlans.length) return null;
+  const theme = useTheme();
 
   const selectablePlans = [
     ...plan.allRelatedPlans.filter(
@@ -81,7 +83,7 @@ const PlanSelector = () => {
           <PlanAvatar
             src={
               plan.image?.small?.src ??
-              '/static/themes/default/images/default-avatar-org.png'
+              getThemeStaticURL(theme.defaultAvatarOrgImage)
             }
             alt=""
           />


### PR DESCRIPTION
* Replaced hardcoded paths for default avatar images with theme variables;
* Applied `getThemeStaticURL()` to dynamically fetch the image URLs

Description in Slack https://kausaltech.slack.com/archives/C01AZ2V3656/p1722333114206229