### PR TITLE
Use relatedPlanIndicators in umbrella plan. Filter by common categories.

### DIFF
--- a/app/[domain]/[lang]/[plan]/(with-layout-elements)/indicators/page.tsx
+++ b/app/[domain]/[lang]/[plan]/(with-layout-elements)/indicators/page.tsx
@@ -29,6 +29,7 @@ export default async function ActionsPage({ params }: Props) {
       leadContent={data.planPage.leadContent}
       displayInsights={data.planPage.displayInsights}
       displayLevel={data.planPage.displayLevel}
+      includeRelatedPlans={data.planPage?.includeRelatedPlans}
     />
   );
 }

--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -2615,6 +2615,7 @@ export type IndicatorListPage = PageInterface & {
   goLiveAt?: Maybe<Scalars['DateTime']>;
   hasUnpublishedChanges: Scalars['Boolean'];
   id?: Maybe<Scalars['ID']>;
+  includeRelatedPlans?: Maybe<Scalars['Boolean']>;
   lastPublishedAt?: Maybe<Scalars['DateTime']>;
   latestRevision?: Maybe<Revision>;
   latestRevisionCreatedAt?: Maybe<Scalars['DateTime']>;
@@ -12226,7 +12227,7 @@ export type GetPlanPageIndicatorListQuery = (
     { id?: string | null, slug: string, title: string, lastPublishedAt?: any | null }
     & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
   ) | (
-    { leadContent?: string | null, displayInsights?: boolean | null, displayLevel?: boolean | null, id?: string | null, slug: string, title: string, lastPublishedAt?: any | null }
+    { leadContent?: string | null, displayInsights?: boolean | null, includeRelatedPlans?: boolean | null, id?: string | null, slug: string, title: string, lastPublishedAt?: any | null }
     & { __typename: 'IndicatorListPage' }
   ) | null }
   & { __typename?: 'Query' }

--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -5725,6 +5725,12 @@ export type IndicatorListQuery = (
         { id: string, identifier: string, order: number, name: string, parent?: (
           { id: string }
           & { __typename?: 'Category' }
+        ) | null, common?: (
+          { type: (
+            { identifier: string, name: string }
+            & { __typename?: 'CommonCategoryType' }
+          ) }
+          & { __typename?: 'CommonCategory' }
         ) | null }
         & { __typename?: 'Category' }
       )> }
@@ -5791,7 +5797,10 @@ export type IndicatorListQuery = (
         { id: string, identifier: string, name: string }
         & { __typename?: 'CategoryType' }
       ), common?: (
-        { id: string, identifier: string, name: string, order: number }
+        { id: string, identifier: string, name: string, order: number, type: (
+          { identifier: string, name: string }
+          & { __typename?: 'CommonCategoryType' }
+        ) }
         & { __typename?: 'CommonCategory' }
       ) | null }
       & { __typename?: 'Category' }

--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -3715,6 +3715,7 @@ export type Query = {
   planPage?: Maybe<PageInterface>;
   plansForHostname?: Maybe<Array<Maybe<PlanInterface>>>;
   relatedPlanActions?: Maybe<Array<Action>>;
+  relatedPlanIndicators?: Maybe<Array<Indicator>>;
   search?: Maybe<SearchResults>;
   workflowStates?: Maybe<Array<Maybe<WorkflowStateDescription>>>;
 };
@@ -3803,6 +3804,14 @@ export type QueryPlansForHostnameArgs = {
 
 
 export type QueryRelatedPlanActionsArgs = {
+  category?: InputMaybe<Scalars['ID']>;
+  first?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Scalars['String']>;
+  plan: Scalars['ID'];
+};
+
+
+export type QueryRelatedPlanIndicatorsArgs = {
   category?: InputMaybe<Scalars['ID']>;
   first?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Scalars['String']>;
@@ -5660,6 +5669,7 @@ export type IndicatorHightlightListQuery = (
 
 export type IndicatorListQueryVariables = Exact<{
   plan: Scalars['ID'];
+  relatedPlanIndicators: Scalars['Boolean'];
 }>;
 
 
@@ -5745,7 +5755,49 @@ export type IndicatorListQuery = (
       & { __typename?: 'CommonIndicator' }
     ) | null }
     & { __typename?: 'Indicator' }
-  ) | null> | null }
+  ) | null> | null, relatedPlanIndicators?: Array<(
+    { id: string, name: string, level?: string | null, timeResolution: IndicatorTimeResolution, organization: (
+      { id: string, name: string }
+      & { __typename?: 'Organization' }
+    ), common?: (
+      { id: string, name: string, normalizations?: Array<(
+        { unit?: (
+          { shortName?: string | null }
+          & { __typename?: 'Unit' }
+        ) | null, normalizer?: (
+          { name: string, id: string, identifier?: string | null }
+          & { __typename?: 'CommonIndicator' }
+        ) | null }
+        & { __typename?: 'CommonIndicatorNormalization' }
+      ) | null> | null }
+      & { __typename?: 'CommonIndicator' }
+    ) | null, latestGraph?: (
+      { id: string }
+      & { __typename?: 'IndicatorGraph' }
+    ) | null, latestValue?: (
+      { id: string, date?: string | null, value: number, normalizedValues?: Array<(
+        { normalizerId?: string | null, value?: number | null }
+        & { __typename?: 'NormalizedValue' }
+      ) | null> | null }
+      & { __typename?: 'IndicatorValue' }
+    ) | null, unit: (
+      { shortName?: string | null }
+      & { __typename?: 'Unit' }
+    ), categories: Array<(
+      { id: string, name: string, parent?: (
+        { id: string }
+        & { __typename?: 'Category' }
+      ) | null, type: (
+        { id: string, identifier: string, name: string }
+        & { __typename?: 'CategoryType' }
+      ), common?: (
+        { id: string, identifier: string, name: string, order: number }
+        & { __typename?: 'CommonCategory' }
+      ) | null }
+      & { __typename?: 'Category' }
+    )> }
+    & { __typename?: 'Indicator' }
+  )> | null }
   & { __typename?: 'Query' }
 );
 

--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -12227,7 +12227,7 @@ export type GetPlanPageIndicatorListQuery = (
     { id?: string | null, slug: string, title: string, lastPublishedAt?: any | null }
     & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
   ) | (
-    { leadContent?: string | null, displayInsights?: boolean | null, includeRelatedPlans?: boolean | null, id?: string | null, slug: string, title: string, lastPublishedAt?: any | null }
+    { leadContent?: string | null, displayInsights?: boolean | null, displayLevel?: boolean | null, includeRelatedPlans?: boolean | null, id?: string | null, slug: string, title: string, lastPublishedAt?: any | null }
     & { __typename: 'IndicatorListPage' }
   ) | null }
   & { __typename?: 'Query' }

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -668,7 +668,6 @@ class CategoryFilter extends DefaultFilter<FilterValue> {
       (cat) => cat.parent,
       (cat) => cat.children
     );
-    console.log('sortedcats', sortedCats);
     this.catById = this.filterByCommonCategory
       ? new Map(sortedCats.map((c) => [c.common.id, c]))
       : new Map(sortedCats.map((c) => [c.id, c]));

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -668,6 +668,7 @@ class CategoryFilter extends DefaultFilter<FilterValue> {
       (cat) => cat.parent,
       (cat) => cat.children
     );
+    console.log('sortedcats', sortedCats);
     this.catById = this.filterByCommonCategory
       ? new Map(sortedCats.map((c) => [c.common.id, c]))
       : new Map(sortedCats.map((c) => [c.id, c]));

--- a/components/indicators/IndicatorList.tsx
+++ b/components/indicators/IndicatorList.tsx
@@ -292,17 +292,12 @@ const filterIndicators = (
   includeRelatedPlans: boolean,
   categoryIdentifier?: string
 ) => {
-  const filterByCategory = (indicator) => {
-    if (
-      !categoryIdentifier ||
-      !filters[getCategoryString(categoryIdentifier)]
-    ) {
-      return true;
-    }
-    return indicator.categories.some(
+  const filterByCategory = (indicator) =>
+    !categoryIdentifier ||
+    !filters[getCategoryString(categoryIdentifier)] ||
+    !!indicator.categories.find(
       ({ type, id }) => filters[getCategoryString(type.identifier)] === id
     );
-  };
 
   const filterByCommonCategory = (indicator) => {
     const activeFilters = Object.entries(filters).filter(
@@ -323,12 +318,9 @@ const filterIndicators = (
     });
   };
 
-  const filterBySearch = (indicator) => {
-    if (!filters['name']) {
-      return true;
-    }
-    return indicator.name.toLowerCase().includes(filters['name'].toLowerCase());
-  };
+  const filterBySearch = (indicator) =>
+    !filters['name'] ||
+    indicator.name.toLowerCase().includes(filters['name'].toLowerCase());
 
   return indicators.filter((indicator) => {
     const categoryResult = filterByCategory(indicator);
@@ -449,7 +441,7 @@ const IndicatorList = ({
     ? getFilterConfig(
         categoryType,
         indicators,
-        includeRelatedPlans ? commonCategories : []
+        includeRelatedPlans ? commonCategories : null
       )
     : {};
 

--- a/components/indicators/IndicatorList.tsx
+++ b/components/indicators/IndicatorList.tsx
@@ -65,11 +65,9 @@ const collectCommonCategories = (indicators) => {
   }));
 };
 
-const includeRelatedPlanIndicators = true;
-
 const getFilterConfig = (categoryType, indicators, commonCategories) => ({
   mainFilters: [
-    ...(includeRelatedPlanIndicators
+    ...(commonCategories
       ? commonCategories.map(({ typeIdentifier, categories, type }) => ({
           __typename: 'CategoryTypeFilterBlock',
           field: 'category',
@@ -291,6 +289,7 @@ interface Filters {
 const filterIndicators = (
   indicators,
   filters: Filters,
+  includeRelatedPlans: boolean,
   categoryIdentifier?: string
 ) => {
   const filterByCategory = (indicator) => {
@@ -336,7 +335,7 @@ const filterIndicators = (
     const commonCategoryResult = filterByCommonCategory(indicator);
     const searchResult = filterBySearch(indicator);
     return (
-      (!includeRelatedPlanIndicators ? categoryResult : commonCategoryResult) &&
+      (!includeRelatedPlans ? categoryResult : commonCategoryResult) &&
       searchResult
     );
   });
@@ -353,12 +352,14 @@ interface Props {
   leadContent: IndicatorListPage['leadContent'];
   displayInsights: IndicatorListPage['displayInsights'];
   displayLevel: IndicatorListPage['displayLevel'];
+  includeRelatedPlans: IndicatorListPage['includeRelatedPlans'];
 }
 
 const IndicatorList = ({
   leadContent,
   displayInsights,
   displayLevel,
+  includeRelatedPlans,
 }: Props) => {
   const plan = usePlan();
   const t = useTranslations();
@@ -369,7 +370,7 @@ const IndicatorList = ({
     {
       variables: {
         plan: plan.identifier,
-        relatedPlanIndicators: includeRelatedPlanIndicators,
+        relatedPlanIndicators: includeRelatedPlans,
       },
     }
   );
@@ -418,9 +419,7 @@ const IndicatorList = ({
       leadContent: generalContent.indicatorListLeadContent,
       displayMunicipality,
       displayNormalizedValues,
-      relatedPlanIndicators: includeRelatedPlanIndicators
-        ? relatedPlanIndicators
-        : [],
+      relatedPlanIndicators: includeRelatedPlans ? relatedPlanIndicators : [],
     };
   };
 
@@ -429,13 +428,13 @@ const IndicatorList = ({
 
   const indicatorListProps = getIndicatorListProps(data);
 
-  const indicators = includeRelatedPlanIndicators
+  const indicators = includeRelatedPlans
     ? indicatorListProps.relatedPlanIndicators
     : indicatorListProps.indicators;
 
   const commonCategories = collectCommonCategories(indicators);
   const hierarchy = processCommonIndicatorHierarchy(
-    includeRelatedPlanIndicators
+    includeRelatedPlans
       ? indicatorListProps.relatedPlanIndicators
       : data?.planIndicators
   );
@@ -450,7 +449,7 @@ const IndicatorList = ({
     ? getFilterConfig(
         categoryType,
         indicators,
-        includeRelatedPlanIndicators ? commonCategories : []
+        includeRelatedPlans ? commonCategories : []
       )
     : {};
 
@@ -467,6 +466,7 @@ const IndicatorList = ({
   const filteredIndicators = filterIndicators(
     indicators,
     filters,
+    includeRelatedPlans,
     categoryType?.identifier
   );
 
@@ -496,7 +496,7 @@ const IndicatorList = ({
             category.type.id === categoryType?.id
           }
           displayLevel={displayLevel}
-          includePlanRelatedIndicators={includeRelatedPlanIndicators}
+          includePlanRelatedIndicators={includeRelatedPlans}
           commonCategories={commonCategories}
         />
       </Container>

--- a/components/indicators/IndicatorList.tsx
+++ b/components/indicators/IndicatorList.tsx
@@ -496,6 +496,8 @@ const IndicatorList = ({
             category.type.id === categoryType?.id
           }
           displayLevel={displayLevel}
+          includePlanRelatedIndicators={includeRelatedPlanIndicators}
+          commonCategories={commonCategories}
         />
       </Container>
     </>

--- a/components/indicators/IndicatorListFiltered.tsx
+++ b/components/indicators/IndicatorListFiltered.tsx
@@ -403,6 +403,8 @@ const IndicatorListFiltered = (props) => {
     displayNormalizedValues,
     shouldDisplayCategory,
     displayLevel,
+    includePlanRelatedIndicators,
+    commonCategories,
   } = props;
 
   const locale = useLocale();
@@ -558,7 +560,17 @@ const IndicatorListFiltered = (props) => {
               </IndentableTableHeader>
             );
           }
-          if (someIndicatorsHaveCategories) {
+          if (includePlanRelatedIndicators) {
+            // Use common categories for columns
+            commonCategories.forEach((category) => {
+              headers.push(
+                <IndentableTableHeader key={`hr-${category.typeIdentifier}`}>
+                  {category.type.name}
+                </IndentableTableHeader>
+              );
+            });
+          } else if (someIndicatorsHaveCategories) {
+            // Existing code for regular categories
             headers.push(
               <IndentableTableHeader key="hr-themes">
                 {categoryColumnLabel || t('themes')}
@@ -693,19 +705,41 @@ const IndicatorListFiltered = (props) => {
                           </IndicatorLink>
                         </IndentableTableCell>
                       )}
-                      {someIndicatorsHaveCategories && (
-                        <IndentableTableCell>
-                          {item.categories.map((cat) => {
-                            if (cat && (shouldDisplayCategory?.(cat) ?? true))
-                              return (
-                                <StyledBadge key={cat.id}>
-                                  {cat.name}
-                                </StyledBadge>
-                              );
-                            return false;
-                          })}
-                        </IndentableTableCell>
-                      )}
+                      {includePlanRelatedIndicators
+                        ? commonCategories.map((commonCategory) => (
+                            <IndentableTableCell
+                              key={`cat-${commonCategory.typeIdentifier}`}
+                            >
+                              {item.categories
+                                .filter(
+                                  (cat) =>
+                                    cat.common &&
+                                    cat.common.type.identifier ===
+                                      commonCategory.typeIdentifier
+                                )
+                                .map((cat) => (
+                                  <StyledBadge key={cat.common.id}>
+                                    {cat.common.name}
+                                  </StyledBadge>
+                                ))}
+                            </IndentableTableCell>
+                          ))
+                        : someIndicatorsHaveCategories && (
+                            <IndentableTableCell>
+                              {item.categories.map((cat) => {
+                                if (
+                                  cat &&
+                                  (shouldDisplayCategory?.(cat) ?? true)
+                                )
+                                  return (
+                                    <StyledBadge key={cat.id}>
+                                      {cat.name}
+                                    </StyledBadge>
+                                  );
+                                return false;
+                              })}
+                            </IndentableTableCell>
+                          )}
                       <IndentableTableCell>
                         {item.latestValue && (
                           <IndicatorDate>
@@ -756,6 +790,8 @@ IndicatorListFiltered.propTypes = {
   indicators: PropTypes.arrayOf(PropTypes.object).isRequired,
   shouldDisplayCategory: PropTypes.func,
   displayLevel: PropTypes.bool,
+  includePlanRelatedIndicators: PropTypes.bool,
+  commonCategories: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default IndicatorListFiltered;

--- a/components/indicators/IndicatorListFiltered.tsx
+++ b/components/indicators/IndicatorListFiltered.tsx
@@ -595,6 +595,40 @@ const IndicatorListFiltered = (props) => {
             );
           }
 
+          const CommonCategoriesCell = ({ item, commonCategories }) => (
+            <>
+              {commonCategories.map((commonCategory) => (
+                <IndentableTableCell
+                  key={`cat-${commonCategory.typeIdentifier}`}
+                >
+                  {item.categories
+                    .filter(
+                      (cat) =>
+                        cat.common &&
+                        cat.common.type.identifier ===
+                          commonCategory.typeIdentifier
+                    )
+                    .map((cat) => (
+                      <StyledBadge key={cat.common.id}>
+                        {cat.common.name}
+                      </StyledBadge>
+                    ))}
+                </IndentableTableCell>
+              ))}
+            </>
+          );
+
+          const RegularCategoriesCell = ({ item, shouldDisplayCategory }) => (
+            <IndentableTableCell>
+              {item.categories.map((cat) => {
+                if (cat && (shouldDisplayCategory?.(cat) ?? true)) {
+                  return <StyledBadge key={cat.id}>{cat.name}</StyledBadge>;
+                }
+                return null;
+              })}
+            </IndentableTableCell>
+          );
+
           return (
             <React.Fragment key={`indicator-group-${idx}`}>
               {!indicatorNameColumnEnabled && (
@@ -705,41 +739,19 @@ const IndicatorListFiltered = (props) => {
                           </IndicatorLink>
                         </IndentableTableCell>
                       )}
-                      {includePlanRelatedIndicators
-                        ? commonCategories.map((commonCategory) => (
-                            <IndentableTableCell
-                              key={`cat-${commonCategory.typeIdentifier}`}
-                            >
-                              {item.categories
-                                .filter(
-                                  (cat) =>
-                                    cat.common &&
-                                    cat.common.type.identifier ===
-                                      commonCategory.typeIdentifier
-                                )
-                                .map((cat) => (
-                                  <StyledBadge key={cat.common.id}>
-                                    {cat.common.name}
-                                  </StyledBadge>
-                                ))}
-                            </IndentableTableCell>
-                          ))
-                        : someIndicatorsHaveCategories && (
-                            <IndentableTableCell>
-                              {item.categories.map((cat) => {
-                                if (
-                                  cat &&
-                                  (shouldDisplayCategory?.(cat) ?? true)
-                                )
-                                  return (
-                                    <StyledBadge key={cat.id}>
-                                      {cat.name}
-                                    </StyledBadge>
-                                  );
-                                return false;
-                              })}
-                            </IndentableTableCell>
-                          )}
+                      {includePlanRelatedIndicators ? (
+                        <CommonCategoriesCell
+                          item={item}
+                          commonCategories={commonCategories}
+                        />
+                      ) : (
+                        someIndicatorsHaveCategories && (
+                          <RegularCategoriesCell
+                            item={item}
+                            shouldDisplayCategory={shouldDisplayCategory}
+                          />
+                        )
+                      )}
                       <IndentableTableCell>
                         {item.latestValue && (
                           <IndicatorDate>

--- a/queries/get-indicator-list-page.ts
+++ b/queries/get-indicator-list-page.ts
@@ -16,6 +16,7 @@ const GET_INDICATOR_LIST_PAGE = gql`
         leadContent
         displayInsights
         displayLevel
+        includeRelatedPlans
       }
       lastPublishedAt
     }


### PR DESCRIPTION
Use relatedPlanIndicators in umbrella plan instead of planindicators. Filter by relatedPlanIndicators common categories instead of planIndicator categories