### PR TITLE
Add indicator pie chart

### DIFF
--- a/common/__generated__/graphql.ts
+++ b/common/__generated__/graphql.ts
@@ -195,6 +195,7 @@ export type Action = {
   editUrl?: Maybe<Scalars['String']['output']>;
   /** The date when implementation of this action ends */
   endDate?: Maybe<Scalars['Date']['output']>;
+  hasDependencyRelationships?: Maybe<Scalars['Boolean']['output']>;
   hasIndicatorsWithGoals?: Maybe<Scalars['Boolean']['output']>;
   id: Scalars['ID']['output'];
   /** The identifier for this action (e.g. number) */
@@ -8235,12 +8236,62 @@ export type CategoryRecursiveFragmentFragment = (
   & { __typename?: 'Category' }
 );
 
+export type DashboardIndicatorFragmentFragment = (
+  { name: string }
+  & { __typename?: 'Indicator' }
+);
+
 export type DashboardIndicatorBlockFragmentFragment = (
-  { blockType: string, blocks: Array<{ __typename?: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename?: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename?: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' } | { __typename?: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' } | { __typename?: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' } | { __typename?: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' } | (
-    { id?: string | null, blockType: string }
-    & { __typename?: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' }
+  { blockType: string, blocks: Array<(
+    { blockType: string }
+    & { __typename?: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
   ) | (
-    { text?: string | null }
+    { blockType: string }
+    & { __typename?: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+  ) | (
+    { blockType: string }
+    & { __typename?: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' }
+  ) | (
+    { blockType: string }
+    & { __typename?: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' }
+  ) | (
+    { blockType: string }
+    & { __typename?: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
+  ) | (
+    { blockType: string }
+    & { __typename?: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+  ) | (
+    { id?: string | null, blockType: string, indicator?: (
+      { name: string }
+      & { __typename?: 'Indicator' }
+    ) | null }
+    & { __typename?: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorSummaryBlock' }
+  ) | (
+    { helpText?: string | null, year?: number | null, blockType: string, chartSeries?: Array<(
+      { dimensionCategory?: (
+        { id: string, name: string }
+        & { __typename?: 'DimensionCategory' }
+      ) | null, values: Array<(
+        { id: string, value: number, date?: string | null, categories: Array<(
+          { id: string, name: string, defaultColor: string }
+          & { __typename?: 'DimensionCategory' }
+        )> }
+        & { __typename?: 'IndicatorValue' }
+      ) | null> }
+      & { __typename?: 'DashboardIndicatorChartSeries' }
+    ) | null> | null, dimension?: (
+      { id: string, name: string, categories: Array<(
+        { id: string, name: string }
+        & { __typename?: 'DimensionCategory' }
+      )> }
+      & { __typename?: 'Dimension' }
+    ) | null, indicator?: (
+      { name: string }
+      & { __typename?: 'Indicator' }
+    ) | null }
+    & { __typename?: 'DashboardIndicatorPieChartBlock' }
+  ) | (
+    { text?: string | null, blockType: string }
     & { __typename?: 'DashboardParagraphBlock' }
   )> }
   & { __typename?: 'DashboardRowBlock' }
@@ -8917,11 +8968,56 @@ type StreamFieldFragment_ChoiceBlock_Fragment = (
 );
 
 type StreamFieldFragment_DashboardRowBlock_Fragment = (
-  { id?: string | null, blockType: string, field: string, blocks: Array<{ __typename?: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename?: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename?: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' } | { __typename?: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' } | { __typename?: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' } | { __typename?: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' } | (
-    { id?: string | null, blockType: string }
-    & { __typename?: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' }
+  { id?: string | null, blockType: string, field: string, blocks: Array<(
+    { blockType: string }
+    & { __typename?: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
   ) | (
-    { text?: string | null }
+    { blockType: string }
+    & { __typename?: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+  ) | (
+    { blockType: string }
+    & { __typename?: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' }
+  ) | (
+    { blockType: string }
+    & { __typename?: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' }
+  ) | (
+    { blockType: string }
+    & { __typename?: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
+  ) | (
+    { blockType: string }
+    & { __typename?: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+  ) | (
+    { id?: string | null, blockType: string, indicator?: (
+      { name: string }
+      & { __typename?: 'Indicator' }
+    ) | null }
+    & { __typename?: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorSummaryBlock' }
+  ) | (
+    { helpText?: string | null, year?: number | null, blockType: string, chartSeries?: Array<(
+      { dimensionCategory?: (
+        { id: string, name: string }
+        & { __typename?: 'DimensionCategory' }
+      ) | null, values: Array<(
+        { id: string, value: number, date?: string | null, categories: Array<(
+          { id: string, name: string, defaultColor: string }
+          & { __typename?: 'DimensionCategory' }
+        )> }
+        & { __typename?: 'IndicatorValue' }
+      ) | null> }
+      & { __typename?: 'DashboardIndicatorChartSeries' }
+    ) | null> | null, dimension?: (
+      { id: string, name: string, categories: Array<(
+        { id: string, name: string }
+        & { __typename?: 'DimensionCategory' }
+      )> }
+      & { __typename?: 'Dimension' }
+    ) | null, indicator?: (
+      { name: string }
+      & { __typename?: 'Indicator' }
+    ) | null }
+    & { __typename?: 'DashboardIndicatorPieChartBlock' }
+  ) | (
+    { text?: string | null, blockType: string }
     & { __typename?: 'DashboardParagraphBlock' }
   )> }
   & { __typename?: 'DashboardRowBlock' }
@@ -14848,11 +14944,56 @@ export type GetContentPageQuery = (
       )> }
       & { __typename?: 'ChoiceBlock' }
     ) | (
-      { id?: string | null, blockType: string, field: string, blocks: Array<{ __typename?: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename?: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename?: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' } | { __typename?: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' } | { __typename?: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' } | { __typename?: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' } | (
-        { id?: string | null, blockType: string }
-        & { __typename?: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' }
+      { id?: string | null, blockType: string, field: string, blocks: Array<(
+        { blockType: string }
+        & { __typename?: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
       ) | (
-        { text?: string | null }
+        { blockType: string }
+        & { __typename?: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+      ) | (
+        { id?: string | null, blockType: string, indicator?: (
+          { name: string }
+          & { __typename?: 'Indicator' }
+        ) | null }
+        & { __typename?: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorSummaryBlock' }
+      ) | (
+        { helpText?: string | null, year?: number | null, blockType: string, chartSeries?: Array<(
+          { dimensionCategory?: (
+            { id: string, name: string }
+            & { __typename?: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date?: string | null, categories: Array<(
+              { id: string, name: string, defaultColor: string }
+              & { __typename?: 'DimensionCategory' }
+            )> }
+            & { __typename?: 'IndicatorValue' }
+          ) | null> }
+          & { __typename?: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension?: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename?: 'DimensionCategory' }
+          )> }
+          & { __typename?: 'Dimension' }
+        ) | null, indicator?: (
+          { name: string }
+          & { __typename?: 'Indicator' }
+        ) | null }
+        & { __typename?: 'DashboardIndicatorPieChartBlock' }
+      ) | (
+        { text?: string | null, blockType: string }
         & { __typename?: 'DashboardParagraphBlock' }
       )> }
       & { __typename?: 'DashboardRowBlock' }
@@ -16198,11 +16339,56 @@ export type GetContentPageQuery = (
       )> }
       & { __typename?: 'ChoiceBlock' }
     ) | (
-      { id?: string | null, blockType: string, field: string, blocks: Array<{ __typename?: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename?: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename?: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' } | { __typename?: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' } | { __typename?: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' } | { __typename?: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' } | (
-        { id?: string | null, blockType: string }
-        & { __typename?: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' }
+      { id?: string | null, blockType: string, field: string, blocks: Array<(
+        { blockType: string }
+        & { __typename?: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
       ) | (
-        { text?: string | null }
+        { blockType: string }
+        & { __typename?: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+      ) | (
+        { id?: string | null, blockType: string, indicator?: (
+          { name: string }
+          & { __typename?: 'Indicator' }
+        ) | null }
+        & { __typename?: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorSummaryBlock' }
+      ) | (
+        { helpText?: string | null, year?: number | null, blockType: string, chartSeries?: Array<(
+          { dimensionCategory?: (
+            { id: string, name: string }
+            & { __typename?: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date?: string | null, categories: Array<(
+              { id: string, name: string, defaultColor: string }
+              & { __typename?: 'DimensionCategory' }
+            )> }
+            & { __typename?: 'IndicatorValue' }
+          ) | null> }
+          & { __typename?: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension?: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename?: 'DimensionCategory' }
+          )> }
+          & { __typename?: 'Dimension' }
+        ) | null, indicator?: (
+          { name: string }
+          & { __typename?: 'Indicator' }
+        ) | null }
+        & { __typename?: 'DashboardIndicatorPieChartBlock' }
+      ) | (
+        { text?: string | null, blockType: string }
         & { __typename?: 'DashboardParagraphBlock' }
       )> }
       & { __typename?: 'DashboardRowBlock' }
@@ -17065,11 +17251,56 @@ export type GetContentPageQuery = (
       )> }
       & { __typename?: 'ChoiceBlock' }
     ) | (
-      { id?: string | null, blockType: string, field: string, blocks: Array<{ __typename?: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename?: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename?: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' } | { __typename?: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' } | { __typename?: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' } | { __typename?: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' } | (
-        { id?: string | null, blockType: string }
-        & { __typename?: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' }
+      { id?: string | null, blockType: string, field: string, blocks: Array<(
+        { blockType: string }
+        & { __typename?: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
       ) | (
-        { text?: string | null }
+        { blockType: string }
+        & { __typename?: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+      ) | (
+        { id?: string | null, blockType: string, indicator?: (
+          { name: string }
+          & { __typename?: 'Indicator' }
+        ) | null }
+        & { __typename?: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorSummaryBlock' }
+      ) | (
+        { helpText?: string | null, year?: number | null, blockType: string, chartSeries?: Array<(
+          { dimensionCategory?: (
+            { id: string, name: string }
+            & { __typename?: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date?: string | null, categories: Array<(
+              { id: string, name: string, defaultColor: string }
+              & { __typename?: 'DimensionCategory' }
+            )> }
+            & { __typename?: 'IndicatorValue' }
+          ) | null> }
+          & { __typename?: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension?: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename?: 'DimensionCategory' }
+          )> }
+          & { __typename?: 'Dimension' }
+        ) | null, indicator?: (
+          { name: string }
+          & { __typename?: 'Indicator' }
+        ) | null }
+        & { __typename?: 'DashboardIndicatorPieChartBlock' }
+      ) | (
+        { text?: string | null, blockType: string }
         & { __typename?: 'DashboardParagraphBlock' }
       )> }
       & { __typename?: 'DashboardRowBlock' }
@@ -17941,11 +18172,56 @@ export type GetHomePageQuery = (
       )> }
       & { __typename?: 'ChoiceBlock' }
     ) | (
-      { id?: string | null, blockType: string, field: string, blocks: Array<{ __typename?: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename?: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename?: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' } | { __typename?: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' } | { __typename?: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' } | { __typename?: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' } | (
-        { id?: string | null, blockType: string }
-        & { __typename?: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' }
+      { id?: string | null, blockType: string, field: string, blocks: Array<(
+        { blockType: string }
+        & { __typename?: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
       ) | (
-        { text?: string | null }
+        { blockType: string }
+        & { __typename?: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename?: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+      ) | (
+        { id?: string | null, blockType: string, indicator?: (
+          { name: string }
+          & { __typename?: 'Indicator' }
+        ) | null }
+        & { __typename?: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorSummaryBlock' }
+      ) | (
+        { helpText?: string | null, year?: number | null, blockType: string, chartSeries?: Array<(
+          { dimensionCategory?: (
+            { id: string, name: string }
+            & { __typename?: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date?: string | null, categories: Array<(
+              { id: string, name: string, defaultColor: string }
+              & { __typename?: 'DimensionCategory' }
+            )> }
+            & { __typename?: 'IndicatorValue' }
+          ) | null> }
+          & { __typename?: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension?: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename?: 'DimensionCategory' }
+          )> }
+          & { __typename?: 'Dimension' }
+        ) | null, indicator?: (
+          { name: string }
+          & { __typename?: 'Indicator' }
+        ) | null }
+        & { __typename?: 'DashboardIndicatorPieChartBlock' }
+      ) | (
+        { text?: string | null, blockType: string }
         & { __typename?: 'DashboardParagraphBlock' }
       )> }
       & { __typename?: 'DashboardRowBlock' }

--- a/components/common/Card.tsx
+++ b/components/common/Card.tsx
@@ -100,6 +100,7 @@ interface CardProps {
   children: React.ReactNode;
   outline?: boolean;
   altText?: string;
+  className?: string;
 }
 
 const Card = (props: CardProps) => {
@@ -113,6 +114,7 @@ const Card = (props: CardProps) => {
     customColor,
     children,
     outline,
+    className = '',
   } = props;
   const t = useTranslations();
 
@@ -145,7 +147,7 @@ const Card = (props: CardProps) => {
 
   return (
     <StyledCard
-      className={outline && 'outline'}
+      className={`${className} ${outline ? 'outline' : ''}`}
       $customColor={customColor}
       $customBackgroundColor={customBackgroundColor}
       data-testid="card"

--- a/components/contentblocks/DashboardRowBlock.tsx
+++ b/components/contentblocks/DashboardRowBlock.tsx
@@ -44,6 +44,10 @@ const StyledRow = styled(Row)`
   --bs-gutter-y: ${({ theme }) => theme.spaces.s200};
 `;
 
+const StyledCard = styled(Card)`
+  height: 100%;
+`;
+
 function getBlockComponent(block: DashboardBlock) {
   switch (block.blockType) {
     case 'DashboardParagraphBlock': {
@@ -100,9 +104,9 @@ const DashboardRowBlock = ({
         <StyledRow>
           {blocks.map((block, index) => (
             <Col key={`${block.id}-${index}`} md={columnWidth}>
-              <Card outline>
+              <StyledCard outline>
                 <DashboardCardContents block={block} />
-              </Card>
+              </StyledCard>
             </Col>
           ))}
         </StyledRow>

--- a/components/contentblocks/DashboardRowBlock.tsx
+++ b/components/contentblocks/DashboardRowBlock.tsx
@@ -11,6 +11,7 @@ import {
   DashboardIndicatorSummaryBlock,
 } from '@/common/__generated__/graphql';
 import Card from '../common/Card';
+import DashboardIndicatorPieChartBlockComponent from './indicator-chart/DashboardIndicatorPieChartBlock';
 
 const DashboardRowSection = styled.div<{
   $topMargin?: boolean;
@@ -43,12 +44,15 @@ function getBlockComponent(block: DashboardBlock) {
   switch (block.blockType) {
     case 'DashboardParagraphBlock': {
       const paragraphBlock = block as DashboardParagraphBlock;
-
       return paragraphBlock.text ? (
         <div dangerouslySetInnerHTML={{ __html: paragraphBlock.text }} />
       ) : null;
     }
-    case 'DashboardIndicatorPieChartBlock':
+    case 'DashboardIndicatorPieChartBlock': {
+      const pieChartBlock = block as DashboardIndicatorPieChartBlock;
+
+      return <DashboardIndicatorPieChartBlockComponent {...pieChartBlock} />;
+    }
     case 'DashboardIndicatorAreaChartBlock':
     case 'DashboardIndicatorBarChartBlock':
     case 'DashboardIndicatorLineChartBlock':
@@ -81,7 +85,6 @@ const DashboardRowBlock = ({
   bottomMargin = true,
 }: DashboardRowBlockProps) => {
   const columnWidth = 12 / blocks.length;
-  console.log(blocks);
 
   return (
     <DashboardRowSection

--- a/components/contentblocks/DashboardRowBlock.tsx
+++ b/components/contentblocks/DashboardRowBlock.tsx
@@ -40,6 +40,10 @@ interface DashboardRowBlockProps extends Omit<TDashboardRowBlock, 'rawValue'> {
   blocks: DashboardBlock[];
 }
 
+const StyledRow = styled(Row)`
+  --bs-gutter-y: ${({ theme }) => theme.spaces.s200};
+`;
+
 function getBlockComponent(block: DashboardBlock) {
   switch (block.blockType) {
     case 'DashboardParagraphBlock': {
@@ -93,7 +97,7 @@ const DashboardRowBlock = ({
       $bottomMargin={bottomMargin}
     >
       <Container>
-        <Row>
+        <StyledRow>
           {blocks.map((block, index) => (
             <Col key={`${block.id}-${index}`} md={columnWidth}>
               <Card outline>
@@ -101,7 +105,7 @@ const DashboardRowBlock = ({
               </Card>
             </Col>
           ))}
-        </Row>
+        </StyledRow>
       </Container>
     </DashboardRowSection>
   );

--- a/components/contentblocks/indicator-chart/DashboardIndicatorPieChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorPieChartBlock.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { useTheme } from 'styled-components';
+import { PieChart } from 'echarts/charts';
+import type { PieSeriesOption } from 'echarts/charts';
+import * as echarts from 'echarts/core';
+import Chart, { ECOption } from '@/components/paths/graphs/Chart';
+import { DashboardIndicatorPieChartBlock as TDashboardIndicatorPieChartBlock } from '@/common/__generated__/graphql';
+
+echarts.use([PieChart]);
+
+interface DashboardIndicatorPieChartBlockProps
+  extends TDashboardIndicatorPieChartBlock {}
+
+function getLatestYear(
+  chartSeries: DashboardIndicatorPieChartBlockProps['chartSeries']
+) {
+  return chartSeries?.[0]?.values?.[chartSeries?.[0]?.values.length - 1]?.date;
+}
+
+const DashboardIndicatorPieChartBlock = ({
+  chartSeries,
+  dimension,
+  year,
+}: DashboardIndicatorPieChartBlockProps) => {
+  const theme = useTheme();
+  const assertedYear = year ?? getLatestYear(chartSeries);
+
+  if (!assertedYear) {
+    return <div>No year provided</div>;
+  }
+
+  const seriesData =
+    chartSeries?.reduce((acc, series) => {
+      if (!series?.dimensionCategory?.name) {
+        return acc;
+      }
+
+      const categoryName = series.dimensionCategory.name;
+      const valueForYear = series.values?.find(
+        (v): v is NonNullable<typeof v> => v !== null && v.date === assertedYear
+      )?.value;
+
+      const value = valueForYear ?? 0;
+
+      return [
+        ...acc,
+        {
+          name: categoryName,
+          value: value,
+        },
+      ];
+    }, [] as { name: string; value: number }[]) ?? [];
+
+  const option: ECOption & { series: PieSeriesOption[] } = {
+    tooltip: {
+      trigger: 'item',
+      formatter: '{b}: {c} ({d}%)',
+    },
+    series: [
+      {
+        type: 'pie',
+        radius: ['40%', '70%'],
+        avoidLabelOverlap: true,
+        itemStyle: {
+          borderRadius: 10,
+          borderColor: theme.themeColors.white,
+          borderWidth: 2,
+        },
+        label: {
+          show: true,
+          formatter: '{b}\n{d}%',
+        },
+        emphasis: {
+          label: {
+            show: true,
+            fontSize: 14,
+            fontWeight: 'bold',
+          },
+        },
+        data: seriesData,
+      },
+    ],
+  };
+
+  return <Chart data={option} isLoading={false} height="300px" />;
+};
+
+export default DashboardIndicatorPieChartBlock;

--- a/components/contentblocks/indicator-chart/DashboardIndicatorPieChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorPieChartBlock.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useTheme } from 'styled-components';
 import { PieChart } from 'echarts/charts';
+import { LegendComponent } from 'echarts/components';
 import type { PieSeriesOption } from 'echarts/charts';
 import * as echarts from 'echarts/core';
 import Chart, { ECOption } from '@/components/paths/graphs/Chart';
@@ -10,8 +11,9 @@ import {
   Unit,
 } from '@/common/__generated__/graphql';
 import { CallbackDataParams } from 'echarts/types/dist/shared';
+import { getDefaultColors } from './indicator-chart-colors';
 
-echarts.use([PieChart]);
+echarts.use([PieChart, LegendComponent]);
 
 interface SeriesData {
   name: string;
@@ -108,6 +110,10 @@ const DashboardIndicatorPieChartBlock = ({
         {
           name: categoryName,
           value: value,
+          itemStyle: {
+            // An unset defaultColor is returned as an empty string
+            color: series.dimensionCategory.defaultColor || undefined,
+          },
         },
       ];
     }, [] as SeriesData[]) ?? [];
@@ -118,6 +124,23 @@ const DashboardIndicatorPieChartBlock = ({
       trigger: 'item',
       formatter: createTooltipFormatter(indicator ?? null, seriesData),
     },
+    legend: {
+      show: true,
+      orient: 'horizontal',
+      bottom: 0,
+      left: 'center',
+      type: 'plain',
+      selectedMode: false,
+      textStyle: {
+        color: theme.textColor.primary,
+      },
+      pageTextStyle: {
+        color: theme.textColor.primary,
+      },
+      pageIconColor: theme.textColor.primary,
+      pageIconInactiveColor: theme.textColor.tertiary,
+    },
+    color: getDefaultColors(theme),
     series: [
       {
         type: 'pie',
@@ -127,23 +150,35 @@ const DashboardIndicatorPieChartBlock = ({
           borderColor: theme.themeColors.white,
           borderWidth: 0,
         },
+
         label: {
           show: true,
-          formatter: '{b}\n{d}%',
+          formatter: (params: CallbackDataParams) =>
+            `${params.name}\n${
+              params.percent ? `${Math.round(params.percent)}%` : ''
+            }`,
         },
+
         emphasis: {
           label: {
             show: true,
-            fontSize: 14,
             fontWeight: 'bold',
           },
         },
+
         data: seriesData,
       },
     ],
   };
 
-  return <Chart data={option} isLoading={false} height="300px" />;
+  return (
+    <>
+      <h5>
+        {dimension?.name} ({assertedYear})
+      </h5>
+      <Chart data={option} isLoading={false} height="300px" />
+    </>
+  );
 };
 
 export default DashboardIndicatorPieChartBlock;

--- a/components/contentblocks/indicator-chart/indicator-chart-colors.tsx
+++ b/components/contentblocks/indicator-chart/indicator-chart-colors.tsx
@@ -1,0 +1,16 @@
+import { Theme } from '@kausal/themes/types';
+
+export function getDefaultColors(theme: Theme) {
+  return [
+    theme.graphColors.blue010,
+    theme.graphColors.blue030,
+    theme.graphColors.blue050,
+    theme.graphColors.blue070,
+    theme.graphColors.blue090,
+    theme.graphColors.green010,
+    theme.graphColors.green030,
+    theme.graphColors.green050,
+    theme.graphColors.green070,
+    theme.graphColors.green090,
+  ];
+}

--- a/fragments/dashboard-indicator-block.fragment.ts
+++ b/fragments/dashboard-indicator-block.fragment.ts
@@ -21,13 +21,10 @@ export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
           dimensionCategory {
             id
             name
+            defaultColor
           }
           values {
             id
-            categories {
-              id
-              name
-            }
             value
             date
           }

--- a/fragments/dashboard-indicator-block.fragment.ts
+++ b/fragments/dashboard-indicator-block.fragment.ts
@@ -17,15 +17,29 @@ export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
       ... on DashboardIndicatorPieChartBlock {
         helpText
         year
-        # chartSeries {
-        #   dimensionCategory {
-        #     id
-        #   }
-        #   values {
-        #     value
-        #     date
-        #   }
-        # }
+        chartSeries {
+          dimensionCategory {
+            id
+            name
+          }
+          values {
+            id
+            categories {
+              id
+              name
+            }
+            value
+            date
+          }
+        }
+        dimension {
+          id
+          name
+          categories {
+            id
+            name
+          }
+        }
         indicator {
           ...DashboardIndicatorFragment
         }


### PR DESCRIPTION
Add the indicator pie chart component and update the dashboard row styles. Parts of this chart will may be useful for the other visualisations. Let's separate those to helper functions/ constants as needed.

### Pie chart with colours defined in dimension categories
| Input | Output |
|--|--|
| ![image](https://github.com/user-attachments/assets/514c359b-36a3-44e3-ab31-1a65838897eb) |  <img width="547" alt="image" src="https://github.com/user-attachments/assets/814a876e-a53d-4d90-85c1-cead33410b81" /> |
| ![image](https://github.com/user-attachments/assets/3456b8dd-fffb-43ce-a882-ce6bf89f3504) | ![image](https://github.com/user-attachments/assets/f9f04c3b-41ca-406d-8ae4-0164ac013c87)) |

### Pie chart with no colours defined in dimension categories (defaults to theme)
| Input | Output |
|--|--|
|  ![image](https://github.com/user-attachments/assets/42d9ade0-5525-40e1-8ad1-73c5a97424d1) | ![image](https://github.com/user-attachments/assets/9c955636-d2ab-4ee8-bc89-72b62e4f7c2b) |

### Invalid pie input

| Input | Output |
|--|--|
| <img width="650" alt="image" src="https://github.com/user-attachments/assets/762a34fa-ef30-4faa-b750-4a14d034799f" /> | <img width="436" alt="image" src="https://github.com/user-attachments/assets/0a8df996-682b-4f49-aa3b-6dac9e992fcf" /> |
