### PR TITLE
Make gridLeft dynamic based on unit name length

### DIFF
--- a/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
@@ -120,7 +120,13 @@ const DashboardIndicatorAreaChartBlock = ({
         indicator?.valueRounding
       ),
     },
-    grid: { left: 20, right: 20, top: 40, bottom: 60, containLabel: true },
+    grid: {
+      left: 20,
+      right: 20,
+      top: 40,
+      bottom: 60,
+      containLabel: true,
+    },
     xAxis: {
       type: 'category',
       data: xCategories,

--- a/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
@@ -100,7 +100,13 @@ const DashboardIndicatorBarChartBlock = ({
         indicator?.valueRounding
       ),
     },
-    grid: { left: 20, right: 20, top: 40, bottom: 60, containLabel: true },
+    grid: {
+      left: 20,
+      right: 20,
+      top: 40,
+      bottom: 60,
+      containLabel: true,
+    },
     xAxis: {
       type: 'category',
       data: xCategories,

--- a/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock.tsx
+++ b/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock.tsx
@@ -141,7 +141,13 @@ const DashboardIndicatorLineChartBlock = ({
         indicator?.valueRounding
       ),
     },
-    grid: { left: 20, right: 20, top: 40, bottom: 60, containLabel: true },
+    grid: {
+      left: 20,
+      right: 20,
+      top: 40,
+      bottom: 60,
+      containLabel: true,
+    },
     xAxis: {
       type: 'category',
       data: xCategories,

--- a/components/contentblocks/indicator-chart/indicator-charts-utility.ts
+++ b/components/contentblocks/indicator-chart/indicator-charts-utility.ts
@@ -203,6 +203,11 @@ export function buildYAxisConfig(
   const yAxis: any = {
     type: 'value',
     name: unit,
+    nameTextStyle: {
+      align: 'left',
+      padding: [0, 0, 0, -25],
+      fontSize: 12,
+    },
     axisLabel: {
       color,
       formatter: (value: number) => {


### PR DESCRIPTION
Unit label on Y-axis cropped if it's long  - Asana https://app.asana.com/1/1201243246741462/project/1209894862159781/task/1210615499515662?focus=true

* Applied padding to the y-axis label to prevent cropping

Before:
<img width="414" alt="Screenshot 2025-06-26 at 15 17 23" src="https://github.com/user-attachments/assets/6f1745b2-401d-4180-a166-93b593a39d3c" />

After:
<img width="417" alt="Screenshot 2025-06-26 at 15 15 50" src="https://github.com/user-attachments/assets/afcd7ad3-143a-4068-a5a6-1f41d659af7a" />
