### PR TITLE
Another fix URL construction for LogoLink

### DIFF
--- a/components/common/GlobalNav.tsx
+++ b/components/common/GlobalNav.tsx
@@ -33,8 +33,7 @@ import NavbarSearch from './NavbarSearch';
 const getRootLink = (plan, locale, primaryLanguage) => {
   if (plan.parent && plan.parent.viewUrl) {
     const shouldAppendLocale =
-      locale !== primaryLanguage &&
-      !plan.parent.viewUrl.includes(`/${locale}/`);
+      locale !== primaryLanguage && !plan.parent.viewUrl.includes(`/${locale}`);
     if (shouldAppendLocale) {
       return `${plan.parent.viewUrl}/${locale}/`;
     }


### PR DESCRIPTION
followup to: https://github.com/kausaltech/kausal-watch-ui/pull/441/files
the first fix did not work because the viewurl included `/<locale>` and not `/<locale>/ `