### PR TITLE
Set GitHub Actions runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -20,7 +20,7 @@ on:
 jobs:
   e2e_test:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3


### PR DESCRIPTION
Fix failing e2e tests in GH Actions.
GitHub actions recently switched Ubuntu version from 22.04 to 24.04.
The Playwright installation step in the GitHub Actions failed because of missing dependencies when using `ubuntu-latest`.  Set the runner to the previous version - Ubuntu 22.04.