### PR TITLE
Fix URL construction for LogoLink

### DIFF
--- a/components/common/GlobalNav.tsx
+++ b/components/common/GlobalNav.tsx
@@ -32,7 +32,9 @@ import NavbarSearch from './NavbarSearch';
 
 const getRootLink = (plan, locale, primaryLanguage) => {
   if (plan.parent && plan.parent.viewUrl) {
-    const shouldAppendLocale = locale !== primaryLanguage;
+    const shouldAppendLocale =
+      locale !== primaryLanguage &&
+      !plan.parent.viewUrl.includes(`/${locale}/`);
     if (shouldAppendLocale) {
       return `${plan.parent.viewUrl}/${locale}/`;
     }


### PR DESCRIPTION
Fix an issue when clicking on the LogoLink directed users to an URL with doubled locale on the first click.
Asana - https://app.asana.com/0/1206017643443542/1208913102229360/f

* Modified `getRootLink` logic to check if `locale` is already included in `viewUrl`.