### PR TITLE
Fix duplicated category tags on indicator page

### DIFF
--- a/components/indicators/IndicatorContent.tsx
+++ b/components/indicators/IndicatorContent.tsx
@@ -68,6 +68,9 @@ function IndicatorDetails({ indicator }: Props) {
       });
   });
 
+  const uniqueTypes = Array.from(
+    new Map(indicator.categories.map((c) => [c.type.id, c.type])).values()
+  );
   return (
     <div className="mb-5">
       <IndicatorHero
@@ -83,7 +86,7 @@ function IndicatorDetails({ indicator }: Props) {
           <Col md="5" lg="4" className="mb-5">
             <CategoryTags
               categories={indicator.categories}
-              types={indicator.categories.map((c) => c.type)}
+              types={uniqueTypes}
               noLink={true}
             />
           </Col>


### PR DESCRIPTION
A bug: Category tags are double-counted on Indicator Details Page - https://lappeenranta.test.kausal.tech/lumo/indicators/3894
Asana https://app.asana.com/0/1206017643443542/1209302839473157
The problem is caused by the types array containing duplicate types.

* Added `uniqueTypes` to remove duplicates so only unique types (based on their id) are passed to the CategoryTags.