### PR TITLE
Handle indentation for non-hierarchical indicators

### DIFF
--- a/components/indicators/IndicatorListFiltered.tsx
+++ b/components/indicators/IndicatorListFiltered.tsx
@@ -508,10 +508,12 @@ const IndicatorListFiltered = (props) => {
       options
     );
   };
-  const indentationLevel = (item) =>
-    item.common == null
-      ? 1
-      : (hierarchy[item.common.id]?.path?.length ?? 1) - 1;
+  const indentationLevel = (item) => {
+    if (!item.common || !hierarchy[item.common.id]) {
+      return 0;
+    }
+    return (hierarchy[item.common.id]?.path?.length ?? 1) - 1;
+  };
 
   const hierarchyEnabled =
     hierarchy != null && Object.keys(hierarchy).length > 1;


### PR DESCRIPTION
Bug fix: Incorrect indentation applied to non-hierarchical indicators (The grey boxes in the indicators organization column ).
Asana - https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1210376968726209?focus=true

* Updated `indentationLevel()` to return `0` for indicators that are not hierarchical.

Before:
<img width="1222" alt="Screenshot 2025-06-30 at 17 52 05" src="https://github.com/user-attachments/assets/5607a632-b481-4ba1-80d5-ec292ab0d571" />

After:
<img width="1178" alt="Screenshot 2025-06-30 at 17 52 34" src="https://github.com/user-attachments/assets/38ef509b-de87-41bb-b225-976c3e1c6bec" />

