### PR TITLE
Close result box after navigation to search page

### DIFF
--- a/components/common/NavbarSearch.js
+++ b/components/common/NavbarSearch.js
@@ -249,7 +249,7 @@ function ResultItem(props) {
 }
 
 const ResultList = (props) => {
-  const { results, searchTerm, loading } = props;
+  const { results, searchTerm, loading, closeSearch } = props;
   const t = useTranslations();
   //const plan = usePlan();
   const counts = [
@@ -295,14 +295,14 @@ const ResultList = (props) => {
             href={`/search?q=${searchTerm}`}
             legacyBehavior
           >
-            <a>
+            <a onClick={closeSearch}>
               {t('see-all-results', { count: results.length })}
               <Icon.ArrowRight />
             </a>
           </Link>
         ) : (
           <Link prefetch={false} href={`/search`} legacyBehavior>
-            <a data-testId="search-advanced">
+            <a onClick={closeSearch} data-testId="search-advanced">
               {t('search-advanced')} <Icon.ArrowRight />
             </a>
           </Link>
@@ -374,10 +374,8 @@ function Search({ isLoading, searchTerm, setSearchTerm, results }) {
   const [searchOpen, setSearchOpen] = useState(false);
   const searchElement = useRef(null);
 
-  // Clear search term if the input is hidden
   const closeSearch = () => {
     setSearchOpen(false);
-    setSearchTerm('');
   };
 
   // Close results modal if clicked outside search ui
@@ -385,7 +383,6 @@ function Search({ isLoading, searchTerm, setSearchTerm, results }) {
     const handlePageClick = (e) => {
       if (!searchElement.current.contains(e.target)) {
         setSearchOpen(false);
-        setSearchTerm('');
       }
     };
 
@@ -480,6 +477,7 @@ function Search({ isLoading, searchTerm, setSearchTerm, results }) {
             searchTerm={searchTerm}
             anchor={searchElement}
             loading={isLoading}
+            closeSearch={closeSearch}
           />
         </ResultsBox>
       )}


### PR DESCRIPTION
The bug was caused by the previous fix: applying `React.memo` for `NavbarSearch` component to prevent unnecessary re-renders. 
When a user enters a keyword in the navbar search, clicks on the "See all results" link and gets redirected to the Search page, the result box is still displayed, but after closing it "No results for this search..." message is displayed, even though there were search results.

https://github.com/user-attachments/assets/ddfa0d58-cc39-4101-83ed-ff2692ceb0fc



* Added `closeSearch()` in the ResultList to close the result box after the link is clicked, redirecting the user to the search page;
* Removed `setSearchTerm('')` to ensure that the search term is passed and the results are displayed on the Search page.

After:

https://github.com/user-attachments/assets/6b7f6fcb-e716-4f97-911e-a74308ea46f0






