### PR TITLE
Truncate category badge differently based on text length

### DIFF
--- a/components/actions/CategoryTags.tsx
+++ b/components/actions/CategoryTags.tsx
@@ -128,7 +128,7 @@ export const CategoryContent = (props: CategoryContentProps) => {
               size="md"
               color="neutralLight"
               isLink={!noLink}
-              maxLines={2}
+              maxLines={item.name.length > 50 ? 2 : 4}
             />
           </CategoryLink>
         </CategoryListItem>


### PR DESCRIPTION
Truncate category badge differently based on text length to avoid short text truncation

To avoid truncation like this: 
![image](https://github.com/user-attachments/assets/f8e1cc39-2370-4c7f-9baa-f80d499e7130)

while still keeping truncation like this:
![image](https://github.com/user-attachments/assets/12a36f74-ea36-417c-bc27-d4d531fddf8f)

For context: tech support request: https://kausaltech.slack.com/archives/C031Z5WMGJ0/p1739343482188709?thread_ts=1739285052.927909&cid=C031Z5WMGJ0