### PR TITLE
Handle zero goal on indicator showcase

### DIFF
--- a/components/indicators/IndicatorProgressBar.tsx
+++ b/components/indicators/IndicatorProgressBar.tsx
@@ -288,9 +288,10 @@ function IndicatorProgressBar(props: IndicatorProgressBarProps) {
   const roundedValues = {
     start: Number(startValue?.toPrecision(minPrecision)),
     latest: Number(latestValue?.toPrecision(minPrecision)),
-    goal: goalDisplayValue
-      ? goalDisplayValue.toPrecision(isNormalized ? minPrecision : 4)
-      : undefined,
+    goal:
+      goalDisplayValue != null
+        ? Number(goalDisplayValue.toPrecision(isNormalized ? minPrecision : 4))
+        : undefined,
   };
 
   const largestValue = Math.max(


### PR DESCRIPTION
Indicator showcase bugs if the indicator goal is 0
<img width="794" alt="Screenshot 2025-05-19 at 11 28 09" src="https://github.com/user-attachments/assets/7997a4ae-c5eb-4f04-84a3-e007951afa23" />

Not anymore!
<img width="786" alt="Screenshot 2025-05-19 at 11 28 16" src="https://github.com/user-attachments/assets/ea6e1ed4-9571-41c8-84ac-d5029b0285c1" />
