### PR TITLE
Feature/scheduled playwright tests

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -21,6 +21,7 @@ on:
 jobs:
   e2e_test:
     name: Run tests
+    #if: github.event.schedule == '0 21 * * 1-5'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -29,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Cache node modules
         uses: actions/cache@v3
@@ -86,6 +87,7 @@ jobs:
 
   accessibility_test:
     name: Run accessibility tests (Weekly)
+    #if: github.event.schedule == '0 21 * * 5'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -94,7 +96,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install yarn
         run: |

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -21,7 +21,6 @@ on:
 jobs:
   e2e_test:
     name: Run tests
-    if: github.event.schedule == '0 21 * * 1-5'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -87,7 +86,6 @@ jobs:
 
   accessibility_test:
     name: Run accessibility tests (Weekly)
-    if: github.event.schedule == '0 21 * * 5'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -9,7 +9,7 @@ on:
       frontend_base_url:
         description: 'Base url for environment to run tests against'
         required: true
-        default: 'http://{planId}.watch.staging.kausal.tech'
+        default: 'http://{planId}.watch-test.kausal.tech'
       backend_base_url:
         description: 'Base url for backend API'
         required: true
@@ -65,7 +65,7 @@ jobs:
             IFS=',' read -ra PLAN_IDS <<< "$TEST_PLAN_IDENTIFIERS"
             for PLAN_ID in "${PLAN_IDS[@]}"
             do
-              FRONTEND_BASE_URL="http://${PLAN_ID}.watch.staging.kausal.tech"
+              FRONTEND_BASE_URL="http://${PLAN_ID}.watch-test.kausal.tech"
               echo "Running tests for plan $PLAN_ID with FRONTEND_BASE_URL=$FRONTEND_BASE_URL"
               echo "APLANS_API_BASE_URL=https://api.watch.kausal.tech/v1" >> $GITHUB_ENV
             done
@@ -123,7 +123,7 @@ jobs:
             IFS=',' read -ra PLAN_IDS <<< "$TEST_PLAN_IDENTIFIERS"
             for PLAN_ID in "${PLAN_IDS[@]}"
             do
-              FRONTEND_BASE_URL="http://${PLAN_ID}.watch.staging.kausal.tech"
+              FRONTEND_BASE_URL="http://${PLAN_ID}.watch-test.kausal.tech"
               echo "Running tests for plan $PLAN_ID with FRONTEND_BASE_URL=$FRONTEND_BASE_URL"
               echo "APLANS_API_BASE_URL=https://api.watch.kausal.tech/v1" >> $GITHUB_ENV
             done

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -16,7 +16,7 @@ on:
         default: 'https://api.watch.kausal.tech/v1'
   schedule:
     - cron: '0 21 * * 1-5' # 21:00 UTC, 00:00 EEST
-    - cron: '0 21 * * 5' #once a week for accessibility check
+    - cron: '0 21 1 * *' #once a month
 
 jobs:
   e2e_test:
@@ -86,8 +86,8 @@ jobs:
           retention-days: 5
 
   accessibility_test:
-    name: Run accessibility tests (Weekly)
-    #if: github.event.schedule == '0 21 * * 5'
+    name: Run accessibility tests
+    #if: github.event.schedule == '0 21 1 * *'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code

--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -16,10 +16,12 @@ on:
         default: 'https://api.watch.kausal.tech/v1'
   schedule:
     - cron: '0 21 * * 1-5' # 21:00 UTC, 00:00 EEST
+    - cron: '0 21 * * 5' #once a week for accessibility check
 
 jobs:
   e2e_test:
     name: Run tests
+    if: github.event.schedule == '0 21 * * 1-5'
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -80,5 +82,63 @@ jobs:
         if: always()
         with:
           name: playwright-report
+          path: playwright-report/
+          retention-days: 5
+
+  accessibility_test:
+    name: Run accessibility tests (Weekly)
+    if: github.event.schedule == '0 21 * * 5'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install yarn
+        run: |
+          corepack enable
+          yarn set version 3.2.1
+          yarn config set nodeLinker 'node-modules'
+          yarn config set npmScopes.kausal.npmRegistryServer "${{ secrets.NPM_REGISTRY_SERVER }}"
+          yarn config set npmScopes.kausal.npmAlwaysAuth true
+          yarn config set npmScopes.kausal.npmAuthIdent ${{ secrets.NPM_AUTH_IDENT }}
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Playwright install
+        run: node_modules/.bin/playwright install --with-deps
+
+      - name: Set TEST_PLAN_IDENTIFIERS for each job
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "TEST_PLAN_IDENTIFIERS=${{ github.event.inputs.plan_identifiers }}" >> $GITHUB_ENV
+            echo "FRONTEND_BASE_URL=${{ github.event.inputs.frontend_base_url }}" >> $GITHUB_ENV
+          else
+            echo "TEST_PLAN_IDENTIFIERS=${{ secrets.TEST_PLAN_IDENTIFIERS }}" >> $GITHUB_ENV
+            IFS=',' read -ra PLAN_IDS <<< "$TEST_PLAN_IDENTIFIERS"
+            for PLAN_ID in "${PLAN_IDS[@]}"
+            do
+              FRONTEND_BASE_URL="http://${PLAN_ID}.watch.staging.kausal.tech"
+              echo "Running tests for plan $PLAN_ID with FRONTEND_BASE_URL=$FRONTEND_BASE_URL"
+              echo "APLANS_API_BASE_URL=https://api.watch.kausal.tech/v1" >> $GITHUB_ENV
+            done
+          fi
+
+      - name: Running Playwright accessibility tests
+        run: node_modules/.bin/playwright test accessibility.spec.ts
+        env:
+          TEST_PLAN_IDENTIFIERS: ${{ env.TEST_PLAN_IDENTIFIERS }}
+          TEST_PAGE_BASE_URL: ${{ env.FRONTEND_BASE_URL }}
+          APLANS_API_BASE_URL: ${{ env.APLANS_API_BASE_URL }}
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: accessibility-playwright-report
           path: playwright-report/
           retention-days: 5

--- a/e2e-tests/accessibility.spec.ts
+++ b/e2e-tests/accessibility.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test as base } from '@playwright/test';
+import {
+  getIdentifiersToTest,
+  PlanContext,
+  checkAccessibility,
+} from './context';
+
+const test = base.extend<{ ctx: PlanContext }>({});
+
+const testPlanAccessibility = (planId: string) =>
+  test.describe(`Accessibility tests for ${planId}`, () => {
+    test.describe.configure({ mode: 'serial' });
+
+    test.use({
+      ctx: async ({}, use) => {
+        const planInfo = await PlanContext.fromPlanId(planId);
+        await use(planInfo);
+      },
+    });
+
+    test.beforeEach(async ({ page, ctx }) => {
+      await page.goto(ctx.baseURL);
+    });
+
+    test('Check accessibility on main pages', async ({ page, ctx }) => {
+      await checkAccessibility(page);
+    });
+  });
+
+getIdentifiersToTest().forEach((plan) => testPlanAccessibility(plan));

--- a/e2e-tests/accessibility.spec.ts
+++ b/e2e-tests/accessibility.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test as base } from '@playwright/test';
+import { test as base } from '@playwright/test';
 import {
   getIdentifiersToTest,
   PlanContext,

--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -88,19 +88,25 @@ const testPlan = (planId: string) =>
         !items || items.length === 0,
         'No children category or content pages for plan'
       );
+
       const nav = page.locator('nav#global-navigation-bar');
-      const emptyPageMenuLink = nav.getByRole('link', {
+      const emptyPageMenuButton = nav.getByRole('button', {
         name: EmptyPageMenuItem?.page.title,
         exact: true,
       });
-      await emptyPageMenuLink.waitFor({ state: 'visible', timeout: 150000 });
-      await emptyPageMenuLink.click();
 
-      const firstItemLink = nav.getByRole('link', {
-        name: items[0].page.title,
-        exact: true,
-      });
-      await firstItemLink.click();
+      await emptyPageMenuButton.waitFor({ state: 'visible', timeout: 15000 });
+      await emptyPageMenuButton.click();
+
+      const firstItemButton = nav
+        .locator('.dropdown-menu')
+        .getByRole('menuitem', {
+          name: items[0].page.title,
+          exact: true,
+        });
+
+      await firstItemButton.waitFor({ state: 'visible', timeout: 15000 });
+      await firstItemButton.click();
 
       await expect(page.locator('main#main')).toBeVisible();
 

--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -93,6 +93,7 @@ const testPlan = (planId: string) =>
         name: EmptyPageMenuItem?.page.title,
         exact: true,
       });
+      await emptyPageMenuLink.waitFor({ state: 'visible', timeout: 150000 });
       await emptyPageMenuLink.click();
 
       const firstItemLink = nav.getByRole('link', {

--- a/e2e-tests/basic.spec.ts
+++ b/e2e-tests/basic.spec.ts
@@ -10,7 +10,6 @@ async function navigateAndCheckLayout(page, url, ctx) {
   await expect(page.locator('nav#branding-navigation-bar')).toBeVisible();
   await expect(page.locator('nav#global-navigation-bar')).toBeVisible();
   await expect(page.locator('main#main')).toBeVisible();
-  await ctx.checkAccessibility(page);
 }
 
 const testPlan = (planId: string) =>

--- a/e2e-tests/context.ts
+++ b/e2e-tests/context.ts
@@ -288,21 +288,18 @@ export class PlanContext {
 
 export async function checkAccessibility(page: Page) {
   await page.waitForLoadState('networkidle');
-  const results = await new AxeBuilder({ page }).analyze();
-  const violationsToIgnore = ['frame-title'];
-  const criticalAndSeriousViolations = results.violations.filter(
-    (violation) =>
-      (violation.impact === 'critical' || violation.impact === 'serious') &&
-      !violationsToIgnore.includes(violation.id)
+
+  const results = await new AxeBuilder({ page })
+    .disableRules('color-contrast')
+    .analyze();
+
+  const criticalViolations = results.violations.filter(
+    (violation) => violation.impact === 'critical'
   );
 
-  if (criticalAndSeriousViolations.length > 0) {
-    console.error(
-      'Critical and serious accessibility violations:',
-      criticalAndSeriousViolations
-    );
-
-    expect(criticalAndSeriousViolations).toEqual([]);
+  if (criticalViolations.length > 0) {
+    console.error('Critical accessibility violations:', criticalViolations);
+    expect(criticalViolations).toEqual([]);
   }
 }
 

--- a/e2e-tests/context.ts
+++ b/e2e-tests/context.ts
@@ -284,24 +284,25 @@ export class PlanContext {
     const planIndicators = res.data!.planIndicators!;
     return new PlanContext(data, baseURL, planIndicators);
   }
+}
 
-  async checkAccessibility(page: Page) {
-    await page.waitForLoadState('networkidle');
-    const results = await new AxeBuilder({ page }).analyze();
-    const violationsToIgnore = ['frame-title'];
-    const criticalAndSeriousViolations = results.violations.filter(
-      (violation) =>
-        (violation.impact === 'critical' || violation.impact === 'serious') &&
-        !violationsToIgnore.includes(violation.id)
+export async function checkAccessibility(page: Page) {
+  await page.waitForLoadState('networkidle');
+  const results = await new AxeBuilder({ page }).analyze();
+  const violationsToIgnore = ['frame-title'];
+  const criticalAndSeriousViolations = results.violations.filter(
+    (violation) =>
+      (violation.impact === 'critical' || violation.impact === 'serious') &&
+      !violationsToIgnore.includes(violation.id)
+  );
+
+  if (criticalAndSeriousViolations.length > 0) {
+    console.error(
+      'Critical and serious accessibility violations:',
+      criticalAndSeriousViolations
     );
 
-    if (criticalAndSeriousViolations.length > 0) {
-      console.error(
-        'Critical and serious accessibility violations:',
-        criticalAndSeriousViolations
-      );
-    }
-    //expect(criticalAndSeriousViolations).toEqual([]);
+    expect(criticalAndSeriousViolations).toEqual([]);
   }
 }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   expect: {
     timeout: 30000,
   },
-  timeout: 250000,
+  timeout: 120000,
 
   /* Configure projects for major browsers */
   projects: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   expect: {
     timeout: 30000,
   },
-  timeout: 120000,
+  timeout: 250000,
 
   /* Configure projects for major browsers */
   projects: [


### PR DESCRIPTION
Update CI workflow to separate and schedule playwright basic and accessibility tests.
* Added separate jobs for basic and accessibility tests in the ci-e2e.yaml workflow.
* Basic tests (basic.spec.ts) now run daily from Monday to Friday.
* Accessibility tests (accessibility.spec.ts) now run once a month and check only for the critical issues.