### PR TITLE
Align badge text always left

### DIFF
--- a/components/common/BadgeTooltip.tsx
+++ b/components/common/BadgeTooltip.tsx
@@ -12,6 +12,7 @@ const WrapperButton = styled(Button)`
   margin: 0;
   background-color: transparent;
   border: none;
+  text-align: left;
 `;
 
 const StyledBadge = styled(Badge)<{ color: string; $isLink: boolean }>`
@@ -28,7 +29,7 @@ const StyledBadge = styled(Badge)<{ color: string; $isLink: boolean }>`
   padding-left: ${(props) => props.theme.badgePaddingX};
   padding-right: ${(props) => props.theme.badgePaddingX};
   font-weight: ${(props) => props.theme.badgeFontWeight};
-  line-height: 1.5;
+  line-height: ${(props) => props.theme.lineHeightMd};
   max-width: 100%;
   word-break: break-all;
   word-break: break-word;


### PR DESCRIPTION
Button makes these center aligned - only visible when multiple lines
<img width="346" alt="Screenshot 2025-05-29 at 14 48 15" src="https://github.com/user-attachments/assets/5a4fe048-fd0e-403a-9ead-b2dba7e1dee1" />

Let's make them all align left
<img width="348" alt="Screenshot 2025-05-29 at 14 48 25" src="https://github.com/user-attachments/assets/937adf85-92c2-4caa-bd04-b7a3d75596a0" />

Also adjust line-height making sure clipping & clamping work
<img width="442" alt="Screenshot 2025-05-29 at 15 00 28" src="https://github.com/user-attachments/assets/3023a099-51b9-4e56-aca2-c430951ebc6f" />

-->
<img width="439" alt="Screenshot 2025-05-29 at 15 00 08" src="https://github.com/user-attachments/assets/53ad806a-1aa3-4f5b-b7fc-e4c2d8e6e581" />


https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1210397264254534?focus=true
