### PR TITLE
Remove duplicated types in CategoryTags

### DIFF
--- a/components/actions/ActionContent.tsx
+++ b/components/actions/ActionContent.tsx
@@ -289,9 +289,7 @@ function ActionContentBlock(props: ActionContentBlockProps) {
       const categories = action.categories.filter(
         (cat) => cat.type.id === block.categoryType.id
       );
-      return (
-        <CategoryTags categories={categories} types={[block.categoryType]} />
-      );
+      return <CategoryTags categories={categories} />;
     }
     case 'ActionContentAttributeTypeBlock': {
       const attribute = action.attributes.find(

--- a/components/actions/CategoryTags.tsx
+++ b/components/actions/CategoryTags.tsx
@@ -145,8 +145,11 @@ type CategoryTagsProps = {
 
 function CategoryTags(props: CategoryTagsProps) {
   const { categories, types, noLink = false } = props;
-  // const typeById = new Map(types.map(ct => [ct.id, ct]));
-  const groupElements = types.map((ct) => {
+  // Remove duplicate category types by filtering unique IDs
+  const filteredTypes = Array.from(
+    new Map(types.map((t) => [t.id, t])).values()
+  );
+  const groupElements = filteredTypes.map((ct) => {
     const cats = categories.filter((cat) => cat.type.id === ct.id);
     if (!cats.length) return null;
     /* If category type seems to have levels,

--- a/components/actions/CategoryTags.tsx
+++ b/components/actions/CategoryTags.tsx
@@ -139,24 +139,23 @@ export const CategoryContent = (props: CategoryContentProps) => {
 
 type CategoryTagsProps = {
   categories: CategoryRecursiveFragmentFragment[];
-  types: CategoryTypeFragmentFragment[];
   noLink?: boolean;
 };
 
 function CategoryTags(props: CategoryTagsProps) {
-  const { categories, types, noLink = false } = props;
-  // Remove duplicate category types by filtering unique IDs
-  const filteredTypes = Array.from(
-    new Map(types.map((t) => [t.id, t])).values()
+  const { categories, noLink = false } = props;
+  const categoryTypes = Array.from(
+    new Map(categories.map((cat) => [cat.type.id, cat.type])).values()
   );
-  const groupElements = filteredTypes.map((ct) => {
+
+  const groupElements = categoryTypes.map((ct) => {
     const cats = categories.filter((cat) => cat.type.id === ct.id);
     if (!cats.length) return null;
     /* If category type seems to have levels,
         use the level name of the first selected categoory
         as section header */
     const categoryTypeHeader =
-      ct.levels.length > 0 ? cats[0].level?.name : ct.name;
+      ct.levels?.length > 0 ? cats[0].level?.name : ct.name;
 
     return (
       <div key={ct.id} className="mb-4">

--- a/components/indicators/IndicatorContent.tsx
+++ b/components/indicators/IndicatorContent.tsx
@@ -81,11 +81,7 @@ function IndicatorDetails({ indicator }: Props) {
             <RichText html={indicator.description} />
           </Col>
           <Col md="5" lg="4" className="mb-5">
-            <CategoryTags
-              categories={indicator.categories}
-              types={indicator.categories.map((c) => c.type)}
-              noLink={true}
-            />
+            <CategoryTags categories={indicator.categories} noLink={true} />
           </Col>
         </Row>
         {(indicator.latestGraph ||


### PR DESCRIPTION
A bug: Category tags are double-counted on Indicator Details Page - Asana https://app.asana.com/0/1206017643443542/1209302839473157
The problem is caused by the types array containing duplicated types

* Removed the unnecessary `types` prop from `CategoryTags`;
* Used `Map` to avoid duplication of category types;

Before:

<img width="1418" alt="Screenshot 2025-02-03 at 16 37 45" src="https://github.com/user-attachments/assets/4c70c42d-7dd4-4811-9ce3-1a6abde7fc75" />

After:

<img width="1415" alt="Screenshot 2025-02-03 at 16 37 21" src="https://github.com/user-attachments/assets/01c9adaa-5876-4215-b718-5719160d7363" />
