### PR TITLE
Align SecondaryIconsContainer vertically

### DIFF
--- a/components/actions/ActionCard.tsx
+++ b/components/actions/ActionCard.tsx
@@ -65,6 +65,9 @@ const SecondaryIcon = styled(SVG)`
 `;
 
 const SecondaryIconsContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: auto;
   text-align: right;
   padding: 0 ${(props) => props.theme.spaces.s050}
     ${(props) => props.theme.spaces.s050};
@@ -75,6 +78,9 @@ const ActionCardElement = styled.div<{
   $isHighlighted: boolean;
 }>`
   position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   width: 100%;
   background: ${(props) => props.theme.themeColors.white};
   border-width: ${(props) => props.theme.cardBorderWidth};


### PR DESCRIPTION
[](url)Align vertically `SecondaryIconsContainer` at the bottom of ActionCard 
Asana https://app.asana.com/0/1205310117865974/1209137870225632/f

* Updated styles for `ActionCardElement` and `SecondaryIconsContainer` to use flexbox.

Before:
<img width="1369" alt="Screenshot 2025-01-14 at 10 41 51" src="https://github.com/user-attachments/assets/1f9096f7-8eec-4a7a-bcb0-6336a18629d6" />

After:
<img width="1360" alt="Screenshot 2025-01-14 at 10 43 36" src="https://github.com/user-attachments/assets/e816e95f-36d1-4252-8d78-b8784b10c9cf" />


