### PR TITLE
Fix root global error

### DIFF
--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -4,9 +4,17 @@ import { captureException } from '@sentry/nextjs';
 import { useEffect } from 'react';
 
 import defaultTheme from '@/public/static/themes/default/theme.json';
-import { ErrorPage } from '@/components/common/ErrorPage';
+import { CardBody, Container, Row, Col } from 'reactstrap';
 import ThemeProvider from '@/components/providers/ThemeProvider';
 import { Theme } from '@kausal/themes/types';
+import {
+  ErrorBackground,
+  errorIcon,
+  StyledCard,
+  StyledTitle,
+} from '@/components/common/ErrorPage';
+import { StyledComponentsRegistry } from '@/styles/StyledComponentsRegistry';
+
 type Props = {
   error: Error & { digest?: string };
 };
@@ -20,7 +28,31 @@ export default function GlobalError({ error }: Props) {
     <html>
       <body>
         <ThemeProvider theme={defaultTheme as Theme}>
-          <ErrorPage />
+          <StyledComponentsRegistry>
+            <ErrorBackground isFullPage>
+              <Container>
+                <Row>
+                  <Col md={{ size: 6, offset: 3 }}>
+                    <StyledCard>
+                      <CardBody>
+                        {errorIcon}
+
+                        <StyledTitle as={'h1'}>
+                          Something went wrong
+                        </StyledTitle>
+
+                        <StyledTitle as={'h4'}>
+                          We're sorry — an unexpected error occurred on our end.
+                          The issue has been reported and our team will
+                          investigate it.
+                        </StyledTitle>
+                      </CardBody>
+                    </StyledCard>
+                  </Col>
+                </Row>
+              </Container>
+            </ErrorBackground>
+          </StyledComponentsRegistry>
         </ThemeProvider>
       </body>
     </html>

--- a/components/common/ErrorPage.tsx
+++ b/components/common/ErrorPage.tsx
@@ -8,13 +8,13 @@ import { Card, CardBody, Container, Row, Col } from 'reactstrap';
 import Button from '@/components/common/Button';
 import Link from 'next/link';
 
-const ErrorBackground = styled.div<{ isFullPage?: boolean }>`
+export const ErrorBackground = styled.div<{ isFullPage?: boolean }>`
   background-color: ${(props) => props.theme.brandDark};
   min-height: ${({ isFullPage }) => (isFullPage ? '800px' : undefined)};
   padding: 5rem 0;
 `;
 
-const StyledCard = styled(Card)`
+export const StyledCard = styled(Card)`
   text-align: center;
   width: 100%;
   transition: all 0.5s ease;
@@ -30,11 +30,11 @@ const StyledCard = styled(Card)`
   }
 `;
 
-const StyledTitle = styled.h1`
+export const StyledTitle = styled.h1`
   margin-bottom: 1rem;
 `;
 
-const StyledSubtitle = styled.h4`
+export const StyledSubtitle = styled.h4`
   font-weight: ${({ theme }) => theme.fontWeightBase};
   color: ${({ theme }) => theme.textColor.secondary};
 `;
@@ -44,17 +44,17 @@ type Props = {
   type?: 'page' | 'block';
 };
 
+export const errorIcon = (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" x="0px" y="0px">
+    <title>emoticon, emoji, face, sick frowning</title>
+    <g data-name="Layer 25">
+      <path d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28ZM8.61,14.72,11.2,13,8.61,11.28,9.72,9.61,14.8,13,9.72,16.39Zm14.78-3.44L20.8,13l2.59,1.72-1.11,1.67L17.2,13l5.08-3.39ZM21.62,22.22l.79.62-1.25,1.57-.78-.63c-3-2.39-5.77-2.39-8.76,0l-.78.63L9.59,22.84l.79-.62C14.05,19.27,18,19.27,21.62,22.22Z"></path>
+    </g>
+  </svg>
+);
+
 export function ErrorPage({ message, type = 'page' }: Props) {
   const t = useTranslations();
-
-  const errorIcon = (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" x="0px" y="0px">
-      <title>emoticon, emoji, face, sick frowning</title>
-      <g data-name="Layer 25">
-        <path d="M16,2A14,14,0,1,0,30,16,14,14,0,0,0,16,2Zm0,26A12,12,0,1,1,28,16,12,12,0,0,1,16,28ZM8.61,14.72,11.2,13,8.61,11.28,9.72,9.61,14.8,13,9.72,16.39Zm14.78-3.44L20.8,13l2.59,1.72-1.11,1.67L17.2,13l5.08-3.39ZM21.62,22.22l.79.62-1.25,1.57-.78-.63c-3-2.39-5.77-2.39-8.76,0l-.78.63L9.59,22.84l.79-.62C14.05,19.27,18,19.27,21.62,22.22Z"></path>
-      </g>
-    </svg>
-  );
 
   return (
     <ErrorBackground isFullPage={type === 'page'}>


### PR DESCRIPTION
### The problem

We can't use translations in the root global error as the translations provider exists in the layout component and `global-error` is designed to wrap and catch layout errors. NextIntl's `useMessages` also doesn't work in `global-error.tsx`. This caused an uncaught error to be thrown in `global-error.tsx` (how meta), as the `ErrorPage` component uses `useTranslations.`.

### The solution

Avoid rendering `ErrorPage` and just render the necessary content directly in `global-error.tsx`. Note that all global errors will now be in English, however 99.99% of errors will be caught further down the tree by `error.tsx` boundaries.