### PR TITLE
Fix problem with _next/static.* file requests ending up in app code

### DIFF
--- a/app/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/page.tsx
+++ b/app/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/page.tsx
@@ -9,9 +9,10 @@ import { getContentPage } from '@/queries/get-content-page';
 import { Content } from './ContentPage';
 import { getMetaDescription, getMetaImage } from '@/utils/metadata';
 import { tryRequest } from '@/utils/api.utils';
+import { shouldIgnoreRequest } from '@/utils/middleware.utils';
 
 type Props = {
-  params: { slug: string[]; plan: string };
+  params: { slug: string[]; plan: string; domain: string };
 };
 
 const getPath = (slug: string[]) =>
@@ -23,6 +24,9 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const { slug, plan } = params;
   const path = getPath(slug);
+  if (shouldIgnoreRequest(params)) {
+    return {};
+  }
 
   const { data } = await tryRequest<GetContentPageQuery>(
     getContentPage(plan, path)
@@ -47,6 +51,9 @@ export async function generateMetadata(
 }
 
 export default async function ContentPage({ params }: Props) {
+  if (shouldIgnoreRequest(params)) {
+    return {};
+  }
   const { slug, plan } = params;
   const path = getPath(slug);
 

--- a/app/[domain]/[lang]/[plan]/(with-layout-elements)/page.tsx
+++ b/app/[domain]/[lang]/[plan]/(with-layout-elements)/page.tsx
@@ -2,12 +2,17 @@ import { getHomePage } from '@/queries/get-home-page';
 import { ErrorPage } from '@/components/common/ErrorPage';
 import { RootPage } from './RootPage';
 import { tryRequest } from '@/utils/api.utils';
+import { shouldIgnoreRequest } from '@/utils/middleware.utils';
 
 type Props = {
-  params: { plan: string; lang: string };
+  params: { plan: string; lang: string; domain: string };
 };
 
 export default async function PlanPage({ params }: Props) {
+  if (shouldIgnoreRequest(params)) {
+    return {};
+  }
+
   const { data, error } = await tryRequest(getHomePage(params.plan));
 
   if (error || !data) {

--- a/app/[domain]/[lang]/[plan]/layout.tsx
+++ b/app/[domain]/[lang]/[plan]/layout.tsx
@@ -13,6 +13,7 @@ import { SharedIcons } from '@/components/common/Icon';
 import { MatomoAnalytics } from '@/components/MatomoAnalytics';
 import { getMetaTitles } from '@/utils/metadata';
 import { tryRequest } from '@/utils/api.utils';
+import { shouldIgnoreRequest } from '@/utils/middleware.utils';
 import { UpdateApolloContext } from './UpdateApolloContext';
 import { SELECTED_WORKFLOW_COOKIE_KEY } from '@/constants/workflow';
 import { WorkflowProvider } from '@/context/workflow-selector';
@@ -29,6 +30,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const origin = `${protocol}://${params.domain}`;
   const url = new URL(urlHeader || origin);
 
+  if (shouldIgnoreRequest(params)) {
+    return {};
+  }
+
   if (!urlHeader) {
     captureException(
       new Error(
@@ -36,6 +41,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       )
     );
   }
+
   const { data } = await tryRequest(
     getPlan(params.domain, params.plan, origin)
   );
@@ -95,6 +101,11 @@ export default async function PlanLayout({ params, children }: Props) {
   const headersList = headers();
   const cookieStore = cookies();
   const protocol = headersList.get('x-forwarded-proto');
+
+  if (shouldIgnoreRequest(params)) {
+    return {};
+  }
+
   const { data } = await tryRequest(
     getPlan(domain, plan, `${protocol}://${domain}`)
   );

--- a/utils/apollo.utils.ts
+++ b/utils/apollo.utils.ts
@@ -43,6 +43,9 @@ function logError(
       variables: JSON.stringify(operation.variables, null, 2),
       ...sentryExtras,
     },
+    tags: {
+      hostname: operation?.variables?.hostname,
+    },
   });
 }
 

--- a/utils/middleware.utils.ts
+++ b/utils/middleware.utils.ts
@@ -234,3 +234,24 @@ export function rewriteUrl(
 
   return response;
 }
+
+export const HOSTNAMES_TO_IGNORE = /^(api|_next|static)$/;
+
+/**
+ * Checks if the domain parameter matches hostnames that should be ignored
+ *
+ * Can be used in page and layout components to avoid processing invalid requests
+ * (Due to the internal nextjs implementation, 404 results for
+ *  missing files served at _next/static and similar end up in application
+ *  pages and layouts.)
+ *
+ * @param params Route parameters from Next.js
+ * @returns boolean indicating if the request should be ignored
+ *
+ * TODO: remove all uses of this function
+ * after having moved to serve the static files outside nextjs
+ * and after ensuring old asset files are kept for robustness
+ */
+export function shouldIgnoreRequest(params: { domain?: string }): boolean {
+  return !!params.domain?.match(HOSTNAMES_TO_IGNORE);
+}


### PR DESCRIPTION
The way nextjs routing works is that it checks if a static file exists in the filesystem and if it does not, it will move on to routing through the application. This results in missing static files causing errors in app code.

Fix this problem by marking the static file requests specially in the middleware and exiting early from app code if the request is thus marked. We need to modify both the app layout and the middleware, because inside the middleware we do not yet know if the static request will be succesful. Only unsuccesful requests end up in the app code.