### PR TITLE
Feat/make section headers consistent

### DIFF
--- a/components/actions/ActionHighlightsList.tsx
+++ b/components/actions/ActionHighlightsList.tsx
@@ -74,8 +74,16 @@ export const GET_ACTION_LIST = gql`
 
 const ListHeader = styled(Col)`
   h2 {
+    text-align: center;
+    padding: ${(props) => props.theme.spaces.s100};
+    border-radius: ${(props) => props.theme.cardBorderRadius};
+    background-color: ${(props) => props.theme.themeColors.white};
+    color: ${(props) => props.theme.headingsColor};
+    margin-bottom: ${(props) => props.theme.spaces.s300};
+    font-size: ${(props) => props.theme.fontSizeLg};
+
+  @media (min-width: ${(props) => props.theme.breakpointMd}) {
     font-size: ${(props) => props.theme.fontSizeXl};
-    margin-bottom: ${(props) => props.theme.spaces.s400};
   }
 `;
 

--- a/components/contentblocks/CategoryListBlock.tsx
+++ b/components/contentblocks/CategoryListBlock.tsx
@@ -11,6 +11,7 @@ import { CommonContentBlockProps } from 'common/blocks.types';
 import { readableColor } from 'polished';
 import { Theme } from '@kausal/themes/types';
 import { CATEGORY_FRAGMENT } from '@/fragments/category.fragment';
+import { SectionHeader } from 'components/contentblocks/ActionListBlock';
 
 const getColor = (theme: Theme, darkFallback = theme.themeColors.black) =>
   theme.section.categoryList?.color ||
@@ -24,11 +25,6 @@ const CategoryListSection = styled.div`
   padding: ${(props) =>
     `${props.theme.spaces.s400} 0 ${props.theme.spaces.s100} 0`};
   color: ${({ theme }) => getColor(theme)};
-
-  h2 {
-    font-size: ${(props) => props.theme.fontSizeLg};
-    color: ${({ theme }) => getColor(theme, theme.headingsColor)};
-  }
 
   @media (min-width: ${(props) => props.theme.breakpointMd}) {
     h2 {
@@ -70,12 +66,6 @@ const CategoryListSection = styled.div`
       line-height: ${(props) => props.theme.lineHeightBase};
     }
   }
-`;
-
-const SectionHeader = styled.h2`
-  text-align: center;
-  color: ${(props) => props.theme.headingsColor};
-  margin-bottom: ${(props) => props.theme.spaces.s100};
 `;
 
 const CardHeader = styled.h3`

--- a/components/indicators/IndicatorHighlightsList.tsx
+++ b/components/indicators/IndicatorHighlightsList.tsx
@@ -41,8 +41,16 @@ export const GET_INDICATOR_HIGHLIGHTS = gql`
 
 const ListHeader = styled(Col)`
   h2 {
+    text-align: center;
+    padding: ${(props) => props.theme.spaces.s100};
+    border-radius: ${(props) => props.theme.cardBorderRadius};
+    background-color: ${(props) => props.theme.themeColors.white};
+    color: ${(props) => props.theme.headingsColor};
+    margin-bottom: ${(props) => props.theme.spaces.s300};
+    font-size: ${(props) => props.theme.fontSizeLg};
+
+  @media (min-width: ${(props) => props.theme.breakpointMd}) {
     font-size: ${(props) => props.theme.fontSizeXl};
-    margin-bottom: ${(props) => props.theme.spaces.s400};
   }
 `;
 


### PR DESCRIPTION
Make section headers consistent across the pages - Asana https://app.asana.com/0/1206017643443542/1208848243610566/f

Initially, the idea was to make ActionListblock and IndicatorListBlock headers consistent - PR https://github.com/kausaltech/kausal-watch-ui/pull/435;
When it was decided to apply the same header style to other displayed on the same page blocks headers:
CategoryListBlock - (re-used SectionHeader from ActionListblock);
IndicatorHighlightsBlock - (applied the same styles to the header to prevent hydration errors);
ActionsHighlightBlock - (applied the same styles to the header to prevent hydration errors).