### PR TITLE
Implement Google analytics script

### DIFF
--- a/components/GoogleAnalytics.tsx
+++ b/components/GoogleAnalytics.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import Script from 'next/script';
+
+type Props = {
+  trackingId: string;
+};
+
+declare global {
+  interface Window {
+    dataLayer: any[];
+  }
+}
+
+const GoogleAnalytics = ({ trackingId }: Props) => {
+  useEffect(() => {
+    window.dataLayer = window.dataLayer || [];
+    function gtag(...args: any[]) {
+      window.dataLayer.push(args);
+    }
+    gtag('js', new Date());
+    gtag('config', trackingId);
+  }, [trackingId]);
+
+  return (
+    <Script
+      type="text/javascript"
+      async
+      src={`https://www.googletagmanager.com/gtag/js?id=${trackingId}`}
+    />
+  );
+};
+
+export default GoogleAnalytics;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -10,6 +10,7 @@ import GlobalNav from 'components/common/GlobalNav';
 import TopToolBar from './common/TopToolBar';
 import SkipToContent from 'components/common/SkipToContent';
 import ApplicationStateBanner from 'components/common/ApplicationStateBanner';
+import GoogleAnalytics from 'components/GoogleAnalytics';
 import { getActiveBranch } from 'common/links';
 import { useTheme } from 'styled-components';
 import { deploymentType } from '@/common/environment';
@@ -89,6 +90,8 @@ function Header() {
       }));
   }, [plan.mainMenu]);
 
+  const googleAnalyticsId = theme.settings?.googleAnalyticsId;
+
   return (
     <header style={{ position: 'relative' }}>
       <SkipToContent />
@@ -105,6 +108,7 @@ function Header() {
         customToolbarItems={theme.settings.customNavbarTools || []}
         sticky={theme.settings.stickyNavigation}
       />
+      {googleAnalyticsId && <GoogleAnalytics trackingId={googleAnalyticsId} />}
     </header>
   );
 }


### PR DESCRIPTION
Integrate Google Analytics script (a customer request):

* Added a new GoogleAnalytics component with a `trackingId` prop;
* The component conditionally loads the GA script based on the `googleAnalyticsId` theme variable.

Related Asana https://app.asana.com/0/1202880927552397/1207663896451596/f