### PR TITLE
Short identifier for plan shown in action dashboard if defined

### DIFF
--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -2406,6 +2406,8 @@ export type Indicator = {
   common?: Maybe<CommonIndicator>;
   createdAt: Scalars['DateTime'];
   description?: Maybe<Scalars['String']>;
+  /** Which trend in the numerical values of this indicator's goals indicates improvement: when the values are increasing or decreasing? */
+  desiredTrend?: Maybe<IndicatorDesiredTrend>;
   dimensions: Array<IndicatorDimension>;
   goals?: Maybe<Array<Maybe<IndicatorGoal>>>;
   id: Scalars['ID'];
@@ -2426,6 +2428,7 @@ export type Indicator = {
   relatedActions: Array<ActionIndicator>;
   relatedCauses: Array<RelatedIndicator>;
   relatedEffects: Array<RelatedIndicator>;
+  showTrendline: Scalars['Boolean'];
   timeResolution: IndicatorTimeResolution;
   unit: Unit;
   updatedAt: Scalars['DateTime'];
@@ -2477,6 +2480,16 @@ export type IndicatorCausalChainBlock = FieldBlockMetaInterface & StreamFieldInt
   rawValue: Scalars['String'];
   value: Scalars['String'];
 };
+
+/** An enumeration. */
+export enum IndicatorDesiredTrend {
+  /** attempt to detect automatically */
+  A = 'A_',
+  /** decreasing */
+  Decreasing = 'DECREASING',
+  /** increasing */
+  Increasing = 'INCREASING'
+}
 
 /** Mapping of which dimensions an indicator has. */
 export type IndicatorDimension = {
@@ -3202,6 +3215,8 @@ export type Plan = PlanInterface & {
   /** Leave empty unless specifically required. Action filters based on this category are displayed more prominently than filters of other categories. */
   secondaryActionClassification?: Maybe<CategoryType>;
   serveFileBaseUrl: Scalars['String'];
+  /** A unique short identifier for the plan to be shown in UI. Could be eg. a number or an abbreviation */
+  shortIdentifier?: Maybe<Scalars['String']>;
   /** A shorter version of the plan name */
   shortName?: Maybe<Scalars['String']>;
   /** Set if this plan is superseded by another plan */
@@ -4509,27 +4524,40 @@ export type MultiUseImageFragmentFragment = (
   & { __typename?: 'Image' }
 );
 
-export type GetAutocompleteResultsQueryVariables = Exact<{
+export type SearchQueryQueryVariables = Exact<{
   plan: Scalars['ID'];
-  term: Scalars['String'];
+  query: Scalars['String'];
+  onlyOtherPlans?: InputMaybe<Scalars['Boolean']>;
   clientUrl?: InputMaybe<Scalars['String']>;
 }>;
 
 
-export type GetAutocompleteResultsQuery = (
+export type SearchQueryQuery = (
   { search?: (
     { hits?: Array<(
-      { id?: string | null, title?: string | null, url?: string | null, highlight?: string | null, plan?: (
+      { title?: string | null, url?: string | null, highlight?: string | null, plan?: (
         { identifier: string, name: string, shortName?: string | null, image?: (
           { rendition?: (
             { src: string }
             & { __typename?: 'ImageRendition' }
           ) | null }
           & { __typename?: 'Image' }
-        ) | null }
+        ) | null, organization: (
+          { name: string }
+          & { __typename?: 'Organization' }
+        ) }
         & { __typename?: 'Plan' }
       ) | null, object?: (
-        { identifier: string }
+        { identifier: string, primaryOrg?: (
+          { name: string, logo?: (
+            { rendition?: (
+              { src: string }
+              & { __typename?: 'ImageRendition' }
+            ) | null }
+            & { __typename?: 'Image' }
+          ) | null }
+          & { __typename?: 'Organization' }
+        ) | null }
         & { __typename: 'Action' }
       ) | (
         { id: string }
@@ -4794,64 +4822,6 @@ export type CreateUserFeedbackMutation = (
   & { __typename?: 'Mutation' }
 );
 
-export type SearchQueryQueryVariables = Exact<{
-  plan: Scalars['ID'];
-  query: Scalars['String'];
-  onlyOtherPlans?: InputMaybe<Scalars['Boolean']>;
-  clientUrl?: InputMaybe<Scalars['String']>;
-}>;
-
-
-export type SearchQueryQuery = (
-  { search?: (
-    { hits?: Array<(
-      { title?: string | null, url?: string | null, highlight?: string | null, plan?: (
-        { identifier: string, name: string, shortName?: string | null, image?: (
-          { rendition?: (
-            { src: string }
-            & { __typename?: 'ImageRendition' }
-          ) | null }
-          & { __typename?: 'Image' }
-        ) | null, organization: (
-          { name: string }
-          & { __typename?: 'Organization' }
-        ) }
-        & { __typename?: 'Plan' }
-      ) | null, object?: (
-        { identifier: string, primaryOrg?: (
-          { name: string, logo?: (
-            { rendition?: (
-              { src: string }
-              & { __typename?: 'ImageRendition' }
-            ) | null }
-            & { __typename?: 'Image' }
-          ) | null }
-          & { __typename?: 'Organization' }
-        ) | null }
-        & { __typename: 'Action' }
-      ) | (
-        { id: string }
-        & { __typename: 'Indicator' }
-      ) | null, page?: (
-        { title: string }
-        & { __typename?: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
-      ) | (
-        { title: string, category?: (
-          { level?: (
-            { name: string }
-            & { __typename?: 'CategoryLevel' }
-          ) | null }
-          & { __typename?: 'Category' }
-        ) | null }
-        & { __typename?: 'CategoryPage' }
-      ) | null }
-      & { __typename?: 'SearchHit' }
-    ) | null> | null }
-    & { __typename?: 'SearchResults' }
-  ) | null }
-  & { __typename?: 'Query' }
-);
-
 export type GetActionListForBlockQueryVariables = Exact<{
   plan: Scalars['ID'];
   category?: InputMaybe<Scalars['ID']>;
@@ -5075,13 +5045,19 @@ export type ActionFragmentFragment = (
     { identifier: ActionTimelinessIdentifier }
     & { __typename?: 'ActionTimeliness' }
   ), plan?: (
-    { id: string, shortName?: string | null, name: string, versionName: string, viewUrl?: string | null, hideActionIdentifiers?: boolean | null, publishedAt?: any | null, image?: (
+    { id: string, shortName?: string | null, name: string, shortIdentifier?: string | null, versionName: string, viewUrl?: string | null, hideActionIdentifiers?: boolean | null, publishedAt?: any | null, image?: (
       { rendition?: (
         { src: string }
         & { __typename?: 'ImageRendition' }
       ) | null }
       & { __typename?: 'Image' }
-    ) | null }
+    ) | null, generalContent: (
+      { actionTaskTerm: SiteGeneralContentActionTaskTerm, organizationTerm: SiteGeneralContentOrganizationTerm }
+      & { __typename?: 'SiteGeneralContent' }
+    ), actionImplementationPhases: Array<(
+      { id: string, identifier: string, name: string, order: number, color?: string | null }
+      & { __typename?: 'ActionImplementationPhase' }
+    )> }
     & { __typename?: 'Plan' }
   ), schedule: Array<(
     { id: string }
@@ -5091,19 +5067,43 @@ export type ActionFragmentFragment = (
     & { __typename?: 'ActionImpact' }
   ) | null, attributes: Array<(
     { id: string, type: (
-      { id: string }
+      { id: string, identifier: string, name: string, format: AttributeTypeFormat, unit?: (
+        { id: string, name: string, shortName?: string | null }
+        & { __typename?: 'Unit' }
+      ) | null }
       & { __typename?: 'AttributeType' }
     ) }
-    & { __typename: 'AttributeCategoryChoice' | 'AttributeNumericValue' | 'AttributeRichText' | 'AttributeText' }
+    & { __typename: 'AttributeCategoryChoice' }
   ) | (
-    { id: string, choice?: (
+    { text?: string | null, id: string, choice?: (
       { id: string, name: string }
       & { __typename?: 'AttributeTypeChoiceOption' }
     ) | null, type: (
-      { id: string }
+      { id: string, identifier: string, name: string, format: AttributeTypeFormat, unit?: (
+        { id: string, name: string, shortName?: string | null }
+        & { __typename?: 'Unit' }
+      ) | null }
       & { __typename?: 'AttributeType' }
     ) }
     & { __typename: 'AttributeChoice' }
+  ) | (
+    { id: string, numericValue: number, type: (
+      { id: string, identifier: string, name: string, format: AttributeTypeFormat, unit?: (
+        { id: string, name: string, shortName?: string | null }
+        & { __typename?: 'Unit' }
+      ) | null }
+      & { __typename?: 'AttributeType' }
+    ) }
+    & { __typename: 'AttributeNumericValue' }
+  ) | (
+    { value: string, id: string, type: (
+      { id: string, identifier: string, name: string, format: AttributeTypeFormat, unit?: (
+        { id: string, name: string, shortName?: string | null }
+        & { __typename?: 'Unit' }
+      ) | null }
+      & { __typename?: 'AttributeType' }
+    ) }
+    & { __typename: 'AttributeRichText' | 'AttributeText' }
   )>, responsibleParties: Array<(
     { id: string, role?: ActionResponsiblePartyRole | null, organization: (
       { id: string, abbreviation: string, name: string }
@@ -5223,13 +5223,19 @@ export type DashboardActionListQuery = (
       { identifier: ActionTimelinessIdentifier }
       & { __typename?: 'ActionTimeliness' }
     ), plan?: (
-      { id: string, shortName?: string | null, name: string, versionName: string, viewUrl?: string | null, hideActionIdentifiers?: boolean | null, publishedAt?: any | null, image?: (
+      { id: string, shortName?: string | null, name: string, shortIdentifier?: string | null, versionName: string, viewUrl?: string | null, hideActionIdentifiers?: boolean | null, publishedAt?: any | null, image?: (
         { rendition?: (
           { src: string }
           & { __typename?: 'ImageRendition' }
         ) | null }
         & { __typename?: 'Image' }
-      ) | null }
+      ) | null, generalContent: (
+        { actionTaskTerm: SiteGeneralContentActionTaskTerm, organizationTerm: SiteGeneralContentOrganizationTerm }
+        & { __typename?: 'SiteGeneralContent' }
+      ), actionImplementationPhases: Array<(
+        { id: string, identifier: string, name: string, order: number, color?: string | null }
+        & { __typename?: 'ActionImplementationPhase' }
+      )> }
       & { __typename?: 'Plan' }
     ), schedule: Array<(
       { id: string }
@@ -5239,19 +5245,43 @@ export type DashboardActionListQuery = (
       & { __typename?: 'ActionImpact' }
     ) | null, attributes: Array<(
       { id: string, type: (
-        { id: string }
+        { id: string, identifier: string, name: string, format: AttributeTypeFormat, unit?: (
+          { id: string, name: string, shortName?: string | null }
+          & { __typename?: 'Unit' }
+        ) | null }
         & { __typename?: 'AttributeType' }
       ) }
-      & { __typename: 'AttributeCategoryChoice' | 'AttributeNumericValue' | 'AttributeRichText' | 'AttributeText' }
+      & { __typename: 'AttributeCategoryChoice' }
     ) | (
-      { id: string, choice?: (
+      { text?: string | null, id: string, choice?: (
         { id: string, name: string }
         & { __typename?: 'AttributeTypeChoiceOption' }
       ) | null, type: (
-        { id: string }
+        { id: string, identifier: string, name: string, format: AttributeTypeFormat, unit?: (
+          { id: string, name: string, shortName?: string | null }
+          & { __typename?: 'Unit' }
+        ) | null }
         & { __typename?: 'AttributeType' }
       ) }
       & { __typename: 'AttributeChoice' }
+    ) | (
+      { id: string, numericValue: number, type: (
+        { id: string, identifier: string, name: string, format: AttributeTypeFormat, unit?: (
+          { id: string, name: string, shortName?: string | null }
+          & { __typename?: 'Unit' }
+        ) | null }
+        & { __typename?: 'AttributeType' }
+      ) }
+      & { __typename: 'AttributeNumericValue' }
+    ) | (
+      { value: string, id: string, type: (
+        { id: string, identifier: string, name: string, format: AttributeTypeFormat, unit?: (
+          { id: string, name: string, shortName?: string | null }
+          & { __typename?: 'Unit' }
+        ) | null }
+        & { __typename?: 'AttributeType' }
+      ) }
+      & { __typename: 'AttributeRichText' | 'AttributeText' }
     )>, responsibleParties: Array<(
       { id: string, role?: ActionResponsiblePartyRole | null, organization: (
         { id: string, abbreviation: string, name: string }
@@ -5319,13 +5349,19 @@ export type DashboardActionListQuery = (
       { identifier: ActionTimelinessIdentifier }
       & { __typename?: 'ActionTimeliness' }
     ), plan?: (
-      { id: string, shortName?: string | null, name: string, versionName: string, viewUrl?: string | null, hideActionIdentifiers?: boolean | null, publishedAt?: any | null, image?: (
+      { id: string, shortName?: string | null, name: string, shortIdentifier?: string | null, versionName: string, viewUrl?: string | null, hideActionIdentifiers?: boolean | null, publishedAt?: any | null, image?: (
         { rendition?: (
           { src: string }
           & { __typename?: 'ImageRendition' }
         ) | null }
         & { __typename?: 'Image' }
-      ) | null }
+      ) | null, generalContent: (
+        { actionTaskTerm: SiteGeneralContentActionTaskTerm, organizationTerm: SiteGeneralContentOrganizationTerm }
+        & { __typename?: 'SiteGeneralContent' }
+      ), actionImplementationPhases: Array<(
+        { id: string, identifier: string, name: string, order: number, color?: string | null }
+        & { __typename?: 'ActionImplementationPhase' }
+      )> }
       & { __typename?: 'Plan' }
     ), schedule: Array<(
       { id: string }
@@ -5335,19 +5371,43 @@ export type DashboardActionListQuery = (
       & { __typename?: 'ActionImpact' }
     ) | null, attributes: Array<(
       { id: string, type: (
-        { id: string }
+        { id: string, identifier: string, name: string, format: AttributeTypeFormat, unit?: (
+          { id: string, name: string, shortName?: string | null }
+          & { __typename?: 'Unit' }
+        ) | null }
         & { __typename?: 'AttributeType' }
       ) }
-      & { __typename: 'AttributeCategoryChoice' | 'AttributeNumericValue' | 'AttributeRichText' | 'AttributeText' }
+      & { __typename: 'AttributeCategoryChoice' }
     ) | (
-      { id: string, choice?: (
+      { text?: string | null, id: string, choice?: (
         { id: string, name: string }
         & { __typename?: 'AttributeTypeChoiceOption' }
       ) | null, type: (
-        { id: string }
+        { id: string, identifier: string, name: string, format: AttributeTypeFormat, unit?: (
+          { id: string, name: string, shortName?: string | null }
+          & { __typename?: 'Unit' }
+        ) | null }
         & { __typename?: 'AttributeType' }
       ) }
       & { __typename: 'AttributeChoice' }
+    ) | (
+      { id: string, numericValue: number, type: (
+        { id: string, identifier: string, name: string, format: AttributeTypeFormat, unit?: (
+          { id: string, name: string, shortName?: string | null }
+          & { __typename?: 'Unit' }
+        ) | null }
+        & { __typename?: 'AttributeType' }
+      ) }
+      & { __typename: 'AttributeNumericValue' }
+    ) | (
+      { value: string, id: string, type: (
+        { id: string, identifier: string, name: string, format: AttributeTypeFormat, unit?: (
+          { id: string, name: string, shortName?: string | null }
+          & { __typename?: 'Unit' }
+        ) | null }
+        & { __typename?: 'AttributeType' }
+      ) }
+      & { __typename: 'AttributeRichText' | 'AttributeText' }
     )>, responsibleParties: Array<(
       { id: string, role?: ActionResponsiblePartyRole | null, organization: (
         { id: string, abbreviation: string, name: string }
@@ -5384,7 +5444,19 @@ export type DashboardActionListQuery = (
     ) | null }
     & { __typename?: 'Action' }
   )> | null, planPage?: { __typename: 'AccessibilityStatementPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' } | (
-    { dashboardColumns?: Array<{ __typename: 'FieldColumnBlock' } | (
+    { dashboardColumns?: Array<(
+      { columnLabel?: string | null, field: string, attributeType?: (
+        { id: string, format: AttributeTypeFormat, name: string, identifier: string, helpText: string, showChoiceNames: boolean, hasZeroOption: boolean, choiceOptions: Array<(
+          { id: string, identifier: string }
+          & { __typename?: 'AttributeTypeChoiceOption' }
+        )>, unit?: (
+          { id: string, name: string }
+          & { __typename?: 'Unit' }
+        ) | null }
+        & { __typename: 'AttributeType' }
+      ) | null }
+      & { __typename: 'FieldColumnBlock' }
+    ) | (
       { columnLabel?: string | null }
       & { __typename: 'IdentifierColumnBlock' | 'ImpactColumnBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorsColumnBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'ResponsiblePartiesColumnBlock' | 'StatusColumnBlock' | 'TasksColumnBlock' | 'UpdatedAtColumnBlock' }
     )> | null }
@@ -6418,7 +6490,19 @@ export type ActionListPageFiltersFragment = (
 );
 
 export type ActionTableColumnFragmentFragment = (
-  { dashboardColumns?: Array<{ __typename: 'FieldColumnBlock' } | (
+  { dashboardColumns?: Array<(
+    { columnLabel?: string | null, field: string, attributeType?: (
+      { id: string, format: AttributeTypeFormat, name: string, identifier: string, helpText: string, showChoiceNames: boolean, hasZeroOption: boolean, choiceOptions: Array<(
+        { id: string, identifier: string }
+        & { __typename?: 'AttributeTypeChoiceOption' }
+      )>, unit?: (
+        { id: string, name: string }
+        & { __typename?: 'Unit' }
+      ) | null }
+      & { __typename: 'AttributeType' }
+    ) | null }
+    & { __typename: 'FieldColumnBlock' }
+  ) | (
     { columnLabel?: string | null }
     & { __typename: 'IdentifierColumnBlock' | 'ImpactColumnBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorsColumnBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'ResponsiblePartiesColumnBlock' | 'StatusColumnBlock' | 'TasksColumnBlock' | 'UpdatedAtColumnBlock' }
   )> | null }
@@ -12273,7 +12357,19 @@ export type OrganizationDetailsQuery = (
     & { __typename?: 'Organization' }
   ) | null, plan?: (
     { id: string, name: string, shortName?: string | null, versionName: string, viewUrl?: string | null, actionListPage?: (
-      { dashboardColumns?: Array<{ __typename: 'FieldColumnBlock' } | (
+      { dashboardColumns?: Array<(
+        { columnLabel?: string | null, field: string, attributeType?: (
+          { id: string, format: AttributeTypeFormat, name: string, identifier: string, helpText: string, showChoiceNames: boolean, hasZeroOption: boolean, choiceOptions: Array<(
+            { id: string, identifier: string }
+            & { __typename?: 'AttributeTypeChoiceOption' }
+          )>, unit?: (
+            { id: string, name: string }
+            & { __typename?: 'Unit' }
+          ) | null }
+          & { __typename: 'AttributeType' }
+        ) | null }
+        & { __typename: 'FieldColumnBlock' }
+      ) | (
         { columnLabel?: string | null }
         & { __typename: 'IdentifierColumnBlock' | 'ImpactColumnBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorsColumnBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'ResponsiblePartiesColumnBlock' | 'StatusColumnBlock' | 'TasksColumnBlock' | 'UpdatedAtColumnBlock' }
       )> | null }

--- a/components/dashboard/ActionList.tsx
+++ b/components/dashboard/ActionList.tsx
@@ -252,6 +252,7 @@ const actionFragment = gql`
       id
       shortName
       name
+      shortIdentifier
       versionName
       viewUrl
       hideActionIdentifiers

--- a/components/dashboard/dashboard.constants.tsx
+++ b/components/dashboard/dashboard.constants.tsx
@@ -212,14 +212,16 @@ export const COLUMN_CONFIG: { [key in ColumnBlock]: Column } = {
   },
   PlanColumnBlock: {
     renderHeader: (t, _, label) => label || t('filter-plan'),
-    renderCell: (action, plan) => (
-      <PlanChip
-        planImage={
-          action.plan?.image?.rendition?.src || plan?.image?.rendition?.src
-        }
-        size="lg"
-      />
-    ),
+    renderCell: (action, plan) =>
+      action.plan?.shortIdentifier ||
+      plan?.shortIdentifier || (
+        <PlanChip
+          planImage={
+            action.plan?.image?.rendition?.src || plan?.image?.rendition?.src
+          }
+          size="lg"
+        />
+      ),
     renderTooltipContent: (action, plan) => (
       <PlanTooltipContent action={action} plan={plan} />
     ),


### PR DESCRIPTION
Show short identifier/abbreviation instead of plan avatar in action dashboard when short_identifier is defined in admin Plan settings.

![image](https://github.com/user-attachments/assets/9f246b36-be06-4441-8b86-29fc6ce65110)
![image](https://github.com/user-attachments/assets/28ff99b4-ae58-43b1-b97a-cb5c639d7eb0)

Depending on backend: https://github.com/kausaltech/kausal-watch-private/pull/266
Asana: https://app.asana.com/0/1206017643443542/1208235388125365