### PR TITLE
Apply custom indicator value formatting to the graphs

### DIFF
--- a/components/graphs/IndicatorGraph.tsx
+++ b/components/graphs/IndicatorGraph.tsx
@@ -276,7 +276,12 @@ const createTraces: (params: CreateTracesParams) => TracesOutput = (params) => {
       }
     }
     const timeFormat = timeResolution === 'YEAR' ? '%Y' : '%x';
-    modTrace.hovertemplate = `(%{x|${timeFormat}})<br> ${trace.name}: %{y:,.3r} ${unit}`;
+    const theme = useTheme();
+    const roundIndicatorValue =
+      theme.settings?.graphs?.roundIndicatorValue ?? true;
+    modTrace.hovertemplate = `(%{x|${timeFormat}})<br> ${trace.name}: ${
+      roundIndicatorValue === false ? '%{y:,.f}' : '%{y:,.3r}'
+    } ${unit}`;
     modTrace.hoverlabel = {
       bgcolor: plotColors.mainScale[idx % numColors],
       namelength: 0,


### PR DESCRIPTION
A customer request - inconsistent indicators data in the graph and table on Indicator page.
Asana task - https://app.asana.com/0/1206017643443542/1208735960472716/f

* Applied conditional formatting for the hover template indicators value based on theme variable `roundIndicatorValue`
Sibling theme PR https://github.com/kausaltech/kausal-themes/pull/35
