### PR TITLE
Add plan name column to action dashboard export

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -98,6 +98,7 @@
   "page": "Page",
   "page-not-found": "Page not found",
   "percent-point-abbreviation": "p.p.",
+  "plan": "Plan",
   "previous": "Previous",
   "published-on": "Published on",
   "read-more": "Read more",


### PR DESCRIPTION
The new column is only added when there are multiple plans in the dashboard, which can happen for umbrella plans.

https://app.asana.com/0/1205307984231852/1208281478512987/f