### PR TITLE
Add styles to avoid text clipping

### DIFF
--- a/components/common/BadgeTooltip.tsx
+++ b/components/common/BadgeTooltip.tsx
@@ -26,8 +26,6 @@ const StyledBadge = styled(({ isLink, ...rest }) => <Badge {...rest} />)<{
   hyphens: manual;
   white-space: normal;
   text-align: left;
-  display: inline-flex;
-  align-items: center;
 
   &:hover {
     background-color: ${(props) =>

--- a/components/common/BadgeTooltip.tsx
+++ b/components/common/BadgeTooltip.tsx
@@ -19,12 +19,15 @@ const StyledBadge = styled(({ isLink, ...rest }) => <Badge {...rest} />)<{
   padding: ${(props) => props.theme.badgePaddingY}
     ${(props) => props.theme.badgePaddingX};
   font-weight: ${(props) => props.theme.badgeFontWeight};
+  line-height: 1.5;
   max-width: 100%;
   word-break: break-all;
   word-break: break-word;
   hyphens: manual;
   white-space: normal;
   text-align: left;
+  display: inline-flex;
+  align-items: center;
 
   &:hover {
     background-color: ${(props) =>


### PR DESCRIPTION
A visual bug fix: Category badges text gets vertically clipped (for letters like "g" or "j").
Asana - https://app.asana.com/0/1206017643443542/1206601794961315/f

* Updated styles for `StyledBadge` to align the badge text vertically.

Before:
<img width="345" alt="Screen Shot 2024-10-29 at 15 26 11" src="https://github.com/user-attachments/assets/9c212ede-89f8-459e-91cc-6c24f9bd9e96">

After:
<img width="335" alt="Screen Shot 2024-10-29 at 15 27 55" src="https://github.com/user-attachments/assets/28df5605-9974-40ae-91bd-5aca511bd048">

