### PR TITLE
Display search text badge again

### DIFF
--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -378,26 +378,29 @@ function ActionListFilterBadges({
     value: SingleFilterValue
   ): Badge | null {
     let label: string;
+
     if (item.id === 'name') {
-      label = value ?? '';
-    } else label = item.getLabel(t);
-    if (item.options) {
+      if (!value || typeof value !== 'string' || value.trim() === '') {
+        return null;
+      }
+      label = value;
+    } else if (item.options) {
       const matchingFilters = enabled.filter((i) => i.id === item.id);
-      let activeOption: any = undefined;
+      let activeOption: ActionListFilterOption | undefined;
+
       for (const filter of matchingFilters) {
-        activeOption = filter.options?.find(
-          (opt) => opt.id === value
-        ) as ActionListFilterOption;
-        if (activeOption !== undefined) break;
+        activeOption = filter.options?.find((opt) => opt.id === value);
+        if (activeOption) break;
       }
 
       if (!activeOption) {
         return null;
       }
-
       label = activeOption.label;
       // Handle boolean type filters
-    } else if (typeof value !== 'boolean') {
+    } else if (typeof value === 'boolean') {
+      label = item.getLabel(t);
+    } else {
       return null;
     }
     return {


### PR DESCRIPTION
Search text badge is disappeared from the ActionListView filter section - Asana https://app.asana.com/0/1206017643443542/1209138285063386/f
Regression bug: the logic of handling boolean filters could cause `name` filters string values return null.

* Refactored `createBadge` function:
Improved validation for `name` filter, logic for `boolean` and `options` filters

Before:
<img width="1361" alt="Screenshot 2025-01-16 at 11 15 21" src="https://github.com/user-attachments/assets/68378775-1951-42e7-b783-a6b4b07239a9" />

After:
<img width="1385" alt="Screenshot 2025-01-16 at 11 15 50" src="https://github.com/user-attachments/assets/1b176982-bbe0-4553-8155-d5583873ef29" />


