### PR TITLE
Apply locale for consistent number formatting

### DIFF
--- a/components/indicators/IndicatorHighlightCard.tsx
+++ b/components/indicators/IndicatorHighlightCard.tsx
@@ -94,6 +94,8 @@ type IndicatorHighlightCardProps = {
   unit?: string;
 };
 
+import { useLocale } from 'next-intl';
+
 function IndicatorHighlightCard({
   level,
   objectid,
@@ -103,6 +105,7 @@ function IndicatorHighlightCard({
 }: IndicatorHighlightCardProps) {
   const t = useTranslations();
   const plan = usePlan();
+  const locale = useLocale();
 
   // FIXME: It sucks that we only use the context for the translation key 'action'
   const indicatorType =
@@ -117,7 +120,7 @@ function IndicatorHighlightCard({
           <IndicatorBg $level={level} />
           <CardImgOverlay>
             <IndicatorValue $level={level} className="action-number">
-              {typeof value === 'number' ? beautifyValue(value) : '-'}
+              {typeof value === 'number' ? beautifyValue(value, locale) : '-'}
               <IndicatorUnit>{unit === 'no unit' ? '' : unit}</IndicatorUnit>
             </IndicatorValue>
           </CardImgOverlay>


### PR DESCRIPTION
Fix: Inconsistent indicator value decimal point in the Indicator highlight card - Asana https://app.asana.com/0/1206017643443542/1208816853419121/f

* Added `useLocale` hook and updated the `beautifyValue` function to use locale for number formatting consistency
<img width="940" alt="Screen Shot 2024-11-26 at 11 12 31" src="https://github.com/user-attachments/assets/60e9fa6f-bbd9-4afe-bd83-5837a44db1ff">
