### PR TITLE
Fix bug in Action List Page text search regex handling

### DIFF
--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -819,17 +819,11 @@ class ActionNameFilter implements ActionListFilter<string | undefined> {
 
   filterAction(value: string, action: ActionListAction) {
     const searchStr = escapeStringRegexp(value.toLowerCase());
+    let searchTarget = action.name.replace(/\u00AD/g, '').toLowerCase();
     if (this.hasActionIdentifiers) {
-      if (action.identifier.toLowerCase().startsWith(searchStr)) return true;
+      searchTarget = `${action.identifier.toLowerCase()} ${searchTarget}`;
     }
-    if (
-      action.name
-        .replace(/\u00AD/g, '')
-        .toLowerCase()
-        .search(searchStr) !== -1
-    )
-      return true;
-    return false;
+    return searchTarget.search(searchStr) !== -1;
   }
   getLabel(t: TFunction) {
     return t('filter-text', this.actionTermContext);


### PR DESCRIPTION
Introduced in 06e9a542452e8190ef390f6c06b88eb6683d76b8 - after having
escaped the user provided search string for use as a regular
expression, the identifier search broke since it was not implemented
as a regular expression search but simple string matching. For example
dashes in identifiers like AB-CD-1 where not matched because they are
a special character in regex and had been escaped.