### PR TITLE
Adjust filter label text on indicators page

### DIFF
--- a/common/i18n.ts
+++ b/common/i18n.ts
@@ -4,10 +4,15 @@ import {
   SiteGeneralContentActionTerm,
 } from './__generated__/graphql';
 
-export function getActionTermContext(plan: {
-  generalContent?: { actionTerm: SiteGeneralContentActionTerm };
-}) {
-  const actionTerm = plan.generalContent?.actionTerm;
+export function getActionTermContext(
+  plan: {
+    generalContent?: { actionTerm: SiteGeneralContentActionTerm };
+  },
+  actionTerm?: string
+) {
+  if (!actionTerm) {
+    actionTerm = plan.generalContent?.actionTerm;
+  }
   return actionTerm === 'ACTION'
     ? { context: undefined }
     : { context: actionTerm };

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -811,9 +811,9 @@ class ActionNameFilter implements ActionListFilter<string | undefined> {
   hasActionIdentifiers: boolean;
   ref: Ref<HTMLInputElement>;
 
-  constructor(plan: PlanContextType) {
+  constructor(plan: PlanContextType, actionTerm?: string) {
     this.hasActionIdentifiers = plan.features.hasActionIdentifiers;
-    this.actionTermContext = getActionTermContext(plan);
+    this.actionTermContext = getActionTermContext(plan, actionTerm);
     this.ref = createRef();
   }
 
@@ -1067,11 +1067,19 @@ type ConstructFiltersOpts = {
   orgs: ActionListOrganization[];
   primaryOrgs: ActionListPrimaryOrg[];
   filterByCommonCategory: boolean;
+  actionTerm?: string;
 };
 
 ActionListFilters.constructFilters = (opts: ConstructFiltersOpts) => {
-  const { mainConfig, plan, t, orgs, primaryOrgs, filterByCommonCategory } =
-    opts;
+  const {
+    mainConfig,
+    plan,
+    t,
+    orgs,
+    primaryOrgs,
+    filterByCommonCategory,
+    actionTerm,
+  } = opts;
   const { primaryFilters, mainFilters, advancedFilters } = mainConfig;
 
   function makeSection(
@@ -1219,7 +1227,7 @@ ActionListFilters.constructFilters = (opts: ConstructFiltersOpts) => {
         };
         filters.push(new GenericSelectFilter(opts));
       }
-      filters.push(new ActionNameFilter(plan));
+      filters.push(new ActionNameFilter(plan, actionTerm));
     }
 
     const ret: ActionListFilterSection = {

--- a/components/indicators/IndicatorList.tsx
+++ b/components/indicators/IndicatorList.tsx
@@ -480,6 +480,7 @@ const IndicatorList = ({
       plan,
       filterByCommonCategory: false,
       t,
+      actionTerm: 'INDICATOR',
     });
 
   const filteredIndicators = filterIndicators(

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -46,7 +46,7 @@
     "filter-primary-organization": "{context, select, DIVISION {Leitende Abteilung} other {Primäre Organisation}}",
     "filter-result-actions": "{context, select, STRATEGY {Strategien} CASE_STUDY {Fallstudien} other {Maßnahmen}}",
     "filter-schedule": "Zeitplan",
-    "filter-text": "{context, select, CASE_STUDY {Fallstudien durchsuchen} STRATEGY {Strategien durchsuchen} other {Maßnahmen durchsuchen}}",
+    "filter-text": "{context, select, CASE_STUDY {Fallstudien durchsuchen} STRATEGY {Strategien durchsuchen} INDICATOR {Indikatoren durchsuchen} other {Maßnahmen durchsuchen}}",
     "filter-text-default": "Nach Schlüsselwort suchen",
     "front-page": "Titelseite",
     "give-feedback": "Feedback geben",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -49,7 +49,7 @@
   "filter-result-actions": "{context, select, CASE_STUDY {case studies} STRATEGY {strategies} other {actions}}",
   "filter-schedule": "Schedule",
   "filter-status": "Status",
-  "filter-text": "{context, select, STRATEGY {Search strategies} CASE_STUDY {Search case studies} other {Search actions}}",
+  "filter-text": "{context, select, STRATEGY {Search strategies} CASE_STUDY {Search case studies} INDICATOR {Search indicators} other {Search actions}}",
   "filter-text-default": "Search by keyword",
   "front-page": "Front Page",
   "give-feedback": "Give feedback",


### PR DESCRIPTION
Adjust text for filter label on Indicator dashboard - Asana https://app.asana.com/0/1206017643443542/1208871410132335/f

* Added optional `actionTerm` parameter to `getActionTermContext`;
* Updated `IndicatorList` to pass `actionTerm: 'INDICATOR'` for the correct context;
* Added `INDICATOR` context to the `filter-text` in locale files (EN and DE).

Before:
<img width="1385" alt="Screenshot 2025-01-07 at 11 33 06" src="https://github.com/user-attachments/assets/415b914e-b520-4823-a96b-d98b075f0cb3" />

After:
<img width="1355" alt="Screenshot 2025-01-07 at 11 34 41" src="https://github.com/user-attachments/assets/1b99ef0f-7b7b-4159-b742-8e3c89d1fa02" />

To do next: Add the rest of translations for `filter-text` via Weblate.


