### PR TITLE
Use custom badge color

### DIFF
--- a/components/actions/ActionImpact.js
+++ b/components/actions/ActionImpact.js
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -17,7 +18,7 @@ const ImpactIcon = styled(Icon)`
   }};
 
   &.icon-on {
-    fill: ${(props) => props.theme.brandDark} !important;
+    fill: ${(props) => props.theme.phaseTimelineColor} !important;
   }
 
   &.icon-off {

--- a/components/actions/ResponsibleList.tsx
+++ b/components/actions/ResponsibleList.tsx
@@ -12,6 +12,7 @@ import styled from 'styled-components';
 import { usePaths } from '@/context/paths/paths';
 
 import { ActionContentAction } from './ActionContent';
+import { ActionResponsiblePartiesBlock } from '@/common/__generated__/graphql';
 
 const Responsibles = styled.div`
   a {
@@ -95,7 +96,7 @@ function ResponsibleBadge({
               ariaLabel={ariaLabel}
               content={org.abbreviation || org.name}
               size={size}
-              color="brandDark"
+              color="badgeColor"
               isLink
             />
           </a>
@@ -107,7 +108,7 @@ function ResponsibleBadge({
           ariaLabel={ariaLabel}
           content={org.abbreviation || org.name}
           size={size}
-          color="brandDark"
+          color="badgeColor"
           isLink
         />
       )}

--- a/components/common/BadgeTooltip.tsx
+++ b/components/common/BadgeTooltip.tsx
@@ -121,7 +121,12 @@ interface BadgeContentProps {
   ariaLabel?: string;
   iconSvg?: string;
   iconImage?: string;
-  color?: 'brandDark' | 'brandLight' | 'neutralDark' | 'neutralLight';
+  color?:
+    | 'badgeColor'
+    | 'brandDark'
+    | 'brandLight'
+    | 'neutralDark'
+    | 'neutralLight';
   isLink: boolean;
   maxLines?: number;
 }
@@ -133,7 +138,7 @@ const BadgeContent = (props: BadgeContentProps) => {
     iconSvg,
     iconImage,
     ariaLabel,
-    color = 'brandDark',
+    color = 'badgeColor',
     isLink = false,
     maxLines,
   } = props;


### PR DESCRIPTION
Refreshed this old PR as an use case came up. Ability to color the badges differently from themes. 
Theme change has already been applied and released.

Before: `brandDark` only
<img width="423" alt="Screenshot 2025-05-21 at 10 23 42" src="https://github.com/user-attachments/assets/92343d25-32e1-4291-a3fd-9571ef237926" />

After: with `badgeColor`
<img width="456" alt="Screenshot 2025-05-21 at 10 23 08" src="https://github.com/user-attachments/assets/163b0e91-4a07-466a-bf07-101645e6c288" />

'Badge' is probably not the modern term for these elements, but let's keep it like that for legacy's sake.
