### PR TITLE
Avoid crashing if an image does not have a rendition

### DIFF
--- a/common/images.js
+++ b/common/images.js
@@ -22,14 +22,14 @@ export const getBgImageAlignment = (image) => {
 export function getActionImage(plan, action) {
   let image;
 
-  if (action.image?.rendition.src) {
+  if (action.image?.rendition?.src) {
     image = action.image;
   } else {
     action.categories.forEach((cat) => {
       if (image) return;
       let parent = cat;
       while (parent) {
-        if (parent.image?.rendition.src) {
+        if (parent.image?.rendition?.src) {
           image = parent.image;
           return;
         }

--- a/components/actions/ActionCard.tsx
+++ b/components/actions/ActionCard.tsx
@@ -223,7 +223,7 @@ const PrimaryIcon = (props) => {
   const { category } = props;
   if (!category) return null;
   if (category.iconSvgUrl) return <PrimarySvgIcon src={category.iconSvgUrl} />;
-  if (category.iconImage)
+  if (category.iconImage?.rendition)
     return <PrimaryImageIcon imagesrc={category.iconImage.rendition.src} />;
   else return null;
 };

--- a/components/common/SearchView.js
+++ b/components/common/SearchView.js
@@ -205,8 +205,8 @@ function SearchResultItem({ hit }) {
   }
   const showPlanChip = true;
   const hitImage =
-    primaryOrg?.logo?.rendition.src ||
-    hit.plan.image?.rendition.src ||
+    primaryOrg?.logo?.rendition?.src ||
+    hit.plan.image?.rendition?.src ||
     'https://via.placeholder.com/64/AAAAAA/EEEEEE';
   const hitOrganization = primaryOrg?.name || hit.plan.organization.name;
 

--- a/components/contentblocks/CardListBlock.js
+++ b/components/contentblocks/CardListBlock.js
@@ -84,7 +84,7 @@ const CardListBlock = (props) => {
             >
               <a href={card.link} className="card-wrapper">
                 <Card
-                  imageUrl={card.image && card.image.rendition.src}
+                  imageUrl={card.image?.rendition && card.image.rendition.src}
                   imageAlign="center"
                   customBackgroundColor={theme.brandDark}
                   customColor={readableColor(

--- a/components/contentblocks/RelatedPlanListBlock.tsx
+++ b/components/contentblocks/RelatedPlanListBlock.tsx
@@ -66,7 +66,7 @@ const RelatedPlanListBlock = ({ id }: Props) => {
           {!isParentPlan && (
             <a href={plan.viewUrl} key={plan.identifier}>
               <PlanChip
-                planImage={plan.image?.rendition.src}
+                planImage={plan.image?.rendition?.src}
                 planShortName={plan.shortName}
                 organization={
                   theme.settings?.multiplan?.hideLongPlanNames
@@ -81,7 +81,7 @@ const RelatedPlanListBlock = ({ id }: Props) => {
           {siblingsOrChildren.map((pl) => (
             <a href={pl.viewUrl} key={pl.identifier}>
               <PlanChip
-                planImage={pl.image?.rendition.src}
+                planImage={pl.image?.rendition?.src}
                 planShortName={pl.shortName}
                 organization={
                   theme.settings?.multiplan?.hideLongPlanNames

--- a/components/indicators/IndicatorContent.tsx
+++ b/components/indicators/IndicatorContent.tsx
@@ -60,7 +60,7 @@ function IndicatorDetails({ indicator }: Props) {
       allOrgs.push({
         id: common.id,
         identifier: common.identifier,
-        image: common.organization.logo?.rendition.src,
+        image: common.organization.logo?.rendition?.src,
         name: common.organization.name,
         shortName: common.organization.abbreviation,
         active: common.organization.id === indicator.organization.id,

--- a/components/orgs/OrgContent.tsx
+++ b/components/orgs/OrgContent.tsx
@@ -161,7 +161,7 @@ function OrgContent({ org, planFromOrgQuery }: Props) {
           <Row>
             {org.logo?.rendition?.src && (
               <Col md="2">
-                <OrgLogo src={org.logo?.rendition.src} />
+                <OrgLogo src={org.logo?.rendition?.src} />
               </Col>
             )}
             <Col md="8" xl="7" className="mb-5">


### PR DESCRIPTION
An image does not necessarily have a rendition, as per the GraphQL schema, for whatever reason. Our code did not take this into account and would crash if an image has no rendition. This seems to have been the cause for the following errors:

- https://sentry.kausal.tech/organizations/kausal/issues/4039/
- https://sentry.kausal.tech/organizations/kausal/issues/4033/

Corresponding Asana task:
https://app.asana.com/0/1206017643443542/1209261486348088