### PR TITLE
Fix/plan selector dropdown

### DIFF
--- a/components/common/GlobalNav.tsx
+++ b/components/common/GlobalNav.tsx
@@ -86,8 +86,6 @@ const BotNav = styled(Navbar)<{ $offsetTop?: number; $expanded: boolean }>`
 
   .container {
     flex-wrap: nowrap;
-    overflow-x: auto;
-    overflow-y: hidden;
     background-image: ${({ theme }) =>
         `linear-gradient(to right, ${theme.themeColors.white}, ${theme.themeColors.white}),
         linear-gradient(to right, ${theme.themeColors.white}, ${theme.themeColors.white})`},
@@ -698,6 +696,7 @@ function GlobalNav(props) {
             </Nav>
             <Nav navbar className="ms-md-5">
               <PlanVersionSelector plan={plan} />
+
               {externalItems.length > 0 &&
                 externalItems.map((item, index) => (
                   <NavItem key={`external${index}`}>

--- a/components/common/GlobalNav.tsx
+++ b/components/common/GlobalNav.tsx
@@ -86,6 +86,8 @@ const BotNav = styled(Navbar)<{ $offsetTop?: number; $expanded: boolean }>`
 
   .container {
     flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
     background-image: ${({ theme }) =>
         `linear-gradient(to right, ${theme.themeColors.white}, ${theme.themeColors.white}),
         linear-gradient(to right, ${theme.themeColors.white}, ${theme.themeColors.white})`},

--- a/components/common/GlobalNav.tsx
+++ b/components/common/GlobalNav.tsx
@@ -696,7 +696,6 @@ function GlobalNav(props) {
             </Nav>
             <Nav navbar className="ms-md-5">
               <PlanVersionSelector plan={plan} />
-
               {externalItems.length > 0 &&
                 externalItems.map((item, index) => (
                   <NavItem key={`external${index}`}>

--- a/components/versioning/PlanVersionSelector.tsx
+++ b/components/versioning/PlanVersionSelector.tsx
@@ -148,7 +148,7 @@ const PlanVersionSelector = (props) => {
           {activeVersion.versionName}
           <Icon.AngleDown />
         </StyledDropdownToggle>
-        <DropdownMenu>
+        <DropdownMenu container="body">
           <DropdownItem header>{t('versions-list')}</DropdownItem>
           {allVersions.reverse().map((v) => (
             <VersionDropdownItem


### PR DESCRIPTION
Fix: The plan selector dropdown menu is overlapped by other components
Asana - https://app.asana.com/0/1206017643443542/1208648881969349/f

* Updated DropdownMenu to use container="body" to ensure the dropdown is not affected by overflow styles

Before:
<img width="1438" alt="Screen Shot 2024-10-31 at 12 02 26" src="https://github.com/user-attachments/assets/80b4a251-e3c1-4b12-84c2-341b560a0adf">

After:
<img width="1440" alt="Screen Shot 2024-10-31 at 11 51 34" src="https://github.com/user-attachments/assets/4dd4edee-d626-41cc-9831-3579443e63ab">
