### PR TITLE
Add missing translations for the data-not-available string

### DIFF
--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -16,7 +16,7 @@
     "copied-to-clipboard": "Kopieret!",
     "copy-to-clipboard": "Kopier link til udklipsholder",
     "current-trend": "tendens",
-    "data-not-available": "Data er ikke tilgængelige",
+    "data-not-available": "Ingen data. Fejl i blokkonfigurationen.",
     "dashboard": "Dashboard",
     "default-sorting": "Standardsortering",
     "email": "E-mail",

--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -16,6 +16,7 @@
     "copied-to-clipboard": "Kopieret!",
     "copy-to-clipboard": "Kopier link til udklipsholder",
     "current-trend": "tendens",
+    "data-not-available": "Data er ikke tilgængelige",
     "dashboard": "Dashboard",
     "default-sorting": "Standardsortering",
     "email": "E-mail",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -16,6 +16,7 @@
     "copied-to-clipboard": "Kopiert!",
     "copy-to-clipboard": "Link in die Zwischenablage kopieren",
     "current-trend": "Trend",
+    "data-not-available": "Daten sind nicht verfügbar",
     "dashboard": "Dashboard",
     "default-sorting": "Standardsortierung",
     "email": "E-Mail",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -16,7 +16,7 @@
     "copied-to-clipboard": "Kopiert!",
     "copy-to-clipboard": "Link in die Zwischenablage kopieren",
     "current-trend": "Trend",
-    "data-not-available": "Daten sind nicht verfügbar",
+    "data-not-available": "Keine Daten. Fehler in der Blockkonfiguration.",
     "dashboard": "Dashboard",
     "default-sorting": "Standardsortierung",
     "email": "E-Mail",

--- a/locales/el/common.json
+++ b/locales/el/common.json
@@ -14,7 +14,7 @@
     "copied-to-clipboard": "Αντιγραφή!",
     "copy-to-clipboard": "Αντιγραφή συνδέσμου στο πρόχειρο",
     "current-trend": "τάση",
-    "data-not-available": "Τα δεδομένα δεν είναι διαθέσιμα",
+    "data-not-available": "Δεν υπάρχουν δεδομένα. Σφάλμα στη διαμόρφωση του μπλοκ.",
     "dashboard": "Ταμπλό",
     "default-sorting": "Προεπιλεγμένη ταξινόμηση",
     "error": "Σφάλμα",

--- a/locales/el/common.json
+++ b/locales/el/common.json
@@ -14,6 +14,7 @@
     "copied-to-clipboard": "Αντιγραφή!",
     "copy-to-clipboard": "Αντιγραφή συνδέσμου στο πρόχειρο",
     "current-trend": "τάση",
+    "data-not-available": "Τα δεδομένα δεν είναι διαθέσιμα",
     "dashboard": "Ταμπλό",
     "default-sorting": "Προεπιλεγμένη ταξινόμηση",
     "error": "Σφάλμα",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -17,7 +17,7 @@
     "copy-to-clipboard": "Copy link to clipboard",
     "current-trend": "trend",
     "dashboard": "Dashboard",
-    "data-not-available": "Data is not available",
+    "data-not-available": "No data. Error in block configuration.",
     "default-sorting": "Default sorting",
     "email": "E-mail",
     "error": "Error",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -16,6 +16,7 @@
     "copied-to-clipboard": "¡Copiado!",
     "copy-to-clipboard": "Copiar enlace al portapapeles",
     "current-trend": "tendencia",
+    "data-not-available": "Los datos no están disponibles",
     "dashboard": "Cuadro de mandos",
     "default-sorting": "Clasificación por defecto",
     "email": "Correo electrónico",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -16,7 +16,7 @@
     "copied-to-clipboard": "¡Copiado!",
     "copy-to-clipboard": "Copiar enlace al portapapeles",
     "current-trend": "tendencia",
-    "data-not-available": "Los datos no están disponibles",
+    "data-not-available": "Sin datos. Error en la configuración del bloque.",
     "dashboard": "Cuadro de mandos",
     "default-sorting": "Clasificación por defecto",
     "email": "Correo electrónico",

--- a/locales/fi/common.json
+++ b/locales/fi/common.json
@@ -16,7 +16,7 @@
     "copied-to-clipboard": "Kopioitu!",
     "copy-to-clipboard": "Kopioi linkki leikepöydälle",
     "current-trend": "nykytrendi",
-    "data-not-available": "Tiedot eivät ole saatavilla",
+    "data-not-available": "Ei sisältöä. Virhe osion asetuksissa",
     "dashboard": "Tilannekuva",
     "default-sorting": "Oletusjärjestys",
     "email": "Sähköposti",

--- a/locales/fi/common.json
+++ b/locales/fi/common.json
@@ -16,6 +16,7 @@
     "copied-to-clipboard": "Kopioitu!",
     "copy-to-clipboard": "Kopioi linkki leikepöydälle",
     "current-trend": "nykytrendi",
+    "data-not-available": "Tiedot eivät ole saatavilla",
     "dashboard": "Tilannekuva",
     "default-sorting": "Oletusjärjestys",
     "email": "Sähköposti",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -1,7 +1,7 @@
 {
     "action": "{context, select, CASE_STUDY {Gadījuma izpēte} STRATEGY {Stratēģija} other {Rīcība}}",
     "actions": "{context, select, CASE_STUDY {Gadījumu izpēte} STRATEGY {Stratēģijas} other {Rīcības}}",
-    "data-not-available": "Dati nav pieejami",
+    "data-not-available": "Nav datu. Kļūda bloka konfigurācijā.",
     "select-sector-for-actions": "Izvēlieties emisiju nozari, lai skatītu saistītās rīcības",
     "no-phase": "Nav fāžu kopuma",
     "filter-all-statuses": "Visi statusi",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -1,6 +1,7 @@
 {
     "action": "{context, select, CASE_STUDY {Gadījuma izpēte} STRATEGY {Stratēģija} other {Rīcība}}",
     "actions": "{context, select, CASE_STUDY {Gadījumu izpēte} STRATEGY {Stratēģijas} other {Rīcības}}",
+    "data-not-available": "Dati nav pieejami",
     "select-sector-for-actions": "Izvēlieties emisiju nozari, lai skatītu saistītās rīcības",
     "no-phase": "Nav fāžu kopuma",
     "filter-all-statuses": "Visi statusi",

--- a/locales/pt-BR/common.json
+++ b/locales/pt-BR/common.json
@@ -17,7 +17,7 @@
     "copied-to-clipboard": "Copiado!",
     "copy-to-clipboard": "Copiar link para a área de transferência",
     "current-trend": "tendência",
-    "data-not-available": "Dados não disponíveis",
+    "data-not-available": "Sem dados. Erro na configuração do bloco.",
     "dashboard": "Painel de controle",
     "default-sorting": "Classificação padrão",
     "email": "E-mail",

--- a/locales/pt-BR/common.json
+++ b/locales/pt-BR/common.json
@@ -17,6 +17,7 @@
     "copied-to-clipboard": "Copiado!",
     "copy-to-clipboard": "Copiar link para a área de transferência",
     "current-trend": "tendência",
+    "data-not-available": "Dados não disponíveis",
     "dashboard": "Painel de controle",
     "default-sorting": "Classificação padrão",
     "email": "E-mail",

--- a/locales/sv/common.json
+++ b/locales/sv/common.json
@@ -16,7 +16,7 @@
     "copied-to-clipboard": "Kopierad!",
     "copy-to-clipboard": "Kopiera länk till urklipp",
     "current-trend": "trend",
-    "data-not-available": "Data är inte tillgängliga",
+    "data-not-available": "Ingen data. Fel i blockkonfigurationen.",
     "dashboard": "Instrumentbräda",
     "email": "E-post",
     "error-email-format": "Ange en giltig e-postadress",

--- a/locales/sv/common.json
+++ b/locales/sv/common.json
@@ -16,6 +16,7 @@
     "copied-to-clipboard": "Kopierad!",
     "copy-to-clipboard": "Kopiera länk till urklipp",
     "current-trend": "trend",
+    "data-not-available": "Data är inte tillgängliga",
     "dashboard": "Instrumentbräda",
     "email": "E-post",
     "error-email-format": "Ange en giltig e-postadress",


### PR DESCRIPTION
Add "data-not-available" locale string used in indicator graphs for all languages.