### PR TITLE
Hide identifier in action highlight card

### DIFF
--- a/components/actions/ActionHighlightCard.tsx
+++ b/components/actions/ActionHighlightCard.tsx
@@ -144,11 +144,12 @@ function ActionHighlightCard(props: ActionHighlightCardProps) {
           <ImgArea $bgcolor={statusColor}>
             {imageUrl && <ImgBg $background={imageUrl} />}
             <ImgOverlay>
-              {!hideIdentifier && (
-                <ActionNumber>
-                  <span>{action.identifier}</span>
-                </ActionNumber>
-              )}
+              {!hideIdentifier &&
+                !theme.settings.hideActionHighlightIdentifier && (
+                  <ActionNumber>
+                    <span>{action.identifier}</span>
+                  </ActionNumber>
+                )}
             </ImgOverlay>
           </ImgArea>
           {statusText && (


### PR DESCRIPTION
A customer request: Hide the action identifier in the ActionHighlight card.
Asana - https://app.asana.com/0/1206017643443542/1209168011618229

Added theme variable `hideActionHighlightIdentifier` to conditionally hide id.