### PR TITLE
Handle svg category icons consistently

### DIFF
--- a/components/actions/ActionCard.tsx
+++ b/components/actions/ActionCard.tsx
@@ -44,24 +44,32 @@ const PrimarySvgIcon = styled(SVG)`
   right: ${(props) => props.theme.spaces.s050};
   top: ${(props) => props.theme.spaces.s050};
   width: ${(props) => props.theme.spaces.s300};
-  fill: white;
+  fill: white !important;
+  path,
+  stroke {
+    fill: white !important;
+  }
 `;
 
-const PrimaryImageIcon = styled.div`
+const PrimaryImageIcon = styled.div<{ $imagesrc: string }>`
   position: absolute;
   right: ${(props) => props.theme.spaces.s050};
   top: ${(props) => props.theme.spaces.s050};
   width: ${(props) => props.theme.spaces.s300};
   height: ${(props) => props.theme.spaces.s300};
-  background-image: url(${(props) => props.imagesrc || 'none'});
+  background-image: url(${(props) => props.$imagesrc || 'none'});
   background-size: cover;
   background-position: center center;
 `;
 
-const SecondaryIcon = styled(SVG)`
+const SecondaryIcon = styled(SVG)<{ $color: string }>`
   width: ${(props) => props.theme.spaces.s100};
   margin-right: ${(props) => props.theme.spaces.s050};
-  fill: ${(props) => props.color};
+  fill: ${(props) => props.$color};
+  path,
+  stroke {
+    fill: ${(props) => props.$color};
+  }
 `;
 
 const SecondaryIconsContainer = styled.div`
@@ -69,8 +77,7 @@ const SecondaryIconsContainer = styled.div`
   justify-content: flex-end;
   margin-top: auto;
   text-align: right;
-  padding: 0 ${(props) => props.theme.spaces.s050}
-    ${(props) => props.theme.spaces.s050};
+  padding: 0 ${({ theme }) => `${theme.spaces.s050} ${theme.spaces.s050}`};
 `;
 
 const ActionCardElement = styled.div<{
@@ -185,8 +192,8 @@ const ActionOrgAvatar = styled.div`
 
 const ActionOrgName = styled.div`
   font-size: ${(props) => props.theme.fontSizeSm};
-  font-family: ${(props) =>
-    `${props.theme.fontFamilyTiny}, ${props.theme.fontFamilyFallback}`}
+  font-family: ${({ theme }) =>
+    `${theme.fontFamilyTiny}, ${theme.fontFamilyFallback}`};
   color: ${(props) => props.theme.themeColors.dark};
   line-height: 1;
 `;
@@ -224,7 +231,7 @@ const PrimaryIcon = (props) => {
   if (!category) return null;
   if (category.iconSvgUrl) return <PrimarySvgIcon src={category.iconSvgUrl} />;
   if (category.iconImage?.rendition)
-    return <PrimaryImageIcon imagesrc={category.iconImage.rendition.src} />;
+    return <PrimaryImageIcon $imagesrc={category.iconImage.rendition.src} />;
   else return null;
 };
 
@@ -241,11 +248,11 @@ const SecondaryIcons = (props) => {
     <SecondaryIconsContainer>
       {secondaryIcons.map((cat) => (
         <SecondaryIcon
-          color={cat.color ? cat.color : 'black'}
+          $color={cat.color ? cat.color : 'black'}
           key={cat.id}
           src={cat.iconSvgUrl}
           preserveAspectRatio="xMinYMid meet"
-          alt={cat.name}
+          title={cat.name}
         />
       ))}
     </SecondaryIconsContainer>

--- a/components/common/BadgeTooltip.tsx
+++ b/components/common/BadgeTooltip.tsx
@@ -97,16 +97,21 @@ const IconImage = styled.div<{ $imageSrc?: string }>`
     props.$imageSrc ? props.theme.spaces.s600 : props.theme.spaces.s300};
 `;
 
-const IconSvg = styled(SVG)`
+const IconSvg = styled(SVG)<{ $color?: string }>`
   height: ${(props) => props.theme.spaces.s200};
   margin: ${(props) => props.theme.spaces.s050};
-  fill: ${(props) => props.theme.brandDark};
+  fill: ${(props) => props.$color || props.theme.brandDark} !important;
+  path,
+  stroke {
+    fill: ${(props) => props.$color || props.theme.brandDark} !important;
+  }
 `;
 
 const IconName = styled.div`
-  padding: ${(props) => props.theme.spaces.s050};
+  padding: ${({ theme }) =>
+    `${theme.spaces.s050} ${theme.spaces.s100} ${theme.spaces.s050} ${theme.spaces.s050}`};
   font-size: ${(props) => props.theme.fontSizeBase};
-  line-height: ${(props) => props.theme.lineHeightBase};
+  line-height: ${(props) => props.theme.lineHeightMd};
   font-weight: ${(props) => props.theme.fontWeightBold};
 `;
 

--- a/components/contentblocks/CategoryPageHeaderBlock.tsx
+++ b/components/contentblocks/CategoryPageHeaderBlock.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import SVG from 'react-inlinesvg';
 
 import {
   CategoryPageMainTopBlock,
@@ -183,6 +184,16 @@ const CategoryIconImage = styled.img<{ size?: IconSize }>`
   margin-bottom: ${(props) => props.theme.spaces.s100};
 `;
 
+const CategoryIconSvg = styled(SVG)<{ size?: IconSize; $color?: string }>`
+  max-height: ${({ theme, size }) => getIconHeight(size, theme)};
+  margin-bottom: ${(props) => props.theme.spaces.s100};
+  fill: ${(props) => props.$color || props.theme.brandDark} !important;
+  path,
+  stroke {
+    fill: ${(props) => props.$color || props.theme.brandDark} !important;
+  }
+`;
+
 const CategoryLevelName = styled.div`
   color: ${(props) => props.theme.textColor.tertiary};
   margin-bottom: ${(props) => props.theme.spaces.s100};
@@ -293,6 +304,7 @@ function CategoryPageHeaderBlock(props: Props) {
   const theme = useTheme();
   const t = useTranslations();
 
+  console.log('props', props);
   const showIdentifiers =
     !plan.primaryActionClassification?.hideCategoryIdentifiers;
 
@@ -344,13 +356,21 @@ function CategoryPageHeaderBlock(props: Props) {
                 />
               )}
 
-              {iconImage && (
-                <CategoryIconImage
-                  size={(page?.layout?.iconSize as IconSize) ?? undefined}
-                  src={iconImage}
-                  alt=""
-                />
-              )}
+              {iconImage &&
+                (iconImage.toLowerCase().includes('.svg') ? (
+                  <CategoryIconSvg
+                    size={(page?.layout?.iconSize as IconSize) ?? undefined}
+                    src={iconImage}
+                    title=""
+                    $color={color}
+                  />
+                ) : (
+                  <CategoryIconImage
+                    size={(page?.layout?.iconSize as IconSize) ?? undefined}
+                    src={iconImage}
+                    alt=""
+                  />
+                ))}
               <h1>
                 {identifier && <Identifier>{identifier}.</Identifier>} {title}
               </h1>

--- a/components/contentblocks/CategoryPageHeaderBlock.tsx
+++ b/components/contentblocks/CategoryPageHeaderBlock.tsx
@@ -304,7 +304,6 @@ function CategoryPageHeaderBlock(props: Props) {
   const theme = useTheme();
   const t = useTranslations();
 
-  console.log('props', props);
   const showIdentifiers =
     !plan.primaryActionClassification?.hideCategoryIdentifiers;
 
@@ -331,6 +330,7 @@ function CategoryPageHeaderBlock(props: Props) {
   const showLevel =
     level && !theme.settings.categories.categoryPageHideCategoryLabel;
 
+  console.log('props', props);
   return (
     <CategoryHeader $bg={color} $hasImage={!!headerImage}>
       <CategoryHeaderImage
@@ -357,7 +357,7 @@ function CategoryPageHeaderBlock(props: Props) {
               )}
 
               {iconImage &&
-                (iconImage.toLowerCase().includes('.svg') ? (
+                (iconImage.toLowerCase().split('?')[0].endsWith('.svg') ? (
                   <CategoryIconSvg
                     size={(page?.layout?.iconSize as IconSize) ?? undefined}
                     src={iconImage}


### PR DESCRIPTION
If category icon is svg always render it smaller and apply catogory color or brandDark

Before actionCard
<img width="384" alt="Screenshot 2025-05-06 at 14 51 28" src="https://github.com/user-attachments/assets/e4889e8d-9a53-4f2f-912e-7cc8ca09e421" />
After actionCard
<img width="379" alt="Screenshot 2025-05-06 at 14 51 42" src="https://github.com/user-attachments/assets/c6344a2b-25bc-4b7b-9062-e5b2332e5c74" />


Before categoryBadge
<img width="350" alt="Screenshot 2025-05-06 at 14 53 34" src="https://github.com/user-attachments/assets/5517df87-d09a-4eda-a2dd-6d3f0fc53960" />

After categoryBadge (also fixed some padding)
<img width="354" alt="Screenshot 2025-05-06 at 14 53 49" src="https://github.com/user-attachments/assets/a65d7a15-6bf0-44d2-b070-af83a0121294" />


before categoryPage
<img width="811" alt="Screenshot 2025-05-06 at 14 55 11" src="https://github.com/user-attachments/assets/5c7543ea-2a3e-457a-9879-7dec60573433" />

after categoryPage
<img width="807" alt="Screenshot 2025-05-06 at 14 55 22" src="https://github.com/user-attachments/assets/8ad3e0d2-1e20-4dda-94d3-ed64e4ce1854" />

SVG should be formatted as typical svg icon (so no outlines, just fills)


If the admin wants to use colourful icons, png format should be used. Png does render also larger in badges to accomodate SDG categories.
![Screenshot 2025-04-30 at 15 10 59](https://github.com/user-attachments/assets/b1de8b42-7b71-4d74-b15b-99d445776945)

