### PR TITLE
Fix/zoom images

### DIFF
--- a/app/[domain]/[lang]/layout.tsx
+++ b/app/[domain]/[lang]/layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { NextIntlClientProvider, useMessages } from 'next-intl';
-
+import 'react-medium-image-zoom/dist/styles.css';
 import { StyledComponentsRegistry } from '@/styles/StyledComponentsRegistry';
 import { ApolloWrapper } from '@/components/providers/ApolloWrapper';
 import ThemeProvider from '@/components/providers/ThemeProvider';

--- a/components/common/RichText.tsx
+++ b/components/common/RichText.tsx
@@ -101,44 +101,41 @@ const CompressIcon = styled(ICompress)`
 function RichTextImage(props: RichTextImageProps) {
   const plan = usePlan();
   const { attribs } = props;
-  const { src, alt, height, width, ...rest } = attribs;
-  rest.className = rest.class;
-  delete rest.class;
+  const {
+    src,
+    alt,
+    height,
+    width,
+    'data-original-src': originalSrc,
+    'data-original-width': originalWidth,
+    'data-original-height': originalHeight,
+    ...rest
+  } = attribs;
 
-  // eslint-disable-next-line @next/next/no-img-element
+  const imageUrl = src?.startsWith('http')
+    ? src
+    : `${plan.serveFileBaseUrl}${src}`;
+
+  if (!imageUrl) {
+    return null;
+  }
+
+  const origWidth = Number(originalWidth);
+  const applyZoom = !isNaN(origWidth) && origWidth > 1000;
+
   const imgElement = (
-    // eslint-disable-next-line @next/next/no-img-element
     <img
-      src={`${plan.serveFileBaseUrl}${src}`}
-      alt={alt}
+      src={imageUrl}
+      alt={alt || 'Image'}
       height={height}
       width={width}
-      className={rest.className}
+      className={rest.className || 'richtext-image full-width'}
+      {...rest}
     />
   );
 
-  const [origWidth, origHeight] = [
-    Number(rest['data-original-width']),
-    Number(rest['data-original-height']),
-  ];
-  if (!isNaN(origWidth) && !isNaN(origHeight) && rest['data-original-src']) {
-    if (origWidth > Number(height) * 1.2 || origHeight > Number(width) * 1.2) {
-      // Only stretch zoomed image full width if original has width > 1000px
-      const zoomImgAttribs =
-        origWidth > 1000
-          ? {
-              src: `${plan.serveFileBaseUrl}${rest['data-original-src']}`,
-              alt,
-              height: origHeight,
-              width: origWidth,
-            }
-          : {};
-      return (
-        <Zoom zoomImg={zoomImgAttribs} IconUnzoom={CompressIcon}>
-          {imgElement}
-        </Zoom>
-      );
-    }
+  if (applyZoom) {
+    return <Zoom IconUnzoom={CompressIcon}>{imgElement}</Zoom>;
   }
   return imgElement;
 }
@@ -216,7 +213,7 @@ export default function RichText(props: RichTextProps) {
 
   const replaceDomElement = useCallback(
     (element: Element) => {
-      const { name, attribs, children } = element as Element;
+      const { name, attribs, children } = element;
       // Rewrite <a> tags to point to the FQDN
       if (name === 'a') {
         // File link
@@ -242,10 +239,9 @@ export default function RichText(props: RichTextProps) {
             {domToReact(children, options)}
           </a>
         );
-      } else if (name === 'img') {
-        if (attribs.src && attribs.src[0] === '/') {
-          return <RichTextImage attribs={attribs} />;
-        }
+      }
+      if (name === 'img') {
+        return <RichTextImage attribs={attribs} />;
       }
       return null;
     },


### PR DESCRIPTION
Related Asana https://app.asana.com/0/1205310117865974/1208119188231555/f
*  Added the missing import for React-medium-zoom to the `Layout` component;
*  Refactored `RichText` component code to access and check the original width of an image and apply zoom only if the width is larger than 1000px. This ensures that only high-resolution images are zoomable.
* Images with smaller widths render normally without zoom.

https://github.com/user-attachments/assets/6218a522-ddd2-44a2-ac23-20ee3bd31763

