### PR TITLE
Highlight the late tasks in the Action Task List

### DIFF
--- a/components/actions/TaskList.js
+++ b/components/actions/TaskList.js
@@ -140,6 +140,10 @@ function parseTimestamp(timestamp) {
   return dayjs(timestamp).format(timeFormat);
 }
 
+const isTaskLate = (task, completed) => {
+  return !completed && new Date(task.dueAt) < new Date();
+};
+
 const Task = (props) => {
   const t = useTranslations();
   const locale = useLocale();
@@ -154,7 +158,7 @@ const Task = (props) => {
     getDateFormat(dateFormat)
   );
 
-  const isLate = !completed && new Date(task.dueAt) < new Date();
+  const isLate = isTaskLate(task, completed);
 
   return (
     <TaskWrapper>
@@ -229,7 +233,7 @@ function TaskList(props) {
     return sortedTasks
       .filter((item) => item.state === state)
       .map((item) => {
-        const isLate = !completed && new Date(item.dueAt) < new Date();
+        const isLate = isTaskLate(item, completed);
         return (
           <ListGroupItem
             key={item.id}

--- a/components/actions/TaskList.js
+++ b/components/actions/TaskList.js
@@ -14,6 +14,13 @@ import RichText from 'components/common/RichText';
 import { useLocale, useTranslations } from 'next-intl';
 import { usePlan } from 'context/plan';
 import { getDateFormat } from 'utils/dates.utils';
+import { setLightness } from 'polished';
+import {
+  StyledStatusBadge,
+  StyledStatusWrapper,
+  StyledStatusIndicator,
+  StyledStatusLabel,
+} from 'components/common/StatusBadge';
 
 const StyledDate = styled.span`
   font-size: ${(props) => props.theme.fontSizeSm};
@@ -100,6 +107,14 @@ const ListGroupTitle = styled.h3`
 
 const ListGroupItem = styled(BaseListGroupItem)`
   padding: ${(props) => props.theme.spaces.s050};
+  background: ${(props) =>
+    props.isLate
+      ? setLightness(0.95, props.theme.taskStatusColors.late)
+      : 'transparent'};
+  border: ${(props) =>
+    props.isLate ? `1px solid ${props.theme.taskStatusColors.late}` : 'none'};
+  border-radius: ${(props) => props.theme.cardBorderRadius};
+  margin-bottom: 8px;
 
   &:first-child {
     border-top-left-radius: ${(props) => props.theme.cardBorderRadius};
@@ -114,6 +129,10 @@ const ListGroupItem = styled(BaseListGroupItem)`
   &.state--cancelled .task-header {
     text-decoration: line-through;
   }
+`;
+
+const StyledStatusBadgeNoBorder = styled(StyledStatusBadge)`
+  border: none;
 `;
 
 function parseTimestamp(timestamp) {
@@ -134,6 +153,8 @@ const Task = (props) => {
     locale,
     getDateFormat(dateFormat)
   );
+
+  const isLate = !completed && new Date(task.dueAt) < new Date();
 
   return (
     <TaskWrapper>
@@ -178,6 +199,17 @@ const Task = (props) => {
           </>
         )}
       </TaskContent>
+      {isLate && (
+        <StyledStatusBadgeNoBorder
+          style={{ marginLeft: 'auto' }}
+          $statusColor={theme.taskStatusColors.late}
+        >
+          <StyledStatusWrapper>
+            <StyledStatusIndicator $statusColor={theme.taskStatusColors.late} />
+            <StyledStatusLabel>{t('late')}</StyledStatusLabel>
+          </StyledStatusWrapper>
+        </StyledStatusBadgeNoBorder>
+      )}
     </TaskWrapper>
   );
 };
@@ -196,11 +228,18 @@ function TaskList(props) {
   function filterTasks(state, completed) {
     return sortedTasks
       .filter((item) => item.state === state)
-      .map((item) => (
-        <ListGroupItem key={item.id} className={`state--${item.state}`}>
-          <Task task={item} theme={theme} completed={completed} />
-        </ListGroupItem>
-      ));
+      .map((item) => {
+        const isLate = !completed && new Date(item.dueAt) < new Date();
+        return (
+          <ListGroupItem
+            key={item.id}
+            className={`state--${item.state}`}
+            isLate={isLate}
+          >
+            <Task task={item} theme={theme} completed={completed} />
+          </ListGroupItem>
+        );
+      });
   }
 
   const notStartedTasks = filterTasks('NOT_STARTED', false);

--- a/components/common/StatusBadge.tsx
+++ b/components/common/StatusBadge.tsx
@@ -14,7 +14,7 @@ type StatusProps = {
   $statusColor: string;
 };
 
-const StyledStatusBadge = styled.div<StatusProps>`
+export const StyledStatusBadge = styled.div<StatusProps>`
   display: inline-block;
   border: ${({ $subtle, $statusColor }) =>
     $subtle ? 'none' : `2px solid ${$statusColor}`};
@@ -28,7 +28,7 @@ const StyledStatusBadgeWithReason = styled(StyledStatusBadge)`
   display: block;
 `;
 
-const StyledStatusIndicator = styled.div<StatusProps>`
+export const StyledStatusIndicator = styled.div<StatusProps>`
   background: ${({ $statusColor }) => $statusColor};
   border-radius: 10px;
   width: 10px;
@@ -36,7 +36,7 @@ const StyledStatusIndicator = styled.div<StatusProps>`
   flex-shrink: 0;
 `;
 
-const StyledStatusLabel = styled.div<{ $subtle?: boolean }>`
+export const StyledStatusLabel = styled.div<{ $subtle?: boolean }>`
   color: ${({ theme }) => theme.textColor.primary};
   font-size: ${({ theme }) => theme.fontSizeSm};
   line-height: ${({ theme }) => theme.lineHeightSm};
@@ -44,7 +44,7 @@ const StyledStatusLabel = styled.div<{ $subtle?: boolean }>`
     $subtle ? theme.fontWeightNormal : theme.fontWeightBold};
 `;
 
-const StyledStatusWrapper = styled.div`
+export const StyledStatusWrapper = styled.div`
   display: flex;
   gap: ${({ theme }) => theme.spaces.s050};
   align-items: center;

--- a/locales/en/actions.json
+++ b/locales/en/actions.json
@@ -60,5 +60,6 @@
   "action-dependencies": "{context, select, CASE_STUDY {Case study dependencies} STRATEGY {Strategy dependencies} other {Action dependencies}}",
   "no-action-version-available": "No --{versionType}--- version available",
   "feedback-on-category": "Give feedback on this category",
-  "feedback-on-category-description": "You can leave a comment or feedback on this category"
+  "feedback-on-category-description": "You can leave a comment or feedback on this category",
+  "late": "Late"
 }


### PR DESCRIPTION
UI improvement: Display late tasks as late in action task list - Asana https://app.asana.com/0/1205310117865974/1207617873637474/f

* Reused `StatusBadge` component for visual consistency to mark the late tasks within the `ListGroupItem`.
* Highlighted the entire `ListGroupItem` when a task is marked as late, using the background color from the StatusBadge/late.
* Added English translations for the "Late" label.

<img width="909" alt="Screen Shot 2024-10-29 at 09 20 01" src="https://github.com/user-attachments/assets/84313fac-82e1-4ec9-a133-bf3f09405710">

To do next: Add translations for the "Late" label via Weblate to support other languages.
