### PR TITLE
Formatting plotly x axis years (again)

### DIFF
--- a/components/graphs/IndicatorGraph.tsx
+++ b/components/graphs/IndicatorGraph.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 
 import { splitLines } from 'common/utils';
-import { merge, uniq } from 'lodash';
+import { merge } from 'lodash';
 import dynamic from 'next/dynamic';
 import { Data, Layout } from 'plotly.js';
 import { transparentize } from 'polished';
@@ -18,6 +18,7 @@ const CATEGORY_XAXIS_LABEL_EXTRA_MARGIN = 200;
 const createLayout = (
   theme,
   timeResolution,
+  xInterval,
   yRange,
   plotColors,
   config,
@@ -85,7 +86,8 @@ const createLayout = (
           showgrid: false,
           showline: false,
           tickformat: timeResolution === 'YEAR' ? '%Y' : '%b %Y',
-          tickmode: 'auto' as const,
+          tickmode: 'linear',
+          dtick: `M${xInterval}`,
           tickfont: {
             family: fontFamily,
             size: 14,
@@ -207,7 +209,7 @@ const createTraces: (params: CreateTracesParams) => TracesOutput = (params) => {
   const newTraces = traces.map((trace, idx) => {
     // Here we are excluding some properties from the trace
     const { xType, dataType, ...plotlyTrace } = trace;
-    const modTrace: Data = { ...plotlyTrace, cliponaxis: false };
+    const modTrace: Data = { ...plotlyTrace };
     allXValues.push(...trace.x);
 
     // we have multiple categories in one time point - draw bar groups
@@ -258,23 +260,23 @@ const createTraces: (params: CreateTracesParams) => TracesOutput = (params) => {
       };
     }
     // Leave out markers for long time series
-    if (modTrace.type === 'scatter')
-      modTrace.mode = trace.x.length > 30 ? 'lines' : 'lines+markers';
+    if (modTrace.type === 'scatter') {
+      if (trace.x.length > 30) {
+        modTrace.mode = 'lines';
+        delete modTrace.marker;
+      } else {
+        modTrace.mode = 'lines+markers';
+        modTrace.cliponaxis = false;
+      }
+    }
     const timeFormat = timeResolution === 'YEAR' ? '%Y' : '%x';
     modTrace.hovertemplate = `(%{x|${timeFormat}})<br> ${trace.name}: %{y:,.3r} ${unit}`;
-    modTrace.hoverinfo = 'none';
     modTrace.hoverlabel = {
       bgcolor: plotColors.mainScale[idx % numColors],
       namelength: 0,
     };
     return modTrace;
   });
-  const uniqueXValues = uniq(allXValues.sort(), true);
-  if (layoutConfig.xaxis?.type !== 'category') {
-    if (uniqueXValues.length < 4) {
-      layoutConfig.xaxis!.tickvals = uniqueXValues;
-    }
-  }
 
   return {
     layoutConfig,
@@ -301,6 +303,53 @@ function getSubplotHeaders(subPlotRowCount, names) {
     };
   });
 }
+
+// Since plotlyjs is not great with determining x axis range, we do it ourselves
+// Return nice interval in months depending on timeResolution
+// We want max 10 xticks
+const getXInterval = (dataset, timeResolution) => {
+  // Use flatMap to simplify the creation of allXValues
+  const allXValues = dataset.flatMap((trace) =>
+    trace.x.map((x) => new Date(x)).filter((d) => !isNaN(d.getTime()))
+  );
+
+  // It's a category dataset or all dates were invalid
+  if (allXValues.length === 0) return undefined;
+
+  const min = new Date(Math.min(...allXValues));
+  const max = new Date(Math.max(...allXValues));
+
+  // Simplified month calculation
+  const months =
+    (max.getFullYear() - min.getFullYear()) * 12 +
+    max.getMonth() -
+    min.getMonth();
+
+  const MAX_TICKS = 10;
+
+  if (timeResolution === 'YEAR') {
+    // For yearly data, ensure the interval is divisible by 12
+    return Math.max(12, Math.ceil(months / MAX_TICKS / 12) * 12);
+  } else {
+    // For other resolutions, use binary search to find the best interval
+    const possibleIntervals = [1, 2, 3, 4, 6, 12, 24, 36, 48, 60];
+    let low = 0;
+    let high = possibleIntervals.length - 1;
+
+    while (low <= high) {
+      const mid = Math.floor((low + high) / 2);
+      if (months / possibleIntervals[mid] <= MAX_TICKS) {
+        high = mid - 1;
+      } else {
+        low = mid + 1;
+      }
+    }
+
+    return (
+      possibleIntervals[low] || possibleIntervals[possibleIntervals.length - 1]
+    );
+  }
+};
 
 interface IndicatorGraphProps {
   yRange: any;
@@ -449,7 +498,6 @@ function IndicatorGraph(props: IndicatorGraphProps) {
       subplotRowCount,
       subplotHeaderTitles
     );
-    mainTraces.layoutConfig.xaxis.nticks = mainTraces.traces[0].length;
     mainTraces.traces.forEach((t, idx) => {
       const axisIndex = hasTimeDimension ? Math.floor(idx / 2) + 1 : idx + 1;
       if (!hasTimeDimension || idx > 1) {
@@ -484,15 +532,19 @@ function IndicatorGraph(props: IndicatorGraphProps) {
   if (!isComparison && goalTraces.length) {
     goalTraces.forEach((goalTrace, idx) => {
       plotlyData.push({
-        ...goalTrace,
+        x: goalTrace.x,
+        y: goalTrace.y,
+        name: goalTrace.name,
         type: 'scatter',
         cliponaxis: false,
         mode: goalTrace.scenario ? 'markers' : 'lines+markers',
-        line: {
-          width: 3,
-          dash: 'dash',
-          color: plotColors.goalScale[idx % plotColors.goalScale.length],
-        },
+        ...(!goalTrace.scenario && {
+          line: {
+            width: 3,
+            dash: 'dash',
+            color: plotColors.goalScale[idx % plotColors.goalScale.length],
+          },
+        }),
         marker: {
           size: 12,
           symbol: 'x',
@@ -511,6 +563,7 @@ function IndicatorGraph(props: IndicatorGraphProps) {
   const layout = createLayout(
     theme,
     timeResolution,
+    getXInterval(plotlyData, timeResolution),
     yRange,
     plotColors,
     layoutConfig,

--- a/components/indicators/IndicatorVisualisation.js
+++ b/components/indicators/IndicatorVisualisation.js
@@ -1,23 +1,24 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
-import { isEqual } from 'lodash';
-import { gql } from '@apollo/client';
-import { useQuery } from '@apollo/experimental-nextjs-app-support/ssr';
-import { Alert } from 'reactstrap';
-import dayjs from 'common/dayjs';
-import styled from 'styled-components';
-import { linearRegression } from 'common/math';
 
+import dayjs from 'common/dayjs';
+import { linearRegression } from 'common/math';
 import { capitalizeFirstLetter } from 'common/utils';
-import { usePlan } from 'context/plan';
 import ContentLoader from 'components/common/ContentLoader';
-import IndicatorComparisonSelect from 'components/indicators/IndicatorComparisonSelect';
-import IndicatorNormalizationSelect from 'components/indicators/IndicatorNormalizationSelect';
+import RichText from 'components/common/RichText';
 import GraphAsTable from 'components/graphs/GraphAsTable';
 import IndicatorGraph from 'components/graphs/IndicatorGraph';
+import IndicatorComparisonSelect from 'components/indicators/IndicatorComparisonSelect';
+import IndicatorNormalizationSelect from 'components/indicators/IndicatorNormalizationSelect';
+import { usePlan } from 'context/plan';
+import { isEqual } from 'lodash';
 import { useLocale, useTranslations } from 'next-intl';
+import PropTypes from 'prop-types';
+import { Alert } from 'reactstrap';
+import styled from 'styled-components';
+
+import { gql } from '@apollo/client';
+import { useQuery } from '@apollo/experimental-nextjs-app-support/ssr';
 import { captureMessage } from '@sentry/nextjs';
-import RichText from 'components/common/RichText';
 
 const GET_INDICATOR_GRAPH_DATA = gql`
   query IndicatorGraphData($id: ID, $plan: ID) {
@@ -297,11 +298,7 @@ const generateTrendTrace = (indicator, traces, goals, i18n) => {
       .map((item) => {
         const { date, value, categories } = item;
         // Make yearly value dates YYYY-1-1 so plotly places them correctly on axis
-        const newDate =
-          indicator.timeResolution === 'YEAR'
-            ? `${date.split('-')[0]}-1-1`
-            : date;
-        return { date: newDate, value, categories };
+        return { date, value, categories };
       });
     const mainValues = values.filter((item) => !item.categories.length);
     const numberOfYears = Math.min(mainValues.length, 10);
@@ -323,7 +320,12 @@ const generateTrendTrace = (indicator, traces, goals, i18n) => {
     }
 
     predictedTrace.y = predictedTrace.x.map((year) => model.m * year + model.b);
-    return [predictedTrace, calculateBounds(predictedTrace.y)];
+    // We want the year format 2019-1-1 so plotly places them correctly on axis
+    const formattedTrace = {
+      x: predictedTrace.x.map((year) => `${year}-1-1`),
+      y: predictedTrace.y,
+    };
+    return [formattedTrace, calculateBounds(predictedTrace.y)];
   }
   return [undefined, undefined];
 };
@@ -375,7 +377,7 @@ const generateGoalTraces = (indicator, planScenarios, i18n) => {
       x: goals.map((item) => {
         const newDate =
           indicator.timeResolution === 'YEAR'
-            ? `${item.date.split('-')[0]}`
+            ? `${item.date.split('-')[0]}-1-1`
             : item.date;
         return newDate;
       }),


### PR DESCRIPTION
RE: [Asana](https://app.asana.com/0/0/1208165767809303/f)
Make sure that all traces follow same (YEARLY/MONTHLY) date format when passed to graph
Calculate a proper xtick interval for date axis instead of trusting Plotlys auto feature that gives us double years for example:

**BEFORE**
![Screenshot 2024-09-10 at 19 51 45](https://github.com/user-attachments/assets/c71235e2-668d-4131-ab6a-ec8de83beafd)

**AFTER**
![Screenshot 2024-09-10 at 19 51 26](https://github.com/user-attachments/assets/9a02ca23-8ece-401e-8f52-0309f809e4c8)

Also remove unused properties from plotly data/layout objects to silence console warnings