### PR TITLE
Fix/visual consistency for category page blocks

### DIFF
--- a/components/contentblocks/ActionListBlock.tsx
+++ b/components/contentblocks/ActionListBlock.tsx
@@ -35,7 +35,7 @@ const ActionListSection = styled.div`
   padding: ${(props) => props.theme.spaces.s400} 0;
 `;
 
-const SectionHeader = styled.h2`
+export const SectionHeader = styled.h2`
   text-align: center;
   padding: ${(props) => props.theme.spaces.s100};
   border-radius: ${(props) => props.theme.cardBorderRadius};

--- a/components/contentblocks/IndicatorGroupBlock.tsx
+++ b/components/contentblocks/IndicatorGroupBlock.tsx
@@ -10,6 +10,7 @@ import IndicatorHighlightCard from 'components/indicators/IndicatorHighlightCard
 import IndicatorVisualisation from 'components/indicators/IndicatorVisualisation';
 import Button from 'components/common/Button';
 import { useTranslations } from 'next-intl';
+import { SectionHeader } from 'components/contentblocks/ActionListBlock';
 
 const IndicatorGraphSection = styled.div`
   background-color: ${(props) => props.theme.neutralLight};
@@ -92,10 +93,14 @@ type Props = {
 const IndicatorGroupBlock = ({ id = '', title, indicators }: Props) => {
   const t = useTranslations();
 
+  const displayHeader = title && title !== '-' ? title : t('indicators');
+
   return (
     <IndicatorGraphSection id={id}>
       <Container>
-        <h2>{title ?? t('indicators')}</h2>
+        {displayHeader && displayHeader !== '-' ? (
+          <SectionHeader>{displayHeader}</SectionHeader>
+        ) : null}
         <Row className="justify-content-center">
           {indicators.map((item) => (
             <IndicatorItem

--- a/components/contentblocks/IndicatorGroupBlock.tsx
+++ b/components/contentblocks/IndicatorGroupBlock.tsx
@@ -14,7 +14,7 @@ import { SectionHeader } from 'components/contentblocks/ActionListBlock';
 
 const IndicatorGraphSection = styled.div`
   background-color: ${(props) => props.theme.neutralLight};
-  padding: ${(props) => props.theme.spaces.s300};
+  padding: ${(props) => props.theme.spaces.s400} 0;
   color: ${(props) =>
     readableColor(
       props.theme.neutralLight,
@@ -83,6 +83,10 @@ const StyledColCentered = styled(Col)`
   justify-content: center;
 `;
 
+const StyledRow = styled(Row)`
+  margin-top: ${(props) => props.theme.spaces.s400};
+`;
+
 type Props = {
   id?: string;
   title?: string;
@@ -101,7 +105,7 @@ const IndicatorGroupBlock = ({ id = '', title, indicators }: Props) => {
         {displayHeader && displayHeader !== '-' ? (
           <SectionHeader>{displayHeader}</SectionHeader>
         ) : null}
-        <Row className="justify-content-center">
+        <StyledRow className="justify-content-center">
           {indicators.map((item) => (
             <IndicatorItem
               indicator={item.indicator}
@@ -109,7 +113,7 @@ const IndicatorGroupBlock = ({ id = '', title, indicators }: Props) => {
               key={item.indicator.id}
             />
           ))}
-        </Row>
+        </StyledRow>
         <Row>
           <StyledColCentered>
             <IndicatorListLink>

--- a/components/contentblocks/IndicatorGroupBlock.tsx
+++ b/components/contentblocks/IndicatorGroupBlock.tsx
@@ -96,15 +96,12 @@ type Props = {
 // TODO: Format as list for a11y
 const IndicatorGroupBlock = ({ id = '', title, indicators }: Props) => {
   const t = useTranslations();
-
-  const displayHeader = title && title !== '-' ? title : t('indicators');
+  const displayHeader = title === '-' ? null : title || t('indicators');
 
   return (
     <IndicatorGraphSection id={id}>
       <Container>
-        {displayHeader && displayHeader !== '-' ? (
-          <SectionHeader>{displayHeader}</SectionHeader>
-        ) : null}
+        {displayHeader ? <SectionHeader>{displayHeader}</SectionHeader> : null}
         <StyledRow className="justify-content-center">
           {indicators.map((item) => (
             <IndicatorItem


### PR DESCRIPTION
Make Actions and Indicators blocks more consistent visually on the Category page.
Asana task (comments) - https://app.asana.com/0/1207297197056782/1208372090337686/f


<img width="1137" alt="Screen Shot 2024-11-27 at 15 45 55" src="https://github.com/user-attachments/assets/00221f7a-609f-461c-a6f5-12450a81a593">
