### PR TITLE
Use graph visual settings from theme

### DIFF
--- a/components/graphs/IndicatorGraph.tsx
+++ b/components/graphs/IndicatorGraph.tsx
@@ -214,7 +214,6 @@ const createTraces: (params: CreateTracesParams) => TracesOutput = (params) => {
   const allXValues = [];
 
   const newTraces = traces.map((trace, idx) => {
-    console.log('trace', trace);
     // Here we are excluding some properties from the trace
     const { xType, dataType, ...plotlyTrace } = trace;
     const modTrace: Data = { ...plotlyTrace };
@@ -525,7 +524,6 @@ function IndicatorGraph(props: IndicatorGraphProps) {
   // add goals if defined
   if (!isComparison && goalTraces.length) {
     goalTraces.forEach((goalTrace, idx) => {
-      console.log('goaltrace', goalTrace);
       plotlyData.push({
         x: goalTrace.x,
         y: goalTrace.y,
@@ -571,7 +569,6 @@ function IndicatorGraph(props: IndicatorGraphProps) {
     ? layoutConfig.grid.rows * 300
     : 450 + (!hasTimeDimension ? CATEGORY_XAXIS_LABEL_EXTRA_MARGIN : 0);
 
-  console.log('plotlyData', plotlyData);
   return (
     <PlotContainer
       data-element="indicator-graph-plot-container"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@elastic/react-search-ui": "^1.11.2",
     "@kausal/mapboxgl-legend": "^1.7.2",
     "@kausal/plotly-custom": "^2.32.0",
-    "@kausal/themes": "^0.8.2",
+    "@kausal/themes": "^0.8.4",
     "@n8tb1t/use-scroll-position": "^2.0.3",
     "@next/bundle-analyzer": "^12.1.6",
     "@popperjs/core": "^2.11.5",
@@ -144,7 +144,7 @@
   },
   "packageManager": "yarn@3.2.1",
   "optionalDependencies": {
-    "@kausal/themes-private": "^0.5.26"
+    "@kausal/themes-private": "^0.5.28"
   },
   "lint-staged": {
     "*.{tsx,ts,js,css,scss,md,json}": "prettier --write"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3842,17 +3842,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@kausal/themes-private@npm:^0.5.26":
-  version: 0.5.26
-  resolution: "@kausal/themes-private@npm:0.5.26"
-  checksum: f8ddc069a8509a1e212a1a4ccab31c038e270bfbf0cc79b5c601873b980c3f325cf1dbbcb383a2a2d7f5e92a4c98f082032db606906029add095d444cdbf6b93
+"@kausal/themes-private@npm:^0.5.28":
+  version: 0.5.28
+  resolution: "@kausal/themes-private@npm:0.5.28"
+  checksum: c96eeadac6e4825967b84ffadf08379bf69bed12bd5e03d4df4985f43bd768e30f9fd6d8aa2a2f2ecbadb4f7d0368c2c93edb98860725cfd4dfd8f1c093491b8
   languageName: node
   linkType: hard
 
-"@kausal/themes@npm:^0.8.2":
-  version: 0.8.2
-  resolution: "@kausal/themes@npm:0.8.2"
-  checksum: 40cdbf2cf01c7f170bad1d8c8fa2b7b07847a7285a51e73b3bc03f323be79a25714aebb7036c731aa55abb0cb9e1c6cd9d2f844c3e9c8d8be9d04cb650accc73
+"@kausal/themes@npm:^0.8.4":
+  version: 0.8.4
+  resolution: "@kausal/themes@npm:0.8.4"
+  checksum: 0e6c99e481d00d0f869ec85ec1f40e891258eb186a683d1085bc370dea2839b8da7a42a21f706796a4a4bf1ea882cfb11f7315fee1ccb5e3adab3848ec9e6f9b
   languageName: node
   linkType: hard
 
@@ -15736,8 +15736,8 @@ __metadata:
     "@graphql-codegen/typescript-react-apollo": ^4.3.2
     "@kausal/mapboxgl-legend": ^1.7.2
     "@kausal/plotly-custom": ^2.32.0
-    "@kausal/themes": ^0.8.2
-    "@kausal/themes-private": ^0.5.26
+    "@kausal/themes": ^0.8.4
+    "@kausal/themes-private": ^0.5.28
     "@n8tb1t/use-scroll-position": ^2.0.3
     "@next/bundle-analyzer": ^12.1.6
     "@playwright/test": ^1.39.0


### PR DESCRIPTION
Dependency: https://github.com/kausaltech/kausal-themes/pull/39

Before merging Patchenstein, moving some customer specific settings from there to `master`

Only visible change in existing graphs should be `hoverformat`:
BEFORE
<img width="1253" alt="Screenshot 2025-01-15 at 19 20 17" src="https://github.com/user-attachments/assets/698506ff-7f62-4866-8bc7-a57e4b5654a8" />

AFTER
<img width="1243" alt="Screenshot 2025-01-15 at 19 20 34" src="https://github.com/user-attachments/assets/6188e677-9314-4da2-ad9c-ebf4310853bc" />


**Via settings we can now set:**
- Fill for trace markers
- Symbol types for all trace markers
- Colors of all traces
- If goals are connected with line

**User need:** 
- Filled circle markers
- Specific color for main trace and goal trace
- Line connecting goal points

<img width="1063" alt="Screenshot 2025-01-15 at 19 23 47" src="https://github.com/user-attachments/assets/ccf1a4ac-3d71-41e2-83d1-1c06dfeadc40" />

