### PR TITLE
Fix/include primary org in org filter

### DIFF
--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -694,8 +694,11 @@ class PrimaryResponsiblePartyFilter extends React.Component<{
 
   filterAction(value: string | undefined, action: ActionListAction) {
     if (!value) return true;
-    return action.responsibleParties.some(
-      (rp) => rp.role === 'PRIMARY' && rp.organization.id === value
+    return (
+      action.primaryOrg?.id === value ||
+      action.responsibleParties.some(
+        (rp) => rp.role === 'PRIMARY' && rp.organization.id === value
+      )
     );
   }
 

--- a/components/actions/ActionListFilters.tsx
+++ b/components/actions/ActionListFilters.tsx
@@ -616,9 +616,10 @@ class ResponsiblePartyFilter extends DefaultFilter<string | undefined> {
     }));
   }
   filterAction(value: string | undefined, action: ActionListAction) {
+    if (!value) return true;
+    if (action.primaryOrg?.id === value) return true;
     return action.responsibleParties.some((rp) => {
-      // @ts-ignore
-      let org: ActionListOrganization = rp.organization;
+      let org = rp.organization as ActionListOrganization;
       while (org) {
         if (org.id === value) return true;
         org = org.parent;
@@ -626,6 +627,7 @@ class ResponsiblePartyFilter extends DefaultFilter<string | undefined> {
       return false;
     });
   }
+
   render(
     value: string | undefined,
     onChange: FilterChangeCallback<string | undefined>,


### PR DESCRIPTION
Asana - https://app.asana.com/0/1206017643443542/1209736943397911/f

Bug: filtering actions by organization did not include actions with the selected organization set only as the primary organization in the action's basic info.

* Updated the organization filter and toggle logic to include the primary organization (even if it's not assigned as a responsible party).