### PR TITLE
add label for trendline

### DIFF
--- a/components/indicators/IndicatorVisualisation.js
+++ b/components/indicators/IndicatorVisualisation.js
@@ -324,6 +324,7 @@ const generateTrendTrace = (indicator, traces, goals, i18n) => {
     const formattedTrace = {
       x: predictedTrace.x.map((year) => `${year}-1-1`),
       y: predictedTrace.y,
+      name: i18n.t('current-trend'),
     };
     return [formattedTrace, calculateBounds(predictedTrace.y)];
   }


### PR DESCRIPTION
The trendline label was missing and was showing as "trace 1" instead of "trend"

Before:
![image](https://github.com/user-attachments/assets/529fe7eb-ddcc-4198-924f-d93c4809831b)


After:
![image](https://github.com/user-attachments/assets/6bf716f5-54ad-4394-8711-7f770227e935)
