### PR TITLE
Various bug and style fixes

### DIFF
--- a/app/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/ContentPage.tsx
+++ b/app/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/ContentPage.tsx
@@ -1,22 +1,23 @@
 'use client';
 
 import React from 'react';
-import { Container, Row, Col } from 'reactstrap';
-import { useTheme } from 'styled-components';
-import RichText from 'components/common/RichText';
-import StreamField from 'components/common/StreamField';
+
+import { GetContentPageQuery } from 'common/__generated__/graphql';
 import { getBgImageAlignment } from 'common/images';
+import CategoryPageContent from 'components/categories/CategoryPageContent';
+import RichText from 'components/common/RichText';
+import SecondaryNavigation from 'components/common/SecondaryNavigation';
+import StreamField from 'components/common/StreamField';
 import CategoryPageHeaderBlock from 'components/contentblocks/CategoryPageHeaderBlock';
 import ContentPageHeaderBlock from 'components/contentblocks/ContentPageHeaderBlock';
-import SecondaryNavigation from 'components/common/SecondaryNavigation';
-import { GetContentPageQuery } from 'common/__generated__/graphql';
-import CategoryPageContent from 'components/categories/CategoryPageContent';
+import { Col, Container, Row } from 'reactstrap';
+import { useTheme } from 'styled-components';
 
 export type GeneralPlanPage = NonNullable<GetContentPageQuery['planPage']>;
 
 type PageHeaderBlockProps = {
   page: GeneralPlanPage;
-  color?: string | null;
+  color?: string | false | null | undefined;
 };
 
 const PageHeaderBlock = ({ color, page }: PageHeaderBlockProps) => {
@@ -90,7 +91,7 @@ export const Content = ({ page }: { page: GeneralPlanPage }) => {
     <article>
       <PageHeaderBlock
         page={page}
-        color={isCategoryPage ? pageSectionColor : undefined}
+        color={isCategoryPage ? categoryColor : undefined}
       />
 
       {isCategoryPage ? (

--- a/components/actions/ActionHero.tsx
+++ b/components/actions/ActionHero.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
-import { Container, Row, Col } from 'reactstrap';
-import styled from 'styled-components';
-import { useTheme } from 'styled-components';
-import { useSession } from 'next-auth/react';
+
+import { Category } from 'common/__generated__/graphql';
+import { getBreadcrumbsFromCategoryHierarchy } from 'common/categories';
 import { getActionTermContext } from 'common/i18n';
 import { ActionLink, ActionListLink, OrganizationLink } from 'common/links';
-import { usePlan } from 'context/plan';
-
-import Icon from 'components/common/Icon';
-import { getBreadcrumbsFromCategoryHierarchy } from 'common/categories';
-import { Category } from 'common/__generated__/graphql';
 import { Breadcrumbs } from 'components/common/Breadcrumbs';
+import Icon from 'components/common/Icon';
+import { usePlan } from 'context/plan';
+import { useSession } from 'next-auth/react';
 import { useTranslations } from 'next-intl';
-import ActionLogBanner from './ActionLogBanner';
+import { Col, Container, Row } from 'reactstrap';
+import styled, { useTheme } from 'styled-components';
+
 import { getThemeStaticURL } from '@/common/theme';
+
+import ActionLogBanner from './ActionLogBanner';
 
 const Hero = styled.header<{ $bgColor: string }>`
   position: relative;
@@ -105,15 +106,11 @@ const ImageCredit = styled.span`
   position: absolute;
   top: 0;
   right: 0;
-  padding: 0.25rem 0.5rem;
+  padding: 0.1rem 0.25rem;
   background-color: rgba(255, 255, 255, 0.66);
   font-size: ${(props) => props.theme.fontSizeSm};
   font-family: ${(props) =>
-      `${props.theme.fontFamilyTiny}, ${props.theme.fontFamilyFallback}`}
-    @media (min-width: ${(props) => props.theme.breakpointLg}) {
-    top: inherit;
-    bottom: 0;
-  }
+    `${props.theme.fontFamilyTiny}, ${props.theme.fontFamilyFallback}`};
 `;
 
 const ActionHeadline = styled.h1`

--- a/components/common/Accordion.tsx
+++ b/components/common/Accordion.tsx
@@ -1,14 +1,15 @@
-import React, { useState, useEffect } from 'react';
-import { Collapse, UncontrolledTooltip } from 'reactstrap';
-import PropTypes from 'prop-types';
-import styled from 'styled-components';
-import { CopyToClipboard } from 'react-copy-to-clipboard';
-import { isServer } from 'common/environment';
+import React, { useEffect, useState } from 'react';
 
+import { isServer } from 'common/environment';
 import Icon from 'components/common/Icon';
-import { replaceHashWithoutScrolling } from '../../common/links';
 import { useTranslations } from 'next-intl';
 import { usePathname } from 'next/navigation';
+import PropTypes from 'prop-types';
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { Collapse, UncontrolledTooltip } from 'reactstrap';
+import styled from 'styled-components';
+
+import { replaceHashWithoutScrolling } from '../../common/links';
 
 const Header = styled.h3<{ $small?: boolean }>`
   position: relative;
@@ -58,7 +59,9 @@ const TriggerIcon = styled.span`
   flex-grow: 0;
   flex-shrink: 0;
   margin-right: ${(props) => props.theme.spaces.s050};
-  color: ${(props) => props.theme.themeColors.dark};
+  color: ${(props) => props.theme.linkColor};
+  font-size: 2.5rem;
+  line-height: 1.75rem;
   font-weight: ${(props) => props.theme.fontWeightNormal};
   text-align: center;
 `;
@@ -71,7 +74,7 @@ const QuestionTrigger = styled.button`
   margin: 0 0 1em;
   text-align: left;
   font-size: inherit;
-  color: ${(props) => props.theme.linkColor};
+  color: ${(props) => props.theme.themeColors.black};
   font-weight: ${(props) => props.theme.fontWeightBold};
   line-height: ${(props) => props.theme.lineHeightMd};
   hyphens: manual;

--- a/components/common/RichText.tsx
+++ b/components/common/RichText.tsx
@@ -61,6 +61,9 @@ type RichTextImageProps = {
 };
 
 const StyledRichText = styled.div`
+  // break words that can not fit on single line
+  overflow-wrap: break-word;
+
   .responsive-object {
     position: relative;
   }

--- a/components/contentblocks/CategoryPageHeaderBlock.tsx
+++ b/components/contentblocks/CategoryPageHeaderBlock.tsx
@@ -1,27 +1,27 @@
-import React, { useContext } from 'react';
-import { gql } from '@apollo/client';
-import { useQuery } from '@apollo/experimental-nextjs-app-support/ssr';
+import React from 'react';
 
-import { Container, Row, Col } from 'reactstrap';
-import styled from 'styled-components';
-import { Theme } from '@kausal/themes/types';
-import PlanContext, { usePlan } from 'context/plan';
-
-import AttributesBlock, { Attributes } from 'components/common/AttributesBlock';
-import { useTheme } from 'styled-components';
 import {
   CategoryPageMainTopBlock,
   CategoryTypePageLevelLayout,
   GetCategoryAttributeTypesQuery,
 } from 'common/__generated__/graphql';
+import { getBreadcrumbsFromCategoryHierarchy } from 'common/categories';
+import AttributesBlock, { Attributes } from 'components/common/AttributesBlock';
+import { Breadcrumbs } from 'components/common/Breadcrumbs';
 import CategoryPageStreamField, {
   CategoryPage,
 } from 'components/common/CategoryPageStreamField';
 import { ChartType } from 'components/dashboard/ActionStatusGraphs';
-import ActionStatusGraphsBlock from './ActionStatusGraphsBlock';
-import { Breadcrumbs } from 'components/common/Breadcrumbs';
-import { getBreadcrumbsFromCategoryHierarchy } from 'common/categories';
+import { usePlan } from 'context/plan';
 import { useTranslations } from 'next-intl';
+import { Col, Container, Row } from 'reactstrap';
+import styled, { useTheme } from 'styled-components';
+
+import { gql } from '@apollo/client';
+import { useQuery } from '@apollo/experimental-nextjs-app-support/ssr';
+import { Theme } from '@kausal/themes/types';
+
+import ActionStatusGraphsBlock from './ActionStatusGraphsBlock';
 
 export const GET_CATEGORY_ATTRIBUTE_TYPES = gql`
   query GetCategoryAttributeTypes($plan: ID!) {
@@ -105,15 +105,11 @@ const ImageCredit = styled.span`
   position: absolute;
   top: 0;
   right: 0;
-  padding: 0.25rem 0.5rem;
+  padding: 0.1rem 0.25rem;
   background-color: rgba(255, 255, 255, 0.66);
   font-size: ${(props) => props.theme.fontSizeSm};
   font-family: ${(props) =>
     `${props.theme.fontFamilyTiny}, ${props.theme.fontFamilyFallback}`};
-  @media (min-width: ${(props) => props.theme.breakpointMd}) {
-    top: inherit;
-    bottom: 0;
-  }
 `;
 
 const HeaderContent = styled.div<{
@@ -270,32 +266,34 @@ interface Props {
   iconImage;
   headerImage;
   imageAlign?: string;
-  color;
+  color?;
   attributes;
   typeId;
   level;
   layout?: CategoryTypePageLevelLayout['layoutMainTop'];
 }
 
-function CategoryPageHeaderBlock({
-  page,
-  title,
-  categoryId,
-  identifier,
-  lead,
-  iconImage,
-  headerImage,
-  imageAlign = 'center',
-  color,
-  attributes,
-  typeId,
-  level,
-  layout,
-}: Props) {
+function CategoryPageHeaderBlock(props: Props) {
+  const {
+    page,
+    title,
+    categoryId,
+    identifier,
+    lead,
+    iconImage,
+    headerImage,
+    imageAlign,
+    color,
+    attributes,
+    typeId,
+    level,
+    layout,
+  } = props;
   const plan = usePlan();
   const theme = useTheme();
   const t = useTranslations();
 
+  console.log(props);
   const showIdentifiers =
     !plan.primaryActionClassification?.hideCategoryIdentifiers;
 

--- a/components/contentblocks/CategoryPageHeaderBlock.tsx
+++ b/components/contentblocks/CategoryPageHeaderBlock.tsx
@@ -293,7 +293,6 @@ function CategoryPageHeaderBlock(props: Props) {
   const theme = useTheme();
   const t = useTranslations();
 
-  console.log(props);
   const showIdentifiers =
     !plan.primaryActionClassification?.hideCategoryIdentifiers;
 

--- a/components/contentblocks/ContentPageHeaderBlock.js
+++ b/components/contentblocks/ContentPageHeaderBlock.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import { Container, Row, Col } from 'reactstrap';
-import styled from 'styled-components';
-import { readableColor } from 'polished';
 import { useTranslations } from 'next-intl';
+import { readableColor } from 'polished';
+import PropTypes from 'prop-types';
+import { Col, Container, Row } from 'reactstrap';
+import styled from 'styled-components';
 
 const HeaderImage = styled.div`
   background-image: url(${(props) => props.image});
@@ -51,16 +51,12 @@ const ImageCredit = styled.span`
   position: absolute;
   top: 0;
   right: 0;
-  padding: 0.25rem 0.5rem;
+  padding: 0.1rem 0.25rem;
   background-color: rgba(255, 255, 255, 0.66);
   color: #000000;
   font-size: ${(props) => props.theme.fontSizeSm};
   font-family: ${(props) =>
-      `${props.theme.fontFamilyTiny}, ${props.theme.fontFamilyFallback}`}
-    @media (min-width: ${(props) => props.theme.breakpointMd}) {
-    top: inherit;
-    bottom: 0;
-  }
+    `${props.theme.fontFamilyTiny}, ${props.theme.fontFamilyFallback}`};
 `;
 
 const ContentPageHeaderBlock = (props) => {

--- a/components/home/HeroFullImage.tsx
+++ b/components/home/HeroFullImage.tsx
@@ -1,10 +1,10 @@
-import { useTheme } from 'styled-components';
-import { Container } from 'reactstrap';
-import styled from 'styled-components';
-import { readableColor } from 'polished';
 import RichText from 'components/common/RichText';
-import { Theme } from '@kausal/themes/types';
 import { useTranslations } from 'next-intl';
+import { readableColor } from 'polished';
+import { Container } from 'reactstrap';
+import styled, { useTheme } from 'styled-components';
+
+import { Theme } from '@kausal/themes/types';
 
 /**
  * Pulls the specified hero height from the theme if defined
@@ -146,15 +146,11 @@ const ImageCredit = styled.span`
   position: absolute;
   top: 0;
   right: 0;
-  padding: 0.25rem 0.5rem;
+  padding: 0.1rem 0.25rem;
   background-color: rgba(255, 255, 255, 0.66);
   font-size: ${(props) => props.theme.fontSizeSm};
   font-family: ${(props) =>
-      `${props.theme.fontFamilyTiny}, ${props.theme.fontFamilyFallback}`}
-    @media (min-width: ${(props) => props.theme.breakpointMd}) {
-    top: inherit;
-    bottom: 0;
-  }
+    `${props.theme.fontFamilyTiny}, ${props.theme.fontFamilyFallback}`};
 `;
 
 interface HeroFullImageProps {

--- a/components/home/HeroSmallImage.tsx
+++ b/components/home/HeroSmallImage.tsx
@@ -1,9 +1,7 @@
-import { useTheme } from 'styled-components';
-import { Col, Container } from 'reactstrap';
-import styled from 'styled-components';
-
 import RichText from 'components/common/RichText';
 import { useTranslations } from 'next-intl';
+import { Col, Container } from 'reactstrap';
+import styled, { useTheme } from 'styled-components';
 
 const Hero = styled.div`
   width: 100%;
@@ -75,15 +73,11 @@ const ImageCredit = styled.span`
   position: absolute;
   top: 0;
   right: 0;
-  padding: 0.25rem 0.5rem;
+  padding: 0.1rem 0.25rem;
   background-color: rgba(255, 255, 255, 0.66);
   font-size: ${(props) => props.theme.fontSizeSm};
   font-family: ${(props) =>
     `${props.theme.fontFamilyTiny}, ${props.theme.fontFamilyFallback}`};
-  @media (min-width: ${(props) => props.theme.breakpointMd}) {
-    top: inherit;
-    bottom: 0;
-  }
 `;
 
 interface HeroSmallImageProps {

--- a/components/indicators/IndicatorProgressBar.tsx
+++ b/components/indicators/IndicatorProgressBar.tsx
@@ -297,6 +297,7 @@ function IndicatorProgressBar(props: IndicatorProgressBarProps) {
   //const hasStartValue = Math.abs(startValue - latestValue)/latestValue > 0.01;
   const hasStartValue = true;
   const showReduction = true; // show reduction if change is more than 20%
+  const hasGoal = isNormalized && !goalValue.normalizedValue ? false : true; // handle cases where we don't have normalized goal
 
   // For simplicity, currently only supports indicators
   // where the goal is towards reduction of a value
@@ -316,7 +317,7 @@ function IndicatorProgressBar(props: IndicatorProgressBarProps) {
     w: roundedValues.latest * scale,
   };
   const goalBar = {
-    x: bars.w - Math.max(MIN_BAR_WIDTH, +roundedValues.goal * scale),
+    x: bars.w - Math.max(MIN_BAR_WIDTH, +roundedValues.goal * scale) || 0,
     y: topMargin + 2 * barHeight,
     w:
       roundedValues.goal && +roundedValues.goal > 0
@@ -567,7 +568,7 @@ function IndicatorProgressBar(props: IndicatorProgressBarProps) {
               opacity={0}
               fill={latestColor}
             />
-            {goalValue && (
+            {hasGoal && (
               <line
                 className="latest-line"
                 y1={segmentsY}
@@ -605,21 +606,28 @@ function IndicatorProgressBar(props: IndicatorProgressBarProps) {
                 }
               />
             </g>
-            <motion.text
-              className="latest-text"
-              translateX={bars.w - latestBar.w}
-              translateY={segmentsY + barMargin * 3}
-              textAnchor="left"
-              opacity={0}
-            >
-              <SegmentHeader>{t('to-reduce')}</SegmentHeader>
-              <SegmentValue x="0" dy="16">
-                {formatValue(roundedValues.latest - roundedValues.goal, locale)}{' '}
-                {displayUnit}
-              </SegmentValue>
-            </motion.text>
+            {hasGoal && (
+              <>
+                <motion.text
+                  className="latest-text"
+                  translateX={bars.w - latestBar.w}
+                  translateY={segmentsY + barMargin * 3}
+                  textAnchor="left"
+                  opacity={0}
+                >
+                  <SegmentHeader>{t('to-reduce')}</SegmentHeader>
+                  <SegmentValue x="0" dy="16">
+                    {formatValue(
+                      roundedValues.latest - roundedValues.goal,
+                      locale
+                    )}{' '}
+                    {displayUnit}
+                  </SegmentValue>
+                </motion.text>
+              </>
+            )}
             {/* Goal bar */}
-            {goalValue && (
+            {hasGoal && (
               <BarBase
                 x={goalBar.x}
                 y={goalBar.y}
@@ -639,41 +647,46 @@ function IndicatorProgressBar(props: IndicatorProgressBarProps) {
                 strokeDasharray="2,4"
               />
             )}
-            <line
-              x1={goalBar.x}
-              y1={segmentsY}
-              x2={goalBar.x + goalBar.w}
-              y2={segmentsY}
-              stroke={goalColor}
-              strokeWidth="2"
-            />
-            <ValueGroup
-              textAnchor={goalBar.w > 120 ? 'start' : 'end'}
-              transform={`translate(${
-                goalBar.w > 120 ? goalBar.x + 4 : goalBar.x - 8
-              } ${goalBar.y})`}
-              date={graphValues.goalYear}
-              value={formatValue(roundedValues.goal, locale)}
-              unit={displayUnit}
-              locale={locale}
-              negative={
-                readableColor(
-                  startColor,
-                  theme.themeColors.black,
-                  theme.themeColors.white
-                ) === theme.themeColors.white || goalBar.w < 120
-              }
-            />
-            <text
-              transform={`translate(${spaceTextBlock(goalBar.x, [
-                '.reduced-text',
-                '.latest-text',
-              ])} ${segmentsY + barMargin * 3})`}
-              textAnchor="left"
-            >
-              <SegmentHeader>{t('bar-goal')}</SegmentHeader>
-              <SegmentValue></SegmentValue>
-            </text>
+            {hasGoal && (
+              <>
+                <line
+                  x1={goalBar.x}
+                  y1={segmentsY}
+                  x2={goalBar.x + goalBar.w}
+                  y2={segmentsY}
+                  stroke={goalColor}
+                  strokeWidth="2"
+                />
+
+                <ValueGroup
+                  textAnchor={goalBar.w > 120 ? 'start' : 'end'}
+                  transform={`translate(${
+                    goalBar.w > 120 ? goalBar.x + 4 : goalBar.x - 8
+                  } ${goalBar.y})`}
+                  date={graphValues.goalYear}
+                  value={formatValue(roundedValues.goal, locale)}
+                  unit={displayUnit}
+                  locale={locale}
+                  negative={
+                    readableColor(
+                      startColor,
+                      theme.themeColors.black,
+                      theme.themeColors.white
+                    ) === theme.themeColors.white || goalBar.w < 120
+                  }
+                />
+                <text
+                  transform={`translate(${spaceTextBlock(goalBar.x, [
+                    '.reduced-text',
+                    '.latest-text',
+                  ])} ${segmentsY + barMargin * 3})`}
+                  textAnchor="left"
+                >
+                  <SegmentHeader>{t('bar-goal')}</SegmentHeader>
+                  <SegmentValue></SegmentValue>
+                </text>
+              </>
+            )}
             <line
               x1={bars.w - 1}
               x2={bars.w - 1}
@@ -699,7 +712,7 @@ function IndicatorProgressBar(props: IndicatorProgressBarProps) {
             >
               <DateText>{graphValues.latestYear}</DateText>
             </text>
-            {goalValue && (
+            {hasGoal && (
               <text
                 transform={`translate(${canvas.w - 10} ${
                   goalBar.y + barHeight / 2

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
   },
   "packageManager": "yarn@3.2.1",
   "optionalDependencies": {
-    "@kausal/themes-private": "^0.5.12"
+    "@kausal/themes-private": "^0.5.13"
   },
   "lint-staged": {
     "*.{tsx,ts,js,css,scss,md,json}": "prettier --write"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3612,10 +3612,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kausal/themes-private@npm:^0.5.12":
-  version: 0.5.12
-  resolution: "@kausal/themes-private@npm:0.5.12"
-  checksum: 0cde416b81ded59728698f2922ffd6aee7cf8b0eff630bcbef04092569a50603b0c49b77136f02e3f4ac7c9c47b8f4c412d71275bb86e22e91088ab12a0c66f5
+"@kausal/themes-private@npm:^0.5.13":
+  version: 0.5.13
+  resolution: "@kausal/themes-private@npm:0.5.13"
+  checksum: a7ca0e79dcc80a428a102a323f1b23e6ac8009b42b17c53c7f7b8eafe22c7add85803ba3d9d60f3531d9bb1f52cac6ded2535f75e727b0dd17fbdc893f3ec05f
   languageName: node
   linkType: hard
 
@@ -16842,7 +16842,7 @@ __metadata:
     "@kausal/mapboxgl-legend": ^1.7.2
     "@kausal/plotly-custom": ^2.32.0
     "@kausal/themes": ^0.8.2
-    "@kausal/themes-private": ^0.5.12
+    "@kausal/themes-private": ^0.5.13
     "@n8tb1t/use-scroll-position": ^2.0.3
     "@next/bundle-analyzer": ^12.1.6
     "@playwright/test": ^1.39.0


### PR DESCRIPTION
- make image credit smaller and always in top right corner of the header image
- Reverse Q&A coloring
- Force wrapping of overflowing words in richtext columns
- Hide goal related content when it's not available for normalised values in indicator showcase
- Up themes

before:
<img width="725" alt="Screenshot 2024-08-27 at 16 47 57" src="https://github.com/user-attachments/assets/f3f440b6-6226-4317-a37f-d2cbfa46a5a5">
after:
<img width="736" alt="Screenshot 2024-08-27 at 16 48 15" src="https://github.com/user-attachments/assets/45b921e4-ee20-4fdc-8060-01f5596ba517">

before:
<img width="754" alt="Screenshot 2024-08-27 at 16 52 29" src="https://github.com/user-attachments/assets/8a06d9ba-8606-420d-a4f1-1b635a30ca75">
after:
<img width="760" alt="Screenshot 2024-08-27 at 16 52 35" src="https://github.com/user-attachments/assets/ca5b904e-4891-4e27-a7b8-1c0cd64be98f">

