### PR TITLE
Support stacking option for area charts

### DIFF
--- a/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
@@ -81,7 +81,7 @@ const DashboardIndicatorAreaChartBlock = ({
     ? dimSeries.map((d) => ({
         name: d.name,
         type: 'line' as const,
-        areaStyle: {},
+        areaStyle: { opacity: 0.9 },
         symbol: 'none' as const,
         data: d.raw.map(([year, value]) => [String(year), value]),
         itemStyle: { color: d.color },
@@ -92,7 +92,7 @@ const DashboardIndicatorAreaChartBlock = ({
         {
           name: totalDef.name,
           type: 'line' as const,
-          areaStyle: {},
+          areaStyle: { opacity: 0.9 },
           symbol: 'circle' as const,
           symbolSize: 6,
           data: totalRaw.map(([year, value]) => [String(year), value]),

--- a/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
@@ -44,6 +44,7 @@ const DashboardIndicatorAreaChartBlock = ({
   }
 
   const hasDimension = !!dimension;
+  const stackable = indicator?.dataCategoriesAreStackable;
   const dimSeries = hasDimension ? buildDimSeries(chartSeries, palette) : [];
 
   const totalDef = buildTotalSeries(
@@ -101,6 +102,10 @@ const DashboardIndicatorAreaChartBlock = ({
         },
       ];
 
+  const seriesWithStack = stackable
+    ? series.map((s) => ({ ...s, stack: 'categories' }))
+    : series;
+
   const option: ECOption = {
     legend: {
       show: true,
@@ -132,7 +137,7 @@ const DashboardIndicatorAreaChartBlock = ({
       indicator,
       theme.textColor.primary
     ),
-    series: [...series, ...trendSeries],
+    series: [...seriesWithStack, ...trendSeries],
   };
 
   return (

--- a/fragments/dashboard-indicator-block.fragment.ts
+++ b/fragments/dashboard-indicator-block.fragment.ts
@@ -14,6 +14,7 @@ export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
       value
       date
     }
+    dataCategoriesAreStackable
     goals {
       value
       date


### PR DESCRIPTION
Support admin-controlled stacking in area charts
Asana - https://app.asana.com/1/1201243246741462/project/1209894862159781/task/1210617059962014?focus=true

* Added `dataCategoriesAreStackable` field to the GraphQL query;
* Enable admin-controlled stacking in the area chart.

<img width="411" alt="Screenshot 2025-06-24 at 11 21 01" src="https://github.com/user-attachments/assets/995e50d6-bba2-4de1-8b77-c29abd736541" />
