### PR TITLE
Resolve SectionHeader contrast issue in IndicatorGroupBlock

### DIFF
--- a/components/contentblocks/IndicatorGroupBlock.tsx
+++ b/components/contentblocks/IndicatorGroupBlock.tsx
@@ -25,12 +25,6 @@ const IndicatorGraphSection = styled.div`
   h2 {
     text-align: center;
     margin-bottom: ${(props) => props.theme.spaces.s300};
-    color: ${(props) =>
-      readableColor(
-        props.theme.neutralLight,
-        props.theme.themeColors.black,
-        props.theme.themeColors.white
-      )};
   }
 `;
 


### PR DESCRIPTION
 Bug: `SectionHeader` text color in the `IndicatorGroupBlock` is not readable in some cases, due to the `readableColor` logic, which caused the text color to be overridden if color contrast insufficient.
 The bug appears after applying SectionHeader to the Indicators block for visual consistency with the ActionListBlock. 
 
 * Removed `readableColor` logic from h2.
 
 Asana https://app.asana.com/0/1206017643443542/1208963765257879/f