### PR TITLE
Apply based on language hyphenation for action.name

### DIFF
--- a/components/actions/ActionCard.tsx
+++ b/components/actions/ActionCard.tsx
@@ -165,7 +165,11 @@ const StyledCardTitle = styled.div<{ $isSmall: boolean }>`
   line-height: ${(props) => props.theme.lineHeightMd};
   text-align: left;
   word-break: break-word;
-  hyphens: manual;
+  hyphens: auto;
+
+  :lang(fi) & {
+    hyphens: manual;
+  }
 `;
 
 const ActionOrg = styled.div`

--- a/components/actions/ActionHero.tsx
+++ b/components/actions/ActionHero.tsx
@@ -114,12 +114,16 @@ const ImageCredit = styled.span`
 `;
 
 const ActionHeadline = styled.h1`
-  hyphens: manual;
+  hyphens: auto;
   display: flex;
   flex-wrap: wrap;
   margin: ${(props) => props.theme.spaces.s100} 0;
   font-size: ${(props) => props.theme.fontSizeLg};
   color: ${(props) => props.theme.textColor.primary} !important;
+
+  :lang(fi) & {
+    hyphens: manual;
+  }
 
   @media (min-width: ${(props) => props.theme.breakpointMd}) {
     font-size: ${(props) => props.theme.fontSizeXl};

--- a/components/actions/ActionHighlightCard.tsx
+++ b/components/actions/ActionHighlightCard.tsx
@@ -57,8 +57,12 @@ const StyledCardTitle = styled(CardTitle)`
   font-size: ${(props) => props.theme.fontSizeMd};
   color: ${(props) => props.theme.neutralDark};
   text-align: left;
-  hyphens: manual;
+  hyphens: auto;
   margin-bottom: 0;
+
+  :lang(fi) & {
+    hyphens: manual;
+  }
 `;
 
 const ImgArea = styled.div<{ $bgcolor?: string }>`


### PR DESCRIPTION
Change `hyphens` from `manual` to `auto` for all languages except Finnish - Asana https://app.asana.com/0/1206017643443542/1208784984047146/f

 We get `hyphens: manual` from backend for `action.name` and need to use that for Finnish language. For other languages should be applied `hyphens: auto`.
 
 * Applied the css `lang(fi)` pseudo-class to the specific components to achieve that.