### PR TITLE
Highlight active plan version

### DIFF
--- a/components/versioning/PlanVersionSelector.tsx
+++ b/components/versioning/PlanVersionSelector.tsx
@@ -23,15 +23,15 @@ const VersionSelect = styled.div`
   }
 `;
 
-const VersionDropdownItem = styled.a`
+const VersionDropdownItem = styled.a<{ active?: boolean }>`
   display: block;
   padding: 0.25rem 0.75rem 0.25rem 0.25rem;
   margin: 0 0.5rem 0.5rem;
   border: 1px solid ${(props) => props.theme.themeColors.light};
   border-radius: 0.5rem;
   text-decoration: none !important;
-  /*font-weight: ${(props) =>
-    props.latest === true ? props.theme.fontWeightBold : 'inherit'};*/
+  font-weight: ${(props) =>
+    props.active ? props.theme.fontWeightBold : 'inherit'};
   /*background: ${(props) =>
     props.active === true ? props.theme.themeColors.light : 'none'};*/
 
@@ -155,6 +155,7 @@ const PlanVersionSelector = (props) => {
               href={v.viewUrl}
               key={v.identifier}
               latest={v.identifier === latestVersion.identifier}
+              active={v.active}
             >
               <VersionDate>{v.versionName}</VersionDate>
             </VersionDropdownItem>


### PR DESCRIPTION
Improvement: Highlight the currently active plan version in the PlanSelector dropdown.
Asana - https://app.asana.com/0/1206017643443542/1209507933492392

<img width="1406" alt="Screenshot 2025-03-04 at 12 20 36" src="https://github.com/user-attachments/assets/9c2f1d34-74e5-4a18-bf5c-7cc2a8aa2ed4" />
