### PR TITLE
Feat/primary responsible party filter

### DIFF
--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -668,11 +668,13 @@ class PrimaryResponsiblePartyFilter extends DefaultFilter<string | undefined> {
             checked={value ? true : false}
             onChange={(e) => onChange(this.id, e.target.checked)}
           />
-          <label htmlFor={this.id}>{this.getLabel(t)}</label>
-          <PopoverTip
-            identifier="primary-responsible-party-tooltip"
-            content={this.getHelpText(t)}
-          />
+          <label htmlFor={this.id}>
+            {this.getLabel(t)}
+            <PopoverTip
+              identifier="primary-responsible-party-tooltip"
+              content={this.getHelpText(t)}
+            />
+          </label>
         </FormGroup>
       </FilterColumn>
     );

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -629,7 +629,8 @@ class ResponsiblePartyFilter extends DefaultFilter<string | undefined> {
   render(
     value: string | undefined,
     onChange: FilterChangeCallback<string | undefined>,
-    t: TFunction
+    t: TFunction,
+    primaryValue?: string | undefined
   ) {
     return (
       <>
@@ -637,6 +638,7 @@ class ResponsiblePartyFilter extends DefaultFilter<string | undefined> {
         {value ? (
           <PrimaryResponsiblePartyFilter
             responsibleParty={value}
+            value={primaryValue}
             onChange={onChange}
             t={t}
           />
@@ -660,6 +662,7 @@ class ResponsiblePartyFilter extends DefaultFilter<string | undefined> {
 
 class PrimaryResponsiblePartyFilter extends React.Component<{
   responsibleParty: string;
+  value: string | undefined;
   onChange: FilterChangeCallback<string | undefined>;
   t: TFunction;
 }> {
@@ -688,6 +691,7 @@ class PrimaryResponsiblePartyFilter extends React.Component<{
             type="switch"
             role="switch"
             id={this.id}
+            checked={this.props.value === this.props.responsibleParty}
             onChange={(e) =>
               onChange(this.id, e.target.checked ? responsibleParty : undefined)
             }
@@ -917,7 +921,8 @@ class ActionNameFilter implements ActionListFilter<string | undefined> {
   render(
     value: string | undefined,
     onChange: FilterChangeCallback<string | undefined>,
-    t: TFunction
+    t: TFunction,
+    primaryValue?: string | undefined
   ) {
     return (
       <FilterColumn m={this.sm} md={this.md} lg={this.lg} key={this.id}>
@@ -990,14 +995,24 @@ type FilterColProps = {
   filter: ActionListFilter;
   onFilterChange: (id: string, val: FilterValue, debounce: number) => void;
   state: FilterValue;
+  primaryResponsibleParty?: string | undefined;
 };
 const FilterCol = React.memo(function FilterCol({
   filter,
   onFilterChange,
   state,
+  primaryResponsibleParty,
 }: FilterColProps) {
   const t = useTranslations();
 
+  if (filter.id === 'responsible_party') {
+    return (filter as ResponsiblePartyFilter).render(
+      state,
+      onFilterChange,
+      t,
+      primaryResponsibleParty
+    );
+  }
   // eslint-disable-next-line react/prop-types
   return filter.render(state, onFilterChange, t);
 });
@@ -1108,6 +1123,9 @@ function ActionListFilters(props: ActionListFiltersProps) {
                     filter={filter}
                     onFilterChange={onFilterChange}
                     state={filterState[filter.id]}
+                    primaryResponsibleParty={
+                      filterState['primary_responsible_party']
+                    }
                   />
                 ))}
                 {section.id === 'main' && (

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -380,7 +380,7 @@ function ActionListFilterBadges({
     let label: string;
 
     if (item.id === 'primary_responsible_party') {
-      if (!value) return null;
+      if (!value || !activeFilters['responsible_party']) return null;
       label = item.getLabel(t);
     } else if (item.id === 'name') {
       if (!value || typeof value !== 'string' || value.trim() === '') {
@@ -426,6 +426,7 @@ function ActionListFilterBadges({
   });
   if (
     activeFilters['primary_responsible_party'] &&
+    activeFilters['responsible_party'] &&
     !badgesToCreate.some((b) => b.id === 'primary_responsible_party')
   ) {
     badgesToCreate.push({
@@ -1042,10 +1043,13 @@ function ActionListFilters(props: ActionListFiltersProps) {
   const onFilterChange = useCallback(
     (id: string, val: FilterValue, debounce: number = 0) => {
       setFilterState((state) => {
-        return {
-          ...state,
-          [id]: val,
-        };
+        const newState = { ...state, [id]: val };
+
+        if (id === 'responsible_party') {
+          newState['primary_responsible_party'] = undefined;
+        }
+
+        return newState;
       });
 
       if (debounce) {
@@ -1067,6 +1071,9 @@ function ActionListFilters(props: ActionListFiltersProps) {
 
   const onReset = useCallback(
     (id: string, value: SingleFilterValue) => {
+      if (id === 'responsible_party') {
+        onFilterChange('primary_responsible_party', undefined);
+      }
       onFilterChange(id, deleteFilterValues(id, value));
     },
     [onFilterChange, deleteFilterValues]

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -677,10 +677,6 @@ class PrimaryResponsiblePartyFilter extends React.Component<{
     return t('filter-primary-responsible-party');
   }
 
-  getHelpText(t: TFunction) {
-    return t('filter-primary-responsible-party-help');
-  }
-
   render() {
     if (!this.props || !this.props.responsibleParty) return null;
     const { responsibleParty, onChange, t } = this.props;
@@ -695,13 +691,7 @@ class PrimaryResponsiblePartyFilter extends React.Component<{
               onChange(this.id, e.target.checked ? responsibleParty : undefined)
             }
           />
-          <label htmlFor={this.id}>
-            {this.getLabel(t)}
-            <PopoverTip
-              identifier="primary-responsible-party-tooltip"
-              content={this.getHelpText(t)}
-            />
-          </label>
+          <label htmlFor={this.id}>{this.getLabel(t)}</label>
         </FormGroup>
       </FilterColumn>
     );

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -1163,12 +1163,14 @@ ActionListFilters.constructFilters = (opts: ConstructFiltersOpts) => {
     blocks: ActionListFilterFragment[]
   ) {
     const filters: ActionListFilter[] = [];
+    let primaryResponsiblePartyFilter: PrimaryResponsiblePartyFilter | null =
+      null;
 
     blocks.forEach((block) => {
       switch (block.__typename) {
         case 'ResponsiblePartyFilterBlock':
           filters.push(new ResponsiblePartyFilter(orgs, plan));
-          filters.push(new PrimaryResponsiblePartyFilter());
+          primaryResponsiblePartyFilter = new PrimaryResponsiblePartyFilter();
           break;
         case 'CategoryTypeFilterBlock':
           filters.push(new CategoryFilter(block, filterByCommonCategory, plan));
@@ -1283,6 +1285,9 @@ ActionListFilters.constructFilters = (opts: ConstructFiltersOpts) => {
           break;
       }
     });
+    if (primaryResponsiblePartyFilter) {
+      filters.push(primaryResponsiblePartyFilter);
+    }
 
     if (id === 'main') {
       if (plan.actionImpacts.length) {

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -653,10 +653,6 @@ class PrimaryResponsiblePartyFilter extends DefaultFilter<string | undefined> {
     return t('filter-primary-responsible-party-help');
   }
 
-  getShowAllLabel(t: TFunction) {
-    return t('filter-all-organizations');
-  }
-
   render(
     value: string | undefined,
     onChange: FilterChangeCallback<string | undefined>,
@@ -673,6 +669,10 @@ class PrimaryResponsiblePartyFilter extends DefaultFilter<string | undefined> {
             onChange={(e) => onChange(this.id, e.target.checked)}
           />
           <label htmlFor={this.id}>{this.getLabel(t)}</label>
+          <PopoverTip
+            identifier="primary-responsible-party-tooltip"
+            content={this.getHelpText(t)}
+          />
         </FormGroup>
       </FilterColumn>
     );

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -379,7 +379,10 @@ function ActionListFilterBadges({
   ): Badge | null {
     let label: string;
 
-    if (item.id === 'name') {
+    if (item.id === 'primary_responsible_party') {
+      if (!value) return null;
+      label = item.getLabel(t);
+    } else if (item.id === 'name') {
       if (!value || typeof value !== 'string' || value.trim() === '') {
         return null;
       }
@@ -421,6 +424,15 @@ function ActionListFilterBadges({
     seenFilterKeyValues.add(uniqueKey);
     return true;
   });
+  if (
+    activeFilters['primary_responsible_party'] &&
+    !badgesToCreate.some((b) => b.id === 'primary_responsible_party')
+  ) {
+    badgesToCreate.push({
+      id: 'primary_responsible_party',
+      getLabel: (t: TFunction) => t('filter-primary-responsible-party'),
+    } as ActionListFilter);
+  }
   const badges = badgesToCreate
     .map((item: ActionListFilter) => {
       const value = activeFilters[item.id];
@@ -430,6 +442,7 @@ function ActionListFilterBadges({
     })
     .flat()
     .filter((item): item is Badge => item != null);
+
   return (
     <FiltersList aria-live="assertive">
       <span className="count">

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -633,17 +633,37 @@ class ResponsiblePartyFilter extends DefaultFilter<string | undefined> {
     primaryValue?: string | undefined
   ) {
     return (
-      <>
-        {super.render(value, onChange, t)}
-        {value ? (
-          <PrimaryResponsiblePartyFilter
-            responsibleParty={value}
-            value={primaryValue}
-            onChange={onChange}
-            t={t}
-          />
-        ) : null}
-      </>
+      <FilterColumn sm={this.sm} md={this.md} lg={this.lg} key={this.id}>
+        <ActionListDropdownInput
+          isMulti={false}
+          id={this.id}
+          label={this.getLabel(t)}
+          helpText={this.getHelpText(t)}
+          showAllLabel={this.getShowAllLabel(t)}
+          currentValue={value}
+          onChange={onChange}
+          options={this.options}
+        />
+        {value && (
+          <FormGroup switch>
+            <Input
+              type="switch"
+              role="switch"
+              id="primary_responsible_party"
+              checked={primaryValue === value}
+              onChange={(e) =>
+                onChange(
+                  'primary_responsible_party',
+                  e.target.checked ? value : undefined
+                )
+              }
+            />
+            <label htmlFor="primary_responsible_party">
+              {t('filter-primary-responsible-party')}
+            </label>
+          </FormGroup>
+        )}
+      </FilterColumn>
     );
   }
   private getOrgTermContext() {

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -617,7 +617,18 @@ class ResponsiblePartyFilter extends DefaultFilter<string | undefined> {
     onChange: FilterChangeCallback<string | undefined>,
     t: TFunction
   ) {
-    return super.render(value, onChange, t);
+    return (
+      <>
+        {super.render(value, onChange, t)}
+        {value ? (
+          <PrimaryResponsiblePartyFilter
+            responsibleParty={value}
+            onChange={onChange}
+            t={t}
+          />
+        ) : null}
+      </>
+    );
   }
   private getOrgTermContext() {
     return { context: this.plan.generalContent.organizationTerm };
@@ -633,7 +644,11 @@ class ResponsiblePartyFilter extends DefaultFilter<string | undefined> {
   }
 }
 
-class PrimaryResponsiblePartyFilter extends DefaultFilter<string | undefined> {
+class PrimaryResponsiblePartyFilter extends React.Component<{
+  responsibleParty: string;
+  onChange: FilterChangeCallback<string | undefined>;
+  t: TFunction;
+}> {
   id = 'primary_responsible_party';
   useValueFilterId = 'responsible_party';
   options: ActionListFilterOption[];
@@ -653,20 +668,19 @@ class PrimaryResponsiblePartyFilter extends DefaultFilter<string | undefined> {
     return t('filter-primary-responsible-party-help');
   }
 
-  render(
-    value: string | undefined,
-    onChange: FilterChangeCallback<string | undefined>,
-    t: TFunction
-  ) {
+  render() {
+    if (!this.props || !this.props.responsibleParty) return null;
+    const { responsibleParty, onChange, t } = this.props;
     return (
-      <FilterColumn sm={this.sm} md={this.md} lg={this.lg} key={this.id}>
+      <FilterColumn>
         <FormGroup switch className="mb-4">
           <Input
             type="switch"
             role="switch"
             id={this.id}
-            checked={value ? true : false}
-            onChange={(e) => onChange(this.id, e.target.checked)}
+            onChange={(e) =>
+              onChange(this.id, e.target.checked ? responsibleParty : undefined)
+            }
           />
           <label htmlFor={this.id}>
             {this.getLabel(t)}
@@ -1030,6 +1044,7 @@ function ActionListFilters(props: ActionListFiltersProps) {
           [id]: val,
         };
       });
+
       if (debounce) {
         debouncedFilterChange(id, val);
       } else {

--- a/components/dashboard/ActionList.tsx
+++ b/components/dashboard/ActionList.tsx
@@ -510,9 +510,17 @@ const ActionList = (props: ActionListProps) => {
 
   let filteredActions = mappedActions;
   enabledFilters.forEach((filter) => {
-    filteredActions = filteredActions.filter((action) =>
-      filter.filterAction(activeFilters[filter.id], action)
-    );
+    filteredActions = filteredActions.filter((action) => {
+      if (filter.useValueFilterId) {
+        if (!activeFilters[filter.id]) return false;
+        return filter.filterAction(
+          activeFilters[filter.useValueFilterId],
+          action
+        );
+      } else {
+        return filter.filterAction(activeFilters[filter.id], action);
+      }
+    });
   });
 
   let groupBy = 'category';

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -48,7 +48,7 @@
     "filter-schedule": "Tidsplan",
     "filter-text": "Tekstsøgning",
     "filter-text-default": "Søg fra sidehoveder",
-    "filter-primary-responsible-party": "Vis handlinger fra den primære organisation",
+    "filter-primary-responsible-party": "som den primære organisation",
     "filter-primary-responsible-party-help": "Vælg organisationen først",
     "front-page": "Forside",
     "give-feedback": "Give feedback",

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -49,7 +49,6 @@
     "filter-text": "Tekstsøgning",
     "filter-text-default": "Søg fra sidehoveder",
     "filter-primary-responsible-party": "som den primære organisation",
-    "filter-primary-responsible-party-help": "Vælg organisationen først",
     "front-page": "Forside",
     "give-feedback": "Give feedback",
     "goal": "mål",

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -49,6 +49,7 @@
     "filter-text": "Tekstsøgning",
     "filter-text-default": "Søg fra sidehoveder",
     "filter-primary-responsible-party": "Vis handlinger fra den primære organisation",
+    "filter-primary-responsible-party-help": "Vælg organisationen først",
     "front-page": "Forside",
     "give-feedback": "Give feedback",
     "goal": "mål",

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -48,6 +48,7 @@
     "filter-schedule": "Tidsplan",
     "filter-text": "Tekstsøgning",
     "filter-text-default": "Søg fra sidehoveder",
+    "filter-primary-responsible-party": "Vis handlinger fra den primære organisation",
     "front-page": "Forside",
     "give-feedback": "Give feedback",
     "goal": "mål",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -48,7 +48,7 @@
     "filter-schedule": "Zeitplan",
     "filter-text": "{context, select, CASE_STUDY {Fallstudien durchsuchen} STRATEGY {Strategien durchsuchen} INDICATOR {Indikatoren durchsuchen} other {Maßnahmen durchsuchen}}",
     "filter-text-default": "Nach Schlüsselwort suchen",
-    "filter-primary-responsible-party": "Zeige Maßnahmen der primären Organisation",
+    "filter-primary-responsible-party": "als primäre Organisation",
     "front-page": "Titelseite",
     "give-feedback": "Feedback geben",
     "goal": "Ziel",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -48,6 +48,7 @@
     "filter-schedule": "Zeitplan",
     "filter-text": "{context, select, CASE_STUDY {Fallstudien durchsuchen} STRATEGY {Strategien durchsuchen} INDICATOR {Indikatoren durchsuchen} other {Maßnahmen durchsuchen}}",
     "filter-text-default": "Nach Schlüsselwort suchen",
+    "filter-primary-responsible-party": "Zeige Maßnahmen der primären Organisation",
     "front-page": "Titelseite",
     "give-feedback": "Feedback geben",
     "goal": "Ziel",

--- a/locales/el/common.json
+++ b/locales/el/common.json
@@ -39,6 +39,7 @@
     "filter-status": "Κατάσταση",
     "filter-text": "{context, select, STRATEGY {Στρατηγικές αναζήτησης} CASE_STUDY {Αναζήτηση μελετών περίπτωσης} other {Αναζήτηση ενεργειών}}",
     "filter-text-default": "Αναζήτηση με λέξη-κλειδί",
+    "filter-primary-responsible-party": "Εμφάνιση ενεργειών από τον κύριο οργανισμό",
     "front-page": "Πρώτη σελίδα",
     "give-feedback": "Δώστε ανατροφοδότηση",
     "goal": "στόχος",

--- a/locales/el/common.json
+++ b/locales/el/common.json
@@ -39,7 +39,7 @@
     "filter-status": "Κατάσταση",
     "filter-text": "{context, select, STRATEGY {Στρατηγικές αναζήτησης} CASE_STUDY {Αναζήτηση μελετών περίπτωσης} other {Αναζήτηση ενεργειών}}",
     "filter-text-default": "Αναζήτηση με λέξη-κλειδί",
-    "filter-primary-responsible-party": "Εμφάνιση ενεργειών από τον κύριο οργανισμό",
+    "filter-primary-responsible-party": "ως κύριος οργανισμός",
     "filter-primary-responsible-party-help": "Επιλέξτε πρώτα τον οργανισμό",
     "front-page": "Πρώτη σελίδα",
     "give-feedback": "Δώστε ανατροφοδότηση",

--- a/locales/el/common.json
+++ b/locales/el/common.json
@@ -40,7 +40,6 @@
     "filter-text": "{context, select, STRATEGY {Στρατηγικές αναζήτησης} CASE_STUDY {Αναζήτηση μελετών περίπτωσης} other {Αναζήτηση ενεργειών}}",
     "filter-text-default": "Αναζήτηση με λέξη-κλειδί",
     "filter-primary-responsible-party": "ως κύριος οργανισμός",
-    "filter-primary-responsible-party-help": "Επιλέξτε πρώτα τον οργανισμό",
     "front-page": "Πρώτη σελίδα",
     "give-feedback": "Δώστε ανατροφοδότηση",
     "goal": "στόχος",

--- a/locales/el/common.json
+++ b/locales/el/common.json
@@ -40,6 +40,7 @@
     "filter-text": "{context, select, STRATEGY {Στρατηγικές αναζήτησης} CASE_STUDY {Αναζήτηση μελετών περίπτωσης} other {Αναζήτηση ενεργειών}}",
     "filter-text-default": "Αναζήτηση με λέξη-κλειδί",
     "filter-primary-responsible-party": "Εμφάνιση ενεργειών από τον κύριο οργανισμό",
+    "filter-primary-responsible-party-help": "Επιλέξτε πρώτα τον οργανισμό",
     "front-page": "Πρώτη σελίδα",
     "give-feedback": "Δώστε ανατροφοδότηση",
     "goal": "στόχος",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -152,7 +152,7 @@
   "filter-phase-help": "Show actions in selected implementation phase",
   "filter-plan-help": "Show actions in selected plan",
   "filter-primary-organization-help": "{context, select, DIVISION {Show actions of selected division} other {Show actions of selected municipality}}",
-  "filter-primary-responsible-party": "Show actions by the primary organization",
+  "filter-primary-responsible-party": "as the primary organization",
   "filter-primary-responsible-party-help": "Select the organization first",
   "filter-schedule-help": "Show actions spanning across selected schedule",
   "filter-status-help": "Show actions with selected status",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -153,7 +153,6 @@
   "filter-plan-help": "Show actions in selected plan",
   "filter-primary-organization-help": "{context, select, DIVISION {Show actions of selected division} other {Show actions of selected municipality}}",
   "filter-primary-responsible-party": "as the primary organization",
-  "filter-primary-responsible-party-help": "Select the organization first",
   "filter-schedule-help": "Show actions spanning across selected schedule",
   "filter-status-help": "Show actions with selected status",
   "additional-filters": "Additional filters",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -153,6 +153,7 @@
   "filter-plan-help": "Show actions in selected plan",
   "filter-primary-organization-help": "{context, select, DIVISION {Show actions of selected division} other {Show actions of selected municipality}}",
   "filter-primary-responsible-party": "Show actions by the primary organization",
+  "filter-primary-responsible-party-help": "Select the organization first",
   "filter-schedule-help": "Show actions spanning across selected schedule",
   "filter-status-help": "Show actions with selected status",
   "additional-filters": "Additional filters",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -152,6 +152,7 @@
   "filter-phase-help": "Show actions in selected implementation phase",
   "filter-plan-help": "Show actions in selected plan",
   "filter-primary-organization-help": "{context, select, DIVISION {Show actions of selected division} other {Show actions of selected municipality}}",
+  "filter-primary-responsible-party": "Show actions by the primary organization",
   "filter-schedule-help": "Show actions spanning across selected schedule",
   "filter-status-help": "Show actions with selected status",
   "additional-filters": "Additional filters",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -48,6 +48,7 @@
     "filter-schedule": "Programar",
     "filter-text": "Búsqueda de texto",
     "filter-text-default": "Búsqueda a partir de cabeceras",
+    "filter-primary-responsible-party": "Mostrar acciones de la organización principal",
     "front-page": "Portada",
     "give-feedback": "Dar su opinión",
     "goal": "meta",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -49,7 +49,6 @@
     "filter-text": "Búsqueda de texto",
     "filter-text-default": "Búsqueda a partir de cabeceras",
     "filter-primary-responsible-party": "como la organización principal",
-    "filter-primary-responsible-party-help": "Seleccione primero la organización",
     "front-page": "Portada",
     "give-feedback": "Dar su opinión",
     "goal": "meta",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -49,6 +49,7 @@
     "filter-text": "Búsqueda de texto",
     "filter-text-default": "Búsqueda a partir de cabeceras",
     "filter-primary-responsible-party": "Mostrar acciones de la organización principal",
+    "filter-primary-responsible-party-help": "Seleccione primero la organización",
     "front-page": "Portada",
     "give-feedback": "Dar su opinión",
     "goal": "meta",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -48,7 +48,7 @@
     "filter-schedule": "Programar",
     "filter-text": "Búsqueda de texto",
     "filter-text-default": "Búsqueda a partir de cabeceras",
-    "filter-primary-responsible-party": "Mostrar acciones de la organización principal",
+    "filter-primary-responsible-party": "como la organización principal",
     "filter-primary-responsible-party-help": "Seleccione primero la organización",
     "front-page": "Portada",
     "give-feedback": "Dar su opinión",

--- a/locales/fi/common.json
+++ b/locales/fi/common.json
@@ -49,6 +49,7 @@
     "filter-text": "Tekstihaku",
     "filter-text-default": "Etsi otsikoista",
     "filter-primary-responsible-party": "Näytä vain toimenpiteet, joissa valittu organisaatio on päävastuutahona",
+    "filter-primary-responsible-party-help": "Valitse ensin vastuuorganisaatio",
     "front-page": "Etusivu",
     "give-feedback": "Anna palautetta",
     "goal": "tavoite",

--- a/locales/fi/common.json
+++ b/locales/fi/common.json
@@ -48,6 +48,7 @@
     "filter-schedule": "Aikataulu",
     "filter-text": "Tekstihaku",
     "filter-text-default": "Etsi otsikoista",
+    "filter-primary-responsible-party": "Näytä vain toimenpiteet, joissa valittu organisaatio on päävastuutahona",
     "front-page": "Etusivu",
     "give-feedback": "Anna palautetta",
     "goal": "tavoite",

--- a/locales/fi/common.json
+++ b/locales/fi/common.json
@@ -48,7 +48,7 @@
     "filter-schedule": "Aikataulu",
     "filter-text": "Tekstihaku",
     "filter-text-default": "Etsi otsikoista",
-    "filter-primary-responsible-party": "Näytä vain toimenpiteet, joissa valittu organisaatio on päävastuutahona",
+    "filter-primary-responsible-party": "päävastuuorganisaationa",
     "filter-primary-responsible-party-help": "Valitse ensin vastuuorganisaatio",
     "front-page": "Etusivu",
     "give-feedback": "Anna palautetta",

--- a/locales/fi/common.json
+++ b/locales/fi/common.json
@@ -49,7 +49,6 @@
     "filter-text": "Tekstihaku",
     "filter-text-default": "Etsi otsikoista",
     "filter-primary-responsible-party": "päävastuuorganisaationa",
-    "filter-primary-responsible-party-help": "Valitse ensin vastuuorganisaatio",
     "front-page": "Etusivu",
     "give-feedback": "Anna palautetta",
     "goal": "tavoite",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -26,6 +26,7 @@
     "filter-primary-organization-help": "{context, select, DIVISION {Parādīt atlasītās nodaļas rīcības} other {Parādīt izvēlētās pašvaldības rīcības}}",
     "filter-schedule-help": "Rādīt rīcības, kas aptver visu atlasīto grafiku",
     "filter-status-help": "Rādīt rīcības ar atlasīto statusu",
+    "filter-primary-responsible-party": "Rādīt darbības pēc primārās organizācijas",
     "navigation-home": "Sākums",
     "graph-hideTable": "Paslēpt tabulu",
     "definition": "Definīcija",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -27,7 +27,6 @@
     "filter-schedule-help": "Rādīt rīcības, kas aptver visu atlasīto grafiku",
     "filter-status-help": "Rādīt rīcības ar atlasīto statusu",
     "filter-primary-responsible-party": "kā primārā organizācija",
-    "filter-primary-responsible-party-help": "Vispirms izvēlieties organizāciju",
     "navigation-home": "Sākums",
     "graph-hideTable": "Paslēpt tabulu",
     "definition": "Definīcija",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -26,7 +26,7 @@
     "filter-primary-organization-help": "{context, select, DIVISION {Parādīt atlasītās nodaļas rīcības} other {Parādīt izvēlētās pašvaldības rīcības}}",
     "filter-schedule-help": "Rādīt rīcības, kas aptver visu atlasīto grafiku",
     "filter-status-help": "Rādīt rīcības ar atlasīto statusu",
-    "filter-primary-responsible-party": "Rādīt darbības pēc primārās organizācijas",
+    "filter-primary-responsible-party": "kā primārā organizācija",
     "filter-primary-responsible-party-help": "Vispirms izvēlieties organizāciju",
     "navigation-home": "Sākums",
     "graph-hideTable": "Paslēpt tabulu",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -27,6 +27,7 @@
     "filter-schedule-help": "Rādīt rīcības, kas aptver visu atlasīto grafiku",
     "filter-status-help": "Rādīt rīcības ar atlasīto statusu",
     "filter-primary-responsible-party": "Rādīt darbības pēc primārās organizācijas",
+    "filter-primary-responsible-party-help": "Vispirms izvēlieties organizāciju",
     "navigation-home": "Sākums",
     "graph-hideTable": "Paslēpt tabulu",
     "definition": "Definīcija",

--- a/locales/sv/common.json
+++ b/locales/sv/common.json
@@ -45,7 +45,6 @@
     "filter-text": "{context, select, STRATEGY {Sökstrategier} CASE_STUDY {Sök efter fallstudier} INDICATOR {Sök indicatorer} other {Sök åtgärder}}",
     "filter-text-default": "Sök efter nyckelord",
     "filter-primary-responsible-party": "som den primära organisationen",
-    "filter-primary-responsible-party-help": "Välj organisationen först",
     "front-page": "Framsida",
     "give-feedback": "Ge respons",
     "goal": "mål",

--- a/locales/sv/common.json
+++ b/locales/sv/common.json
@@ -45,6 +45,7 @@
     "filter-text": "{context, select, STRATEGY {Sökstrategier} CASE_STUDY {Sök efter fallstudier} INDICATOR {Sök indicatorer} other {Sök åtgärder}}",
     "filter-text-default": "Sök efter nyckelord",
     "filter-primary-responsible-party": "Visa åtgärder av den primära organisationen",
+    "filter-primary-responsible-party-help": "Välj organisationen först",
     "front-page": "Framsida",
     "give-feedback": "Ge respons",
     "goal": "mål",

--- a/locales/sv/common.json
+++ b/locales/sv/common.json
@@ -44,6 +44,7 @@
     "filter-schedule": "Tidsram",
     "filter-text": "{context, select, STRATEGY {Sökstrategier} CASE_STUDY {Sök efter fallstudier} INDICATOR {Sök indicatorer} other {Sök åtgärder}}",
     "filter-text-default": "Sök efter nyckelord",
+    "filter-primary-responsible-party": "Visa åtgärder av den primära organisationen",
     "front-page": "Framsida",
     "give-feedback": "Ge respons",
     "goal": "mål",

--- a/locales/sv/common.json
+++ b/locales/sv/common.json
@@ -44,7 +44,7 @@
     "filter-schedule": "Tidsram",
     "filter-text": "{context, select, STRATEGY {Sökstrategier} CASE_STUDY {Sök efter fallstudier} INDICATOR {Sök indicatorer} other {Sök åtgärder}}",
     "filter-text-default": "Sök efter nyckelord",
-    "filter-primary-responsible-party": "Visa åtgärder av den primära organisationen",
+    "filter-primary-responsible-party": "som den primära organisationen",
     "filter-primary-responsible-party-help": "Välj organisationen först",
     "front-page": "Framsida",
     "give-feedback": "Ge respons",


### PR DESCRIPTION
Add an option to filter actions by only the primary responsible party/organization on the `ActionListView` page. 
Asana - https://app.asana.com/0/1206017643443542/1208880507599785/f

* Implemented a toggle to filter actions by the selected organization with the primary role only.
* Made toggle appear only if organization selected.



https://github.com/user-attachments/assets/6d7a613d-63ff-405a-9ace-c29e19ed5e9b





