### PR TITLE
fix icon badges from clipping text and descending letters

### DIFF
--- a/components/common/BadgeTooltip.tsx
+++ b/components/common/BadgeTooltip.tsx
@@ -93,6 +93,8 @@ const IconImage = styled.div<{ $imageSrc?: string }>`
     !!props.$imageSrc && `background-image: url(${props.$imageSrc});`};
   background-size: cover;
   background-position: center center;
+  min-width: ${(props) =>
+    props.$imageSrc ? props.theme.spaces.s600 : props.theme.spaces.s300};
 `;
 
 const IconSvg = styled(SVG)`
@@ -104,7 +106,7 @@ const IconSvg = styled(SVG)`
 const IconName = styled.div`
   padding: ${(props) => props.theme.spaces.s050};
   font-size: ${(props) => props.theme.fontSizeBase};
-  line-height: ${(props) => props.theme.lineHeightSm};
+  line-height: ${(props) => props.theme.lineHeightBase};
   font-weight: ${(props) => props.theme.fontWeightBold};
 `;
 


### PR DESCRIPTION
Fix width clipping some badges
Also fix descending letters clipping

From this:
![image](https://github.com/user-attachments/assets/e0554670-7717-4a36-a1f1-981fd071ebce)


To this (localhost so no icons showing) :
![image](https://github.com/user-attachments/assets/ec4f640e-a321-4bd5-bc65-4206bf1df7fe)
