### PR TITLE
Fix: remove global height overriding iframe height

### DIFF
--- a/components/common/StreamField.tsx
+++ b/components/common/StreamField.tsx
@@ -53,7 +53,6 @@ const ResponsiveStyles = styled.div`
   .responsive-object object,
   .responsive-object embed {
     width: 100%;
-    height: 100%;
   }
 
   .responsive-object[data-embed-provider='${EmbedProvider.YOUTUBE}'] {


### PR DESCRIPTION
Bug fix - Embeds were displayed at the wrong height.
Asana https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1210470076974007?focus=true

Remove the global height: 100% style for iframes to fix overriding issues with embeds