### PR TITLE
Refactor: Handle absent avatars

### DIFF
--- a/components/actions/ContactPerson.tsx
+++ b/components/actions/ContactPerson.tsx
@@ -83,12 +83,10 @@ const Avatar = styled.div<{
   width: 5em;
   height: 5em;
   border-radius: 50%;
-  background-color: ${(props) =>
-    !props.hasAvatar ? props.theme.themeColors.light : 'transparent'};
+  background-color: transparent;
   background-size: cover;
   background-position: center;
-  background-image: ${(props) =>
-    !props.hasAvatar ? 'none' : `url(${props.src})`};
+  background-image: ${(props) => `url(${props.src})`};
   border: ${(props) =>
     props.$isLeader
       ? `4px solid ${props.theme.brandDark}`
@@ -204,6 +202,7 @@ function ContactPerson({ person, leader = false }: ContactPersonProps) {
   const fullName = `${person.firstName} ${person.lastName}`;
   const role = leader ? t('contact-person-main') : '';
   const withoutAvatar = !plan.features.contactPersonsShowPicture;
+  const theme = useTheme();
   const hasAvatar = Boolean(person.avatarUrl);
 
   return (
@@ -211,7 +210,10 @@ function ContactPerson({ person, leader = false }: ContactPersonProps) {
       {plan.features.contactPersonsShowPicture ? (
         <>
           <Avatar
-            src={person.avatarUrl || ''}
+            src={
+              person.avatarUrl ||
+              getThemeStaticURL(theme.defaultAvatarUserImage)
+            }
             hasAvatar={hasAvatar}
             $isLeader={leader}
             aria-label={`${role} ${fullName}`}

--- a/components/actions/ContactPerson.tsx
+++ b/components/actions/ContactPerson.tsx
@@ -75,9 +75,24 @@ const PersonOrg = styled.div`
   line-height: ${(props) => props.theme.lineHeightSm};
 `;
 
-const Avatar = styled.img`
+const Avatar = styled.div<{
+  src?: string;
+  hasAvatar: boolean;
+  $isLeader: boolean;
+}>`
   width: 5em;
   height: 5em;
+  border-radius: 50%;
+  background-color: ${(props) =>
+    !props.hasAvatar ? props.theme.themeColors.light : 'transparent'};
+  background-size: cover;
+  background-position: center;
+  background-image: ${(props) =>
+    !props.hasAvatar ? 'none' : `url(${props.src})`};
+  border: ${(props) =>
+    props.$isLeader
+      ? `4px solid ${props.theme.brandDark}`
+      : `2px solid ${props.theme.themeColors.light}`};
 `;
 
 const Address = styled.address`
@@ -189,21 +204,19 @@ function ContactPerson({ person, leader = false }: ContactPersonProps) {
   const fullName = `${person.firstName} ${person.lastName}`;
   const role = leader ? t('contact-person-main') : '';
   const withoutAvatar = !plan.features.contactPersonsShowPicture;
-  const theme = useTheme();
+  const hasAvatar = Boolean(person.avatarUrl);
 
   return (
     <Person $isLeader={leader} $withoutAvatar={withoutAvatar}>
       {plan.features.contactPersonsShowPicture ? (
-        <div>
+        <>
           <Avatar
-            src={
-              person.avatarUrl ||
-              getThemeStaticURL(theme.defaultAvatarUserImage)
-            }
-            className="rounded-circle"
-            alt={`${role} ${fullName}`}
+            src={person.avatarUrl || ''}
+            hasAvatar={hasAvatar}
+            $isLeader={leader}
+            aria-label={`${role} ${fullName}`}
           />
-        </div>
+        </>
       ) : (
         <span className="visually-hidden">{`${role} ${fullName}`}</span>
       )}


### PR DESCRIPTION
Display an empty circle when the avatar image is not provided (and not intentionally hidden).
* Replaced the `img` element with a styled `div` to get more control over avatar's placeholder;
* Added `hasAvatar` prop for conditional rendering;
* Removed the default path;
* Added `aria-label` for accessibility.

Before:
<img width="426" alt="Screen Shot 2024-07-31 at 13 10 43" src="https://github.com/user-attachments/assets/022d2d29-4e10-4c28-a21b-b548099a7278">

After:
<img width="345" alt="Screen Shot 2024-08-06 at 16 27 19" src="https://github.com/user-attachments/assets/7d562a8b-6df9-408d-bbbb-681208fd9f34">