### PR TITLE
Fix years mismatch due to timezone difference

### DIFF
--- a/common/dayjs.ts
+++ b/common/dayjs.ts
@@ -15,10 +15,12 @@ import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { ReactNode } from 'react';
+import utc from 'dayjs/plugin/utc';
 
 dayjs.extend(isSameOrAfter);
 dayjs.extend(localizedFormat);
 dayjs.extend(relativeTime);
+dayjs.extend(utc);
 
 export function DayjsLocaleProvider({
   locale,

--- a/components/graphs/GraphAsTable.js
+++ b/components/graphs/GraphAsTable.js
@@ -98,22 +98,16 @@ function GraphAsTable(props) {
   const tableData = [];
   tableRows.map((row, i) => {
     const rowObj = {};
-    rowObj.label =
-      data[0].xType === 'time'
-        ? format.dateTime(new Date(row), dateFormat)
-        : row;
+    rowObj.raw = row;
+    rowObj.label = dayjs.utc(row).format('YYYY');
     rowObj.values = [];
     data.map((trace, i) => {
-      const indexOfX = trace.x.indexOf(row);
-      trace.y[indexOfX]
-        ? rowObj.values.push(trace.y[indexOfX])
-        : rowObj.values.push(null);
+      const indexOfX = trace.x.indexOf(rowObj.raw);
+      rowObj.values.push(indexOfX !== -1 ? trace.y[indexOfX] : null);
     });
     goalTraces.map((trace, i) => {
-      const indexOfX = trace.x.indexOf(row);
-      trace.y[indexOfX]
-        ? rowObj.values.push(trace.y[indexOfX])
-        : rowObj.values.push(null);
+      const indexOfX = trace.x.indexOf(rowObj.raw);
+      rowObj.values.push(indexOfX !== -1 ? trace.y[indexOfX] : null);
     });
     tableData.push(rowObj);
   });


### PR DESCRIPTION
Indicator years in data table in public UI do not match the years in admin UI  - Asana https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1210078915968237?focus=true

The browser interpreted dates like midnight in Finnish time as the previous day in UTC, which made the displayed year shift back. 

* Added `utc` plugin to `dayjs` setup.
* Used the raw date `rowObj.raw` instead of formatted label for trace lookups.