### PR TITLE
WIP: Hide total line on indicator graphs as per setting

### DIFF
--- a/components/indicators/IndicatorVisualisation.js
+++ b/components/indicators/IndicatorVisualisation.js
@@ -1,3 +1,4 @@
+'use client';
 import React, { useState } from 'react';
 
 import dayjs from 'common/dayjs';
@@ -33,8 +34,7 @@ const GET_INDICATOR_GRAPH_DATA = gql`
       name
       timeResolution
       showTrendline
-      # TODO: add when backend available
-      # showTotalLine
+      showTotalLine
       desiredTrend
       reference
       minValue
@@ -187,7 +187,6 @@ function generateCubeFromValues(
   indicatorGraphSpecification,
   combinedValues
 ) {
-  const traces = [];
   const values = [...combinedValues]
     .sort((a, b) => a.date - b.date)
     .map((item) => {
@@ -240,7 +239,6 @@ function getTraces(dimensions, cube, names, hasTimeDimension, i18n) {
         ).join(', ');
         let x,
           y,
-          xType,
           _cube = cube[idx];
         x = _cube.map((val) => val.date);
         y = _cube.map((val) => val.value);
@@ -454,7 +452,7 @@ function getIndicatorGraphSpecification(
 
   if (hasTime) {
     dimensions.forEach((d) => {
-      const { categories, id: dimId, type } = d.dimension;
+      const { categories, type } = d.dimension;
       if (type === 'organization') {
         return;
       }
@@ -565,13 +563,7 @@ function normalizeValuesByNormalizer(values, normalizerId) {
   );
 }
 
-const isServer = typeof window === 'undefined';
 function IndicatorVisualisation({ indicatorId, indicatorLink }) {
-  // FIXME: Hooks cannot be called conditionally, we shouldn't return early here
-  if (isServer) {
-    return null;
-  }
-
   const plan = usePlan();
   const enableIndicatorComparison =
     plan.features.enableIndicatorComparison === true;
@@ -682,7 +674,7 @@ function IndicatorVisualisation({ indicatorId, indicatorLink }) {
   indicatorGraphSpecification.cube = cube;
   const hasTimeDimension =
     indicatorGraphSpecification.axes.filter((a) => a[0] === 'time').length > 0;
-  const showTotalLine = false; //indicator.showTotalLine;
+  const showTotalLine = indicator.showTotalLine;
   const traces = getTraces(
     indicatorGraphSpecification.dimensions,
     cube,
@@ -691,7 +683,6 @@ function IndicatorVisualisation({ indicatorId, indicatorLink }) {
     i18n
   ).filter((t) => t.dataType !== 'total' || showTotalLine);
 
-  console.log('traces', traces);
   const [goalTraces, goalBounds] = normalizeByPopulation
     ? [[], []]
     : generateGoalTraces(indicator, scenarios, i18n);

--- a/components/indicators/IndicatorVisualisation.js
+++ b/components/indicators/IndicatorVisualisation.js
@@ -33,6 +33,8 @@ const GET_INDICATOR_GRAPH_DATA = gql`
       name
       timeResolution
       showTrendline
+      # TODO: add when backend available
+      # showTotalLine
       desiredTrend
       reference
       minValue
@@ -242,6 +244,7 @@ function getTraces(dimensions, cube, names, hasTimeDimension, i18n) {
           _cube = cube[idx];
         x = _cube.map((val) => val.date);
         y = _cube.map((val) => val.value);
+        console.log('trace', traceName, x, y);
         return {
           xType: 'time',
           dataType: cat.id === 'total' ? 'total' : null,
@@ -679,13 +682,16 @@ function IndicatorVisualisation({ indicatorId, indicatorLink }) {
   indicatorGraphSpecification.cube = cube;
   const hasTimeDimension =
     indicatorGraphSpecification.axes.filter((a) => a[0] === 'time').length > 0;
+  const showTotalLine = false; //indicator.showTotalLine;
   const traces = getTraces(
     indicatorGraphSpecification.dimensions,
     cube,
     null,
     hasTimeDimension,
     i18n
-  );
+  ).filter((t) => t.dataType !== 'total' || showTotalLine);
+
+  console.log('traces', traces);
   const [goalTraces, goalBounds] = normalizeByPopulation
     ? [[], []]
     : generateGoalTraces(indicator, scenarios, i18n);

--- a/components/indicators/IndicatorVisualisation.js
+++ b/components/indicators/IndicatorVisualisation.js
@@ -687,7 +687,10 @@ function IndicatorVisualisation({ indicatorId, indicatorLink }) {
     ? [[], []]
     : generateGoalTraces(indicator, scenarios, i18n);
   const [trendTrace, trendBounds] =
-    normalizeByPopulation || !hasTimeDimension || !indicator.showTrendline
+    normalizeByPopulation ||
+    !hasTimeDimension ||
+    !indicator.showTrendline ||
+    !indicator.showTotalLine
       ? [null, null]
       : generateTrendTrace(indicator, traces, goalTraces, i18n);
 

--- a/components/indicators/IndicatorVisualisation.js
+++ b/components/indicators/IndicatorVisualisation.js
@@ -242,7 +242,6 @@ function getTraces(dimensions, cube, names, hasTimeDimension, i18n) {
           _cube = cube[idx];
         x = _cube.map((val) => val.date);
         y = _cube.map((val) => val.value);
-        console.log('trace', traceName, x, y);
         return {
           xType: 'time',
           dataType: cat.id === 'total' ? 'total' : null,


### PR DESCRIPTION
Use showTotalLine setting on indicator graphs

BEFORE:
<img width="1052" alt="Screenshot 2025-01-02 at 15 30 48" src="https://github.com/user-attachments/assets/de88539c-1004-49db-93b2-dce14bec19d4" />

AFTER:
<img width="1238" alt="Screenshot 2025-01-02 at 15 35 16" src="https://github.com/user-attachments/assets/fdac20ad-baf4-4230-b4b8-246fd0cd1e5f" />

