### PR TITLE
Make date columns styling consistent

### DIFF
--- a/components/dashboard/cells/DateCell.tsx
+++ b/components/dashboard/cells/DateCell.tsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import dayjs from 'common/dayjs';
+
+interface Props {
+  date: string | null;
+}
+
+const Wrapper = styled.div`
+  font-size: ${(props) => props.theme.fontSizeSm};
+  font-family: ${(props) =>
+    `${props.theme.fontFamilyTiny}, ${props.theme.fontFamilyFallback}`};
+  white-space: nowrap;
+  padding: ${(props) => props.theme.spaces.s050};
+  color: ${(props) => props.theme.textColorPrimary};
+`;
+
+const DateCell = ({ date }: Props) => {
+  const formattedDate = date ? dayjs(date).format('L') : null;
+  return <Wrapper>{formattedDate}</Wrapper>;
+};
+
+export default DateCell;

--- a/components/dashboard/cells/DateCell.tsx
+++ b/components/dashboard/cells/DateCell.tsx
@@ -5,7 +5,7 @@ interface Props {
   date: string | null;
 }
 
-const Wrapper = styled.div`
+const Wrapper = styled.span`
   font-size: ${(props) => props.theme.fontSizeSm};
   font-family: ${(props) =>
     `${props.theme.fontFamilyTiny}, ${props.theme.fontFamilyFallback}`};

--- a/components/dashboard/dashboard.constants.tsx
+++ b/components/dashboard/dashboard.constants.tsx
@@ -26,6 +26,7 @@ import ResponsiblePartiesCell from './cells/ResponsiblePartiesCell';
 import StatusCell from './cells/StatusCell';
 import TasksStatusCell from './cells/TasksStatusCell';
 import UpdatedAtCell from './cells/UpdatedAtCell';
+import DateCell from './cells/DateCell';
 import { ActionListAction, ColumnBlock } from './dashboard.types';
 
 const getPlanUrl = (mergedWith, actionPlan, planId) => {
@@ -181,16 +182,14 @@ export const COLUMN_CONFIG: { [key in ColumnBlock]: Column } = {
     sortable: true,
     headerKey: 'startDate',
     renderHeader: (t, _, label) => label || t('action-start-date'),
-    renderCell: (action) =>
-      action.startDate != null && dayjs(action.startDate).format('l'),
+    renderCell: (action) => <DateCell date={action.startDate} />,
   },
 
   EndDateColumnBlock: {
     sortable: true,
     headerKey: 'endDate',
     renderHeader: (t, _, label) => label || t('action-end-date'),
-    renderCell: (action) =>
-      action.endDate != null && dayjs(action.endDate).format('l'),
+    renderCell: (action) => <DateCell date={action.endDate} />,
   },
 
   FieldColumnBlock: {


### PR DESCRIPTION
In `ActionStatusTable` Start and End Date columns have inconsistent styling to other columns - Asana https://app.asana.com/0/1206017643443542/1209097282477368/f

* Added a reusable `DateCell` component for consistent styling and date formatting for the date columns;
* Applied the `DateCell` to the related column blocks in the `COLUMN_CONFIG`.

Before:
<img width="1299" alt="Screenshot 2025-01-13 at 13 19 35" src="https://github.com/user-attachments/assets/4b0cae4b-35a7-489d-a468-497cf4ee4050" />


After:
<img width="1299" alt="Screenshot 2025-01-13 at 13 20 01" src="https://github.com/user-attachments/assets/7bc8a17e-9a85-4484-a10c-8df21902aa84" />
