### PR TITLE
Try to show category level name only if category level is defined

### DIFF
--- a/components/actions/CategoryTags.tsx
+++ b/components/actions/CategoryTags.tsx
@@ -151,7 +151,9 @@ function CategoryTags(props: CategoryTagsProps) {
         use the level name of the first selected categoory
         as section header */
     const categoryTypeHeader =
-      ct.levels.length > 0 ? cats[0].level?.name : ct.name;
+      ct.levels.length > 0 && cats[0].level?.name
+        ? cats[0].level.name
+        : ct.name;
 
     return (
       <div key={ct.id} className="mb-4">


### PR DESCRIPTION
Fix for: https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1210204441071810

