### PR TITLE
Format time-to-goal better

### DIFF
--- a/components/graphs/IndicatorGraph.tsx
+++ b/components/graphs/IndicatorGraph.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import React from 'react';
-import dynamic from 'next/dynamic';
-import { merge, uniq } from 'lodash';
-import styled from 'styled-components';
-import { useTheme } from 'styled-components';
-import { transparentize } from 'polished';
+
 import { splitLines } from 'common/utils';
+import { merge, uniq } from 'lodash';
+import dynamic from 'next/dynamic';
 import { Data, Layout } from 'plotly.js';
+import { transparentize } from 'polished';
+import styled, { useTheme } from 'styled-components';
 
 const PlotContainer = styled.div<{ $vizHeight: number }>`
   height: ${(props) => props.$vizHeight}px;
@@ -276,9 +276,6 @@ const createTraces: (params: CreateTracesParams) => TracesOutput = (params) => {
     }
   }
 
-  // Avoid repetitive years to set max value of xaxis ticks
-  layoutConfig.xaxis!.nticks = uniqueXValues.length;
-
   return {
     layoutConfig,
     traces: newTraces,
@@ -489,6 +486,7 @@ function IndicatorGraph(props: IndicatorGraphProps) {
       plotlyData.push({
         ...goalTrace,
         type: 'scatter',
+        cliponaxis: false,
         mode: goalTrace.scenario ? 'markers' : 'lines+markers',
         line: {
           width: 3,

--- a/components/indicators/IndicatorValueSummary.js
+++ b/components/indicators/IndicatorValueSummary.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import { Row, Col } from 'reactstrap';
-import styled, { useTheme } from 'styled-components';
-import dayjs from '../../common/dayjs';
-import { beautifyValue } from '../../common/data/format';
+
 import { useLocale, useTranslations } from 'next-intl';
+import { Col, Row } from 'reactstrap';
+import styled, { useTheme } from 'styled-components';
+
+import { beautifyValue } from '../../common/data/format';
+import dayjs from '../../common/dayjs';
 
 const ValueSummary = styled.div`
   margin: 2em 0 0;
@@ -156,14 +158,13 @@ function IndicatorValueSummary(props) {
   let differenceDisplay = undefined;
   if (values.length > 0 && nextGoal) {
     const difference = nextGoal.value - values[values.length - 1].value;
-    const timeToGoal = `${dayjs(nextGoal.date)
-      .diff(now, 'years', true)
-      .toFixed(0)} ${' '} ${t('indicator-resolution-years')}`;
+    const timeToGoal = dayjs(now).to(dayjs(nextGoal.date));
     differenceDisplay = (
       <div className="mb-4">
         <ValueLabel>{t('indicator-time-to-goal')}</ValueLabel>
         <ValueDate>{timeToGoal}</ValueDate>
         <ValueDisplay>
+          {difference > 0 ? '+' : ''}
           {beautifyValue(difference, locale)}
           <ValueUnit>{diffUnitName}</ValueUnit>
         </ValueDisplay>


### PR DESCRIPTION
When we are less than a year from the indicator goal, the summary displays 0 years
<img width="763" alt="Screenshot 2024-08-13 at 20 29 51" src="https://github.com/user-attachments/assets/85c86a99-30e5-4ef2-9458-946dff24dc41">

Use `dayjs().to` to make time-to-goal human readable and localised
<img width="767" alt="Screenshot 2024-08-13 at 20 29 43" src="https://github.com/user-attachments/assets/c7602a44-2be5-4353-b6ca-9111b54d305f">

Add "+" to emphasise expected increase as opposed to decrease
<img width="758" alt="Screenshot 2024-08-13 at 20 28 20" src="https://github.com/user-attachments/assets/939b7c60-f53e-4fae-95b5-e4cba1ad2b18">

Also added a few quick customer requested improvements on plotly graph formatting.

