### PR TITLE
Filter actions included in Excel exports

### DIFF
--- a/components/dashboard/ActionStatusExport.js
+++ b/components/dashboard/ActionStatusExport.js
@@ -11,8 +11,9 @@ export default function ActionStatusExport({ actions }) {
   const t = useTranslations();
   const plan = usePlan();
   const url = plan.actionReportExportViewUrl;
-  const csvExportUrl = `${url}?format=csv`;
-  const excelExportUrl = `${url}?format=xlsx`;
+  const actionIds = actions.map(({ id }) => id).join(',');
+  const csvExportUrl = `${url}?actions=${actionIds}&format=csv`;
+  const excelExportUrl = `${url}?actions=${actionIds}&format=xlsx`;
   return (
     <UncontrolledDropdown>
       <DropdownToggle caret>{t('export')}</DropdownToggle>


### PR DESCRIPTION
Implements a [feature request](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1209631179643361?focus=true) to filter the actions included in Excel exports.

It requires a [corresponding backend PR](https://github.com/kausaltech/kausal-watch-private/pull/351) to be effective, but deploying this before the backend PR is merged should be fine.