### PR TITLE
Bar and area charts for indicator visualisation 

### DIFF
--- a/components/contentblocks/DashboardRowBlock.tsx
+++ b/components/contentblocks/DashboardRowBlock.tsx
@@ -15,6 +15,7 @@ import DashboardIndicatorSummaryBlock from './DashboardIndicatorSummaryBlock';
 import DashboardIndicatorPieChartBlockComponent from './indicator-chart/DashboardIndicatorPieChartBlock';
 import DashboardIndicatorLineChartBlockComponent from './indicator-chart/DashboardIndicatorLineChartBlock';
 import DashboardIndicatorBarChartBlockComponent from './indicator-chart/DashboardIndicatorBarChartBlock';
+import DashboardIndicatorAreaChartBlockComponent from './indicator-chart/DashboardIndicatorAreaChartBlock';
 
 const DashboardRowSection = styled.div<{
   $topMargin?: boolean;
@@ -78,9 +79,10 @@ function getBlockComponent(block: DashboardBlock) {
       const barChartBlock = block as DashboardIndicatorBarChartBlock;
       return <DashboardIndicatorBarChartBlockComponent {...barChartBlock} />;
     }
-    case 'DashboardIndicatorAreaChartBlock':
-      // TODO: Add component for each block type
-      return null;
+    case 'DashboardIndicatorAreaChartBlock': {
+      const areaChartBlock = block as DashboardIndicatorAreaChartBlock;
+      return <DashboardIndicatorAreaChartBlockComponent {...areaChartBlock} />;
+    }
   }
 }
 

--- a/components/contentblocks/DashboardRowBlock.tsx
+++ b/components/contentblocks/DashboardRowBlock.tsx
@@ -14,6 +14,7 @@ import Card from '../common/Card';
 import DashboardIndicatorSummaryBlock from './DashboardIndicatorSummaryBlock';
 import DashboardIndicatorPieChartBlockComponent from './indicator-chart/DashboardIndicatorPieChartBlock';
 import DashboardIndicatorLineChartBlockComponent from './indicator-chart/DashboardIndicatorLineChartBlock';
+import DashboardIndicatorBarChartBlockComponent from './indicator-chart/DashboardIndicatorBarChartBlock';
 
 const DashboardRowSection = styled.div<{
   $topMargin?: boolean;
@@ -73,8 +74,11 @@ function getBlockComponent(block: DashboardBlock) {
       const lineChartBlock = block as DashboardIndicatorLineChartBlock;
       return <DashboardIndicatorLineChartBlockComponent {...lineChartBlock} />;
     }
+    case 'DashboardIndicatorBarChartBlock': {
+      const barChartBlock = block as DashboardIndicatorBarChartBlock;
+      return <DashboardIndicatorBarChartBlockComponent {...barChartBlock} />;
+    }
     case 'DashboardIndicatorAreaChartBlock':
-    case 'DashboardIndicatorBarChartBlock':
       // TODO: Add component for each block type
       return null;
   }

--- a/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
@@ -17,6 +17,7 @@ import {
   buildDimSeries,
   buildTotalSeries,
   buildTooltipFormatter,
+  getYAxisBounds,
 } from './indicator-charts-utility';
 
 echarts.use([LineChart, GridComponent, TooltipComponent, LegendComponent]);
@@ -94,6 +95,7 @@ const DashboardIndicatorAreaChartBlock = ({
     yAxis: {
       type: 'value',
       name: unit,
+      ...getYAxisBounds(indicator?.minValue, indicator?.maxValue),
       axisLabel: { color: theme.textColor.primary },
     },
     series,

--- a/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
@@ -36,6 +36,9 @@ const DashboardIndicatorAreaChartBlock = ({
   const unit = indicator?.unit?.name ?? '';
   const palette = graphsTheme.categoryColors ?? getDefaultColors(theme);
 
+  const totalLabel = t('total');
+  const trendLabel = t('current-trend');
+
   if (!chartSeries?.length) {
     return <div>{t('data-not-available')}</div>;
   }
@@ -46,7 +49,7 @@ const DashboardIndicatorAreaChartBlock = ({
   const totalDef = buildTotalSeries(
     chartSeries,
     graphsTheme.totalLineColor ?? palette[0],
-    indicator.name ?? t('total')
+    totalLabel
   );
   const totalRaw = totalDef.raw;
 
@@ -55,13 +58,14 @@ const DashboardIndicatorAreaChartBlock = ({
       ? buildTrendSeries(
           totalRaw,
           indicator,
-          graphsTheme.trendLineColor ?? '#aaa'
+          graphsTheme.trendLineColor ?? '#aaa',
+          trendLabel
         )
       : [];
 
   const legendData = [
-    ...(hasDimension ? dimSeries.map((d) => d.name) : [totalDef.name]),
-    ...(trendSeries.length ? ['Trend'] : []),
+    ...(hasDimension ? dimSeries.map((d) => d.name) : [totalLabel]),
+    ...(trendSeries.length ? [trendLabel] : []),
   ];
 
   const xCategories = Array.from(

--- a/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
@@ -13,7 +13,11 @@ import * as echarts from 'echarts/core';
 import Chart, { ECOption } from '@/components/paths/graphs/Chart';
 import { DashboardIndicatorAreaChartBlock as TDashboardIndicatorAreaChartBlock } from '@/common/__generated__/graphql';
 import { getDefaultColors } from './indicator-chart-colors';
-import { buildDimSeries, buildTotalSeries } from './indicator-charts-utility';
+import {
+  buildDimSeries,
+  buildTotalSeries,
+  buildTooltipFormatter,
+} from './indicator-charts-utility';
 
 echarts.use([LineChart, GridComponent, TooltipComponent, LegendComponent]);
 
@@ -72,17 +76,13 @@ const DashboardIndicatorAreaChartBlock = ({
       trigger: 'axis',
       appendTo: 'body',
       axisPointer: { type: 'line' },
-      formatter: (params: any[]) => {
-        const year = params[0]?.data?.[0] ?? '';
-        const rows = params
-          .filter((p) => legendData.includes(p.seriesName))
-          .map((p) => {
-            const value =
-              typeof p.data?.[1] === 'number' ? p.data[1].toFixed(1) : '-';
-            return `${p.marker} ${p.seriesName}: ${value} ${unit}`;
-          });
-        return `<strong>${year}</strong><br/>${rows.join('<br/>')}`;
-      },
+      formatter: buildTooltipFormatter(
+        unit,
+        legendData,
+        t,
+        dimension,
+        indicator?.valueRounding
+      ),
     },
     grid: { left: 20, right: 20, top: 40, bottom: 60, containLabel: true },
     xAxis: {

--- a/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
@@ -17,7 +17,7 @@ import {
   buildDimSeries,
   buildTotalSeries,
   buildTooltipFormatter,
-  getYAxisBounds,
+  buildYAxisConfig,
 } from './indicator-charts-utility';
 
 echarts.use([LineChart, GridComponent, TooltipComponent, LegendComponent]);
@@ -92,12 +92,11 @@ const DashboardIndicatorAreaChartBlock = ({
       boundaryGap: false,
       axisLabel: { color: theme.textColor.primary },
     },
-    yAxis: {
-      type: 'value',
-      name: unit,
-      ...getYAxisBounds(indicator?.minValue, indicator?.maxValue),
-      axisLabel: { color: theme.textColor.primary },
-    },
+    yAxis: buildYAxisConfig(
+      indicator?.unit?.name ?? '',
+      indicator,
+      theme.textColor.primary
+    ),
     series,
   };
 

--- a/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
@@ -15,6 +15,7 @@ import {
   buildDimSeries,
   buildTotalSeries,
   buildTooltipFormatter,
+  getYAxisBounds,
 } from './indicator-charts-utility';
 
 echarts.use([BarChart, GridComponent, TooltipComponent, LegendComponent]);
@@ -105,6 +106,7 @@ const DashboardIndicatorBarChartBlock = ({
     },
     yAxis: {
       type: 'value',
+      ...getYAxisBounds(indicator?.minValue, indicator?.maxValue),
       name: unit,
       axisLabel: { color: theme.textColor.primary },
     },

--- a/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
@@ -34,6 +34,8 @@ const DashboardIndicatorBarChartBlock = ({
   const unit = indicator?.unit?.name ?? '';
   const palette = graphsTheme.categoryColors ?? getDefaultColors(theme);
 
+  const totalLabel = t('total');
+
   if (!chartSeries?.length) {
     return <div>{t('data-not-available')}</div>;
   }
@@ -44,7 +46,7 @@ const DashboardIndicatorBarChartBlock = ({
         buildTotalSeries(
           chartSeries,
           graphsTheme.totalLineColor ?? palette[0],
-          indicator.name ?? t('total')
+          totalLabel
         ),
       ];
 

--- a/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
@@ -89,7 +89,13 @@ const DashboardIndicatorBarChartBlock = ({
       trigger: 'axis',
       appendTo: 'body',
       axisPointer: { type: 'shadow' },
-      formatter: buildTooltipFormatter(unit, legendData, t, dimension),
+      formatter: buildTooltipFormatter(
+        unit,
+        legendData,
+        t,
+        dimension,
+        indicator?.valueRounding
+      ),
     },
     grid: { left: 20, right: 20, top: 40, bottom: 60, containLabel: true },
     xAxis: {

--- a/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { useTheme } from 'styled-components';
+import { useTranslations } from 'next-intl';
+import { BarChart } from 'echarts/charts';
+import {
+  GridComponent,
+  TooltipComponent,
+  LegendComponent,
+} from 'echarts/components';
+import * as echarts from 'echarts/core';
+import Chart, { ECOption } from '@/components/paths/graphs/Chart';
+import { DashboardIndicatorBarChartBlock as TDashboardIndicatorBarChartBlock } from '@/common/__generated__/graphql';
+import { getDefaultColors } from './indicator-chart-colors';
+import { buildDimSeries } from './indicator-charts-utility';
+
+echarts.use([BarChart, GridComponent, TooltipComponent, LegendComponent]);
+
+type Props = TDashboardIndicatorBarChartBlock;
+
+const DashboardIndicatorBarChartBlock = ({
+  chartSeries,
+  indicator,
+  dimension,
+  barType,
+}: Props) => {
+  const theme = useTheme();
+  const t = useTranslations();
+  const graphsTheme = theme.settings?.graphs ?? {};
+  const unit = indicator?.unit?.name ?? '';
+  const palette = graphsTheme.categoryColors ?? getDefaultColors(theme);
+
+  if (!chartSeries?.length) {
+    return <div>{t('data-not-available')}</div>;
+  }
+
+  const dimSeries = dimension
+    ? buildDimSeries(chartSeries, palette)
+    : [
+        {
+          name: indicator.name ?? t('total'),
+          color: palette[0],
+          raw: chartSeries.flatMap((s) =>
+            s.values.map((v) => [new Date(v.date).getFullYear(), v.value])
+          ),
+        },
+      ];
+
+  const xCategoriesSet = new Set<string>();
+  const seriesDataMap: Record<string, (number | null)[]> = {};
+
+  dimSeries.forEach(({ name, raw }) => {
+    seriesDataMap[name] = [];
+    raw.forEach(([year, value]) => {
+      const yearStr = String(year);
+      xCategoriesSet.add(yearStr);
+    });
+  });
+
+  const xCategories = Array.from(xCategoriesSet).sort();
+
+  dimSeries.forEach(({ name, raw }) => {
+    const valuesByYear: Record<string, number> = Object.fromEntries(
+      raw.map(([year, value]) => [String(year), value])
+    );
+    seriesDataMap[name] = xCategories.map((year) => valuesByYear[year] ?? null);
+  });
+
+  const series = Object.entries(seriesDataMap).map(([name, data]) => ({
+    name,
+    type: 'bar' as const,
+    stack: barType === 'stacked' ? 'total' : undefined,
+    data,
+    emphasis: { focus: 'series' },
+    itemStyle: {
+      color: dimSeries.find((d) => d.name === name)?.color,
+    },
+  }));
+
+  const legendData = dimSeries.map((d) => d.name);
+
+  const option: ECOption = {
+    legend: {
+      show: true,
+      bottom: 0,
+      textStyle: { color: theme.textColor.secondary },
+    },
+    tooltip: {
+      trigger: 'axis',
+      appendTo: 'body',
+      axisPointer: { type: 'shadow' },
+      formatter: (params: any[]) => {
+        const processedSeries = new Set<string>();
+        const paramsArray = Array.isArray(params) ? params : [params];
+        const year = paramsArray[0]?.axisValue;
+        const rows = paramsArray
+          .filter((p) => {
+            if (!legendData.includes(p.seriesName)) return false;
+            if (processedSeries.has(p.seriesName)) return false;
+            processedSeries.add(p.seriesName);
+            return true;
+          })
+          .map((p) => {
+            const value = typeof p.data === 'number' ? p.data.toFixed(1) : '-';
+            const name = dimension ? p.seriesName : t('total');
+            return `${p.marker} ${name}: ${value} ${unit}`;
+          });
+
+        return `<strong>${year}</strong><br/>${rows.join('<br/>')}`;
+      },
+    },
+    grid: { left: 20, right: 20, top: 40, bottom: 60, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: xCategories,
+      axisLabel: { color: theme.textColor.primary },
+    },
+    yAxis: {
+      type: 'value',
+      name: unit,
+      axisLabel: { color: theme.textColor.primary },
+    },
+    series,
+  };
+
+  return (
+    <>
+      <h5>{dimension?.name}</h5>
+      <Chart data={option} isLoading={false} height="300px" />
+    </>
+  );
+};
+
+export default DashboardIndicatorBarChartBlock;

--- a/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
@@ -15,7 +15,7 @@ import {
   buildDimSeries,
   buildTotalSeries,
   buildTooltipFormatter,
-  getYAxisBounds,
+  buildYAxisConfig,
 } from './indicator-charts-utility';
 
 echarts.use([BarChart, GridComponent, TooltipComponent, LegendComponent]);
@@ -104,12 +104,11 @@ const DashboardIndicatorBarChartBlock = ({
       data: xCategories,
       axisLabel: { color: theme.textColor.primary },
     },
-    yAxis: {
-      type: 'value',
-      ...getYAxisBounds(indicator?.minValue, indicator?.maxValue),
-      name: unit,
-      axisLabel: { color: theme.textColor.primary },
-    },
+    yAxis: buildYAxisConfig(
+      indicator?.unit?.name ?? '',
+      indicator,
+      theme.textColor.primary
+    ),
     series,
   };
 

--- a/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock.tsx
@@ -20,7 +20,7 @@ import {
   buildTotalSeries,
   buildTrendSeries,
   buildTooltipFormatter,
-  getYAxisBounds,
+  buildYAxisConfig,
 } from './indicator-charts-utility';
 
 echarts.use([
@@ -141,13 +141,11 @@ const DashboardIndicatorLineChartBlock = ({
       boundaryGap: false,
       axisLabel: { color: theme.textColor.primary },
     },
-    yAxis: {
-      type: 'value',
-      name: unit,
-      ...getYAxisBounds(indicator?.minValue, indicator?.maxValue),
-      min: 0,
-      axisLabel: { color: theme.textColor.primary },
-    },
+    yAxis: buildYAxisConfig(
+      indicator?.unit?.name ?? '',
+      indicator,
+      theme.textColor.primary
+    ),
     series: [...seriesLines, ...seriesTotal, ...goalSeries, ...trendSeries],
   };
 

--- a/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock.tsx
@@ -45,6 +45,10 @@ const DashboardIndicatorLineChartBlock = ({
   const unit = indicator?.unit?.name ?? '';
   const palette = graphsTheme.categoryColors ?? getDefaultColors(theme);
 
+  const totalLabel = t('total');
+  const goalLabel = t('goal');
+  const trendLabel = t('current-trend');
+
   if (!chartSeries?.length) {
     return <div>{t('data-not-available')}</div>;
   }
@@ -52,7 +56,8 @@ const DashboardIndicatorLineChartBlock = ({
   const dimSeries = buildDimSeries(chartSeries, palette);
   const totalDef = buildTotalSeries(
     chartSeries,
-    graphsTheme.totalLineColor ?? '#000'
+    graphsTheme.totalLineColor ?? '#000',
+    totalLabel
   );
   const totalRaw = totalDef.raw;
 
@@ -99,19 +104,21 @@ const DashboardIndicatorLineChartBlock = ({
   const trendSeries = buildTrendSeries(
     totalRaw,
     indicator,
-    graphsTheme.trendLineColor ?? '#aaa'
+    graphsTheme.trendLineColor ?? '#aaa',
+    trendLabel
   );
   const goalSeries = buildGoalSeries(
     indicator,
     unit,
-    graphsTheme.goalLineColors ?? []
+    graphsTheme.goalLineColors ?? [],
+    goalLabel
   );
 
   const legendData = [
     ...dimSeries.map((d) => d.name),
-    ...(showTotalLine && totalRaw.length ? [totalDef.name] : []),
-    ...(goalSeries.length ? ['Goal'] : []),
-    ...(trendSeries.length ? ['Trend'] : []),
+    ...(showTotalLine && totalRaw.length ? [totalLabel] : []),
+    ...(goalSeries.length ? [goalLabel] : []),
+    ...(trendSeries.length ? [trendLabel] : []),
   ];
 
   const option: ECOption = {

--- a/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock.tsx
@@ -20,6 +20,7 @@ import {
   buildTotalSeries,
   buildTrendSeries,
   buildTooltipFormatter,
+  getYAxisBounds,
 } from './indicator-charts-utility';
 
 echarts.use([
@@ -143,6 +144,7 @@ const DashboardIndicatorLineChartBlock = ({
     yAxis: {
       type: 'value',
       name: unit,
+      ...getYAxisBounds(indicator?.minValue, indicator?.maxValue),
       min: 0,
       axisLabel: { color: theme.textColor.primary },
     },

--- a/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock.tsx
@@ -19,6 +19,7 @@ import {
   buildGoalSeries,
   buildTotalSeries,
   buildTrendSeries,
+  buildTooltipFormatter,
 } from './indicator-charts-utility';
 
 echarts.use([
@@ -107,7 +108,7 @@ const DashboardIndicatorLineChartBlock = ({
 
   const legendData = [
     ...dimSeries.map((d) => d.name),
-    ...(seriesTotal.length ? ['Total'] : []),
+    ...(showTotalLine && totalRaw.length ? [totalDef.name] : []),
     ...(goalSeries.length ? ['Goal'] : []),
     ...(trendSeries.length ? ['Trend'] : []),
   ];
@@ -124,23 +125,13 @@ const DashboardIndicatorLineChartBlock = ({
       trigger: 'axis',
       appendTo: 'body',
       axisPointer: { type: 'line' },
-      formatter: (params) => {
-        const processedSeries = new Set<string>();
-        const paramsArray = Array.isArray(params) ? params : [params];
-        const year = paramsArray[0]?.data?.[0];
-        const rows = paramsArray
-          .filter((p) => {
-            if (!legendData.includes(p.seriesName)) return false;
-            if (processedSeries.has(p.seriesName)) return false;
-            processedSeries.add(p.seriesName);
-            return true;
-          })
-          .map((p) => {
-            const v = (p.data as any[])[1] as number;
-            return `${p.marker} ${p.seriesName}: ${v.toFixed(1)} ${unit}`;
-          });
-        return `<strong>${year}</strong><br/>${rows.join('<br/>')}`;
-      },
+      formatter: buildTooltipFormatter(
+        unit,
+        legendData,
+        t,
+        dimension,
+        indicator?.valueRounding
+      ),
     },
     grid: { left: 20, right: 20, top: 40, bottom: 60, containLabel: true },
     xAxis: {

--- a/components/contentblocks/indicator-chart/indicator-charts-utility.ts
+++ b/components/contentblocks/indicator-chart/indicator-charts-utility.ts
@@ -1,5 +1,6 @@
 import { linearRegression } from 'common/math';
 import { DashboardIndicatorLineChartBlock as TDashboardIndicatorLineChartBlock } from '@/common/__generated__/graphql';
+import { TFunction } from 'next-intl';
 
 export const X_SYMBOL =
   'path://M0.979266 20.7782C-0.192306 21.9497 -0.192307 23.8492 0.979266 25.0208C2.15084 26.1924 4.05033 26.1924 5.22191 ' +
@@ -135,4 +136,32 @@ export function buildTrendSeries(
         },
       ]
     : [];
+}
+
+export function buildTooltipFormatter(
+  unit: string,
+  legendData: string[],
+  t: TFunction,
+  dimension?: { name: string }
+) {
+  return (params: any[]) => {
+    const processedSeries = new Set<string>();
+    const paramsArray = Array.isArray(params) ? params : [params];
+    const year = paramsArray[0]?.axisValue;
+
+    const rows = paramsArray
+      .filter((p) => {
+        if (!legendData.includes(p.seriesName)) return false;
+        if (processedSeries.has(p.seriesName)) return false;
+        processedSeries.add(p.seriesName);
+        return true;
+      })
+      .map((p) => {
+        const value = typeof p.data === 'number' ? p.data.toFixed(1) : '-';
+        const name = dimension ? p.seriesName : t('total');
+        return `${p.marker} ${name}: ${value} ${unit}`;
+      });
+
+    return `${year}<br/>${rows.join('<br/>')}`;
+  };
 }

--- a/components/contentblocks/indicator-chart/indicator-charts-utility.ts
+++ b/components/contentblocks/indicator-chart/indicator-charts-utility.ts
@@ -1,6 +1,7 @@
 import { linearRegression } from 'common/math';
 import { DashboardIndicatorLineChartBlock as TDashboardIndicatorLineChartBlock } from '@/common/__generated__/graphql';
-import { TFunction } from 'next-intl';
+
+type TFunction = (key: string) => string;
 
 export const X_SYMBOL =
   'path://M0.979266 20.7782C-0.192306 21.9497 -0.192307 23.8492 0.979266 25.0208C2.15084 26.1924 4.05033 26.1924 5.22191 ' +
@@ -60,7 +61,8 @@ export function buildDimSeries(
 
 export function buildTotalSeries(
   chartSeries: TDashboardIndicatorLineChartBlock['chartSeries'],
-  totalLineColor: string
+  totalLineColor: string,
+  label = 'Total'
 ) {
   const totalMap = new Map<number, number>();
   chartSeries
@@ -74,7 +76,7 @@ export function buildTotalSeries(
 
   const totalRaw = Array.from(totalMap.entries()).sort((a, b) => a[0] - b[0]);
   return {
-    name: 'Total',
+    name: label,
     color: totalLineColor,
     raw: totalRaw,
   };
@@ -83,13 +85,14 @@ export function buildTotalSeries(
 export function buildGoalSeries(
   indicator: TDashboardIndicatorLineChartBlock['indicator'],
   unit: string,
-  goalLineColors: string[]
+  goalLineColors: string[],
+  label = 'Goal'
 ) {
   return (
     indicator?.goals?.map((g) => {
       const y = new Date(g.date).getFullYear();
       return {
-        name: 'Goal',
+        name: label,
         type: 'scatter' as const,
         symbol: X_SYMBOL,
         symbolSize: 10,
@@ -104,7 +107,8 @@ export function buildGoalSeries(
 export function buildTrendSeries(
   totalRaw: [number, number][],
   indicator: TDashboardIndicatorLineChartBlock['indicator'],
-  trendLineColor: string
+  trendLineColor: string,
+  label = 'Trend'
 ) {
   const regData = totalRaw.slice(-Math.min(totalRaw.length, 10));
   const predictedYears = regData.map(([yr]) => yr);
@@ -122,7 +126,7 @@ export function buildTrendSeries(
   return regData.length >= 2 && (indicator?.showTrendline ?? true)
     ? [
         {
-          name: 'Trend',
+          name: label,
           type: 'line' as const,
           symbol: 'none',
           showSymbol: false,
@@ -177,12 +181,7 @@ export function buildTooltipFormatter(
             ? formatValue(p.data)
             : '-';
 
-        const label =
-          p.seriesName === 'Goal'
-            ? t('goal')
-            : dimension
-            ? p.seriesName
-            : t('total');
+        const label = dimension ? p.seriesName : p.seriesName;
 
         return `${p.marker} ${label}: ${value} ${unit}`;
       });

--- a/components/contentblocks/indicator-chart/indicator-charts-utility.ts
+++ b/components/contentblocks/indicator-chart/indicator-charts-utility.ts
@@ -176,8 +176,15 @@ export function buildTooltipFormatter(
             : typeof p.data === 'number'
             ? formatValue(p.data)
             : '-';
-        const name = dimension ? p.seriesName : t('total');
-        return `${p.marker} ${name}: ${value} ${unit}`;
+
+        const label =
+          p.seriesName === 'Goal'
+            ? t('goal')
+            : dimension
+            ? p.seriesName
+            : t('total');
+
+        return `${p.marker} ${label}: ${value} ${unit}`;
       });
 
     return `<strong>${year}</strong><br/>${rows.join('<br/>')}`;

--- a/components/contentblocks/indicator-chart/indicator-charts-utility.ts
+++ b/components/contentblocks/indicator-chart/indicator-charts-utility.ts
@@ -138,12 +138,25 @@ export function buildTrendSeries(
     : [];
 }
 
+export function buildValueFormatter(valueRounding?: number) {
+  return (value: number) => {
+    return valueRounding != null
+      ? value.toLocaleString(undefined, {
+          maximumSignificantDigits: valueRounding,
+        })
+      : `${value}`;
+  };
+}
+
 export function buildTooltipFormatter(
   unit: string,
   legendData: string[],
   t: TFunction,
-  dimension?: { name: string }
+  dimension?: { name: string },
+  valueRounding?: number
 ) {
+  const formatValue = buildValueFormatter(valueRounding);
+
   return (params: any[]) => {
     const processedSeries = new Set<string>();
     const paramsArray = Array.isArray(params) ? params : [params];
@@ -157,11 +170,16 @@ export function buildTooltipFormatter(
         return true;
       })
       .map((p) => {
-        const value = typeof p.data === 'number' ? p.data.toFixed(1) : '-';
+        const value =
+          Array.isArray(p.data) && typeof p.data[1] === 'number'
+            ? formatValue(p.data[1])
+            : typeof p.data === 'number'
+            ? formatValue(p.data)
+            : '-';
         const name = dimension ? p.seriesName : t('total');
         return `${p.marker} ${name}: ${value} ${unit}`;
       });
 
-    return `${year}<br/>${rows.join('<br/>')}`;
+    return `<strong>${year}</strong><br/>${rows.join('<br/>')}`;
   };
 }

--- a/components/contentblocks/indicator-chart/indicator-charts-utility.ts
+++ b/components/contentblocks/indicator-chart/indicator-charts-utility.ts
@@ -184,12 +184,41 @@ export function buildTooltipFormatter(
   };
 }
 
-export function getYAxisBounds(
-  minValue?: number | null,
-  maxValue?: number | null
+export function buildYAxisConfig(
+  unit: string,
+  indicator?: {
+    minValue?: number | null;
+    maxValue?: number | null;
+    ticksCount?: number | null;
+    ticksRounding?: number | null;
+  },
+  color?: string
 ) {
-  return {
-    min: typeof minValue === 'number' ? minValue : undefined,
-    max: typeof maxValue === 'number' ? maxValue : undefined,
+  const yAxis: any = {
+    type: 'value',
+    name: unit,
+    axisLabel: {
+      color,
+      formatter: (value: number) => {
+        const rounding = indicator?.ticksRounding;
+        if (rounding != null) {
+          const rounded = Number(value).toPrecision(rounding);
+          return Number(rounded).toLocaleString();
+        }
+        return value;
+      },
+    },
   };
+
+  if (typeof indicator?.minValue === 'number') {
+    yAxis.min = indicator.minValue;
+  }
+  if (typeof indicator?.maxValue === 'number') {
+    yAxis.max = indicator.maxValue;
+  }
+  if (typeof indicator?.ticksCount === 'number') {
+    yAxis.splitNumber = indicator.ticksCount;
+  }
+
+  return yAxis;
 }

--- a/components/contentblocks/indicator-chart/indicator-charts-utility.ts
+++ b/components/contentblocks/indicator-chart/indicator-charts-utility.ts
@@ -183,3 +183,13 @@ export function buildTooltipFormatter(
     return `<strong>${year}</strong><br/>${rows.join('<br/>')}`;
   };
 }
+
+export function getYAxisBounds(
+  minValue?: number | null,
+  maxValue?: number | null
+) {
+  return {
+    min: typeof minValue === 'number' ? minValue : undefined,
+    max: typeof maxValue === 'number' ? maxValue : undefined,
+  };
+}

--- a/fragments/dashboard-indicator-block.fragment.ts
+++ b/fragments/dashboard-indicator-block.fragment.ts
@@ -5,6 +5,8 @@ export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
     name
     description
     valueRounding
+    minValue
+    maxValue
     latestValue {
       value
       date

--- a/fragments/dashboard-indicator-block.fragment.ts
+++ b/fragments/dashboard-indicator-block.fragment.ts
@@ -94,6 +94,28 @@ export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
 
       ... on DashboardIndicatorBarChartBlock {
         id
+        barType
+        helpText
+        chartSeries {
+          dimensionCategory {
+            id
+            name
+            defaultColor
+          }
+          values {
+            id
+            value
+            date
+          }
+        }
+        dimension {
+          id
+          name
+          categories {
+            id
+            name
+          }
+        }
         indicator {
           ...DashboardIndicatorFragment
         }

--- a/fragments/dashboard-indicator-block.fragment.ts
+++ b/fragments/dashboard-indicator-block.fragment.ts
@@ -4,6 +4,7 @@ export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
   fragment DashboardIndicatorFragment on Indicator {
     name
     description
+    valueRounding
     latestValue {
       value
       date

--- a/fragments/dashboard-indicator-block.fragment.ts
+++ b/fragments/dashboard-indicator-block.fragment.ts
@@ -4,6 +4,7 @@ export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
   fragment DashboardIndicatorFragment on Indicator {
     name
     description
+    showTrendline
     valueRounding
     minValue
     maxValue

--- a/fragments/dashboard-indicator-block.fragment.ts
+++ b/fragments/dashboard-indicator-block.fragment.ts
@@ -87,6 +87,27 @@ export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
 
       ... on DashboardIndicatorAreaChartBlock {
         id
+        helpText
+        chartSeries {
+          dimensionCategory {
+            id
+            name
+            defaultColor
+          }
+          values {
+            id
+            value
+            date
+          }
+        }
+        dimension {
+          id
+          name
+          categories {
+            id
+            name
+          }
+        }
         indicator {
           ...DashboardIndicatorFragment
         }

--- a/fragments/dashboard-indicator-block.fragment.ts
+++ b/fragments/dashboard-indicator-block.fragment.ts
@@ -7,6 +7,8 @@ export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
     valueRounding
     minValue
     maxValue
+    ticksCount
+    ticksRounding
     latestValue {
       value
       date


### PR DESCRIPTION
Add the new blocks for the bar and area charts based on e-charts for indicators visualisation. 

Asana tasks: https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1210259161444271?focus=true and https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1210259161444275?focus=true.

* Implemented Bar Chart Block:
  - Dynamically renders grouped or stacked bars based on the admin settings;
  - Supports both total and dimensions with categories.
  - Bar charts don't support trendlines or goal markers.
 * Implemented Area Chart Block:
     - Supports both total and dimensional indicators.
     - Displays total and trendline only when no dimension is selected (for total values only).
     - Don't support goal markers.
  * Added support for the admin indicator visualisation settings: `minValue`, `maxValue`, `valueRounding`, `ticksCount`, `ticksRounding`.
  
  Bar charts (grouped):
  
<img width="1315" alt="bar-charts-grouped" src="https://github.com/user-attachments/assets/93edb662-30fa-433b-84c9-2ebf0774f357" />

Bar charts (stacked):

<img width="1315" alt="bar-charts-stacked" src="https://github.com/user-attachments/assets/0d29a124-eae7-4a56-b972-ec0cbd4ec208" />

Area charts:

<img width="1303" alt="area-charts" src="https://github.com/user-attachments/assets/8c14bffa-28c8-4dd0-bf6b-cb7f7a9170db" />
