### PR TITLE
Fix trend line not extending to the goal year

### DIFF
--- a/components/indicators/IndicatorVisualisation.js
+++ b/components/indicators/IndicatorVisualisation.js
@@ -311,8 +311,8 @@ const generateTrendTrace = (indicator, traces, goals, i18n) => {
     const highestDataYear = traces[0].y[traces[0].y.length - 1];
     const highestGoalYear = Math.max(
       ...goals.map((goal) => {
-        const goalYear = goal.x[goal.x.length - 1];
-        return goalYear ? parseInt(goalYear.split('-')[0], 10) : NaN;
+        const goalDate = goal.x[goal.x.length - 1];
+        return goalDate ? new Date(goalDate).getFullYear() : NaN;
       })
     );
 

--- a/components/indicators/IndicatorVisualisation.js
+++ b/components/indicators/IndicatorVisualisation.js
@@ -310,8 +310,12 @@ const generateTrendTrace = (indicator, traces, goals, i18n) => {
 
     const highestDataYear = traces[0].y[traces[0].y.length - 1];
     const highestGoalYear = Math.max(
-      ...goals.map((goal) => goal.x[goal.x.length - 1])
+      ...goals.map((goal) => {
+        const goalYear = goal.x[goal.x.length - 1];
+        return goalYear ? parseInt(goalYear.split('-')[0], 10) : NaN;
+      })
     );
+
     if (highestGoalYear && highestGoalYear > highestDataYear) {
       predictedTrace.x.push(highestGoalYear);
     }


### PR DESCRIPTION
A bug: The trend line was not extending to the correct goal year in the Indicator graphs.
Asana https://app.asana.com/0/1206017643443542/1208538004462773/f

We were getting `highestGoalYear: NaN`. 
Modified `highestGoalYear` to extract and parse the last element of the `x` array.

Before:
<img width="1261" alt="before" src="https://github.com/user-attachments/assets/75142018-7c02-4a34-9eb3-a3c386691923">

After:
<img width="1268" alt="after" src="https://github.com/user-attachments/assets/d09e7610-e6d1-4ed9-bbe5-35342c6271ef">

