### PR TITLE
Apply selected in admin size to ArcGIS embeds

### DIFF
--- a/components/common/StreamField.tsx
+++ b/components/common/StreamField.tsx
@@ -40,6 +40,7 @@ enum EmbedProvider {
   YOUTUBE = 'YouTube',
   PLOTLY = 'Plotly Chart Studio',
   POWERBI = 'PowerBI',
+  ARCGIS = 'ArcGIS',
   DEFAULT = 'default',
 }
 
@@ -108,6 +109,24 @@ const ResponsiveStyles = styled.div`
     &.responsive-object-large {
       iframe {
         height: 800px;
+      }
+    }
+  }
+
+  .responsive-object[data-embed-provider='${EmbedProvider.ARCGIS}'] {
+    &.responsive-object-small {
+      iframe {
+        height: 400px !important;
+      }
+    }
+    &.responsive-object-medium {
+      iframe {
+        height: 600px !important;
+      }
+    }
+    &.responsive-object-large {
+      iframe {
+        height: 800px !important;
       }
     }
   }


### PR DESCRIPTION
Fix for an issue where ArcGIS embeds ignore the selected in the admin embed size (small, medium, large) and always rendering at a large height.
Asana - https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1210518770420421?focus=true

* The iframe content from ArcGIS sets its own height that overrides our responsive styling.
* Added a style block for ArcGIS embeds with fixed heights for the selected sizes and applied `!important` to override ArcGIS's default.