### PR TITLE
Add missing icons to AvailableIcons

### DIFF
--- a/components/common/Icon.tsx
+++ b/components/common/Icon.tsx
@@ -90,6 +90,8 @@ export enum AvailableIcons {
   Times = 'times',
   User = 'user',
   Version = 'version',
+  SimpleLanguage = 'simple-language',
+  SignLanguage = 'sign-language',
 }
 
 type ValidIconName = `${AvailableIcons}`;


### PR DESCRIPTION
Regression bug: The SimpleLanguage and SignLanguage icons were missing from the Bremen navbar because they were not included in the AvailableIcons enum - Asana https://app.asana.com/0/1206017643443542/1209444524338843

<img width="1415" alt="Screenshot 2025-02-20 at 14 32 02" src="https://github.com/user-attachments/assets/7004ce05-4996-434f-97c6-593f65387bc1" />
