### PR TITLE
Feat/see full data link

### DIFF
--- a/locales/da/common.json
+++ b/locales/da/common.json
@@ -114,6 +114,7 @@
     "searching-for": "Søger efter \"{term}\"",
     "search-advanced": "Avanceret søgning",
     "search-no-results": "Ingen resultater for denne søgning. Prøv at ændre søgetermerne.",
+    "see-full-data": "Se fulde data →",
     "send": "Sende",
     "skip-to-content": "Hoppe til hovedindhold",
     "strategic-indicator": "Strategisk indikator",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -115,7 +115,7 @@
     "searching-for": "Suche nach \"{term}\"",
     "search-advanced": "Fortgeschrittene Suche",
     "search-no-results": "Keine Ergebnisse für diese Suche. Versuchen Sie, die Suchbegriffe zu ändern.",
-    "see-full-data": "Vollständige Daten anzeigen →",
+    "see-full-data": "Alle Daten anzeigen →",
     "send": "Abschicken",
     "skip-to-content": "Zum Hauptinhalt springen",
     "strategic-indicator": "Strategischer Indikator",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -115,6 +115,7 @@
     "searching-for": "Suche nach \"{term}\"",
     "search-advanced": "Fortgeschrittene Suche",
     "search-no-results": "Keine Ergebnisse für diese Suche. Versuchen Sie, die Suchbegriffe zu ändern.",
+    "see-full-data": "Vollständige Daten anzeigen →",
     "send": "Abschicken",
     "skip-to-content": "Zum Hauptinhalt springen",
     "strategic-indicator": "Strategischer Indikator",

--- a/locales/el/common.json
+++ b/locales/el/common.json
@@ -117,6 +117,7 @@
     "see-all-results": "Δείτε όλα τα αποτελέσματα {count}",
     "searching-for": "Αναζήτηση για \"{term}\"",
     "search-advanced": "Σύνθετη αναζήτηση",
+    "see-full-data": "Δείτε όλα τα δεδομένα →",
     "send": "Στείλτε",
     "skip-to-content": "Μετάβαση στο κύριο περιεχόμενο",
     "strategic-indicator": "Στρατηγικός δείκτης",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -119,6 +119,7 @@
     "searching-for": "Searching for \"{term}\"",
     "search-advanced": "Advanced search",
     "search-no-results": "No results for this search. Try changing the search terms.",
+    "see-full-data": "See full data →",
     "send": "Send",
     "skip-to-content": "Skip to main content",
     "strategic-indicator": "Strategic indicator",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -114,6 +114,7 @@
     "searching-for": "Búsqueda de \"{term}\"",
     "search-advanced": "Búsqueda avanzada",
     "search-no-results": "No hay resultados para esta búsqueda. Pruebe a cambiar los términos de búsqueda.",
+    "see-full-data": "Ver datos completos →",
     "send": "Envíe",
     "skip-to-content": "Ir al contenido principal",
     "strategic-indicator": "Indicador estratégico",

--- a/locales/fi/common.json
+++ b/locales/fi/common.json
@@ -115,6 +115,7 @@
     "searching-for": "Haetaan: \"{term}\"",
     "search-advanced": "Lisää hakuvaihtoehtoja",
     "search-no-results": "Haulla ei löytynyt tuloksia. Yritä muokata hakuehtoja.",
+    "see-full-data": "Näytä kaikki tiedot →",
     "send": "Lähetä",
     "skip-to-content": "Hyppää sisältöön",
     "strategic-indicator": "Strateginen mittari",

--- a/locales/lv/common.json
+++ b/locales/lv/common.json
@@ -145,6 +145,7 @@
     "searching-for": "Meklēšana \"{term}\"",
     "search-advanced": "Izvērstā meklēšana",
     "search-no-results": "Šai meklēšanai nav rezultātu. Mēģiniet mainīt meklēšanas noteikumus.",
+    "see-full-data": "Skatīt visus datus →",
     "send": "Sūtīt",
     "skip-to-content": "Pāriet uz galveno saturu",
     "supported-by": "Atbalsta",

--- a/locales/pt-BR/common.json
+++ b/locales/pt-BR/common.json
@@ -118,6 +118,7 @@
     "searching-for": "Pesquisando por \"{term}\"",
     "search-advanced": "Pesquisa avançada",
     "search-no-results": "Não há resultados para esta pesquisa. Tente alterar os termos de pesquisa.",
+    "see-full-data": "Ver dados completos →",
     "send": "Enviar",
     "skip-to-content": "Pular para o conteúdo principal",
     "strategic-indicator": "Indicador estratégico",

--- a/locales/sv/common.json
+++ b/locales/sv/common.json
@@ -104,6 +104,7 @@
     "search-advanced": "Fler sökalternativ",
     "search-no-results": "Inga resultat",
     "send": "Skicka",
+    "see-full-data": "Visa fullständig data →",
     "skip-to-content": "Hoppa till huvudinnehåll",
     "strategic-indicator": "Strategisk indikator",
     "supported-by": "Stöds av",

--- a/src/components/contentblocks/DashboardRowBlock.tsx
+++ b/src/components/contentblocks/DashboardRowBlock.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { Container, Row, Col } from 'reactstrap';
 import styled from 'styled-components';
+import { useTranslations } from 'next-intl';
 
 import {
   DashboardIndicatorAreaChartBlock,
@@ -140,6 +141,7 @@ const DashboardRowBlock = ({
   topMargin = true,
   bottomMargin = true,
 }: DashboardRowBlockProps) => {
+  const t = useTranslations();
   const columnWidth = 12 / blocks.length;
   const chartTypes = [
     'DashboardIndicatorPieChartBlock',
@@ -166,7 +168,7 @@ const DashboardRowBlock = ({
                   <DashboardCardContents block={block} />
                   {isChart && indicatorId && (
                     <StyledLink href={`/indicators/${indicatorId}`}>
-                      See full data →
+                      {t('see-full-data')}
                     </StyledLink>
                   )}
                 </StyledCard>

--- a/src/components/contentblocks/DashboardRowBlock.tsx
+++ b/src/components/contentblocks/DashboardRowBlock.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-
-import { Col, Container, Row } from 'reactstrap';
+import Link from 'next/link';
+import { Container, Row, Col } from 'reactstrap';
 import styled from 'styled-components';
 
 import {
@@ -55,12 +55,34 @@ const StyledRow = styled(Row)`
 /* Style richtext content slightly smaller on dashboard cards*/
 const StyledCard = styled(Card)`
   height: 100%;
+  display: flex;
+  flex-direction: column;
+
+  .card-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
 
   h2 {
     font-size: ${({ theme }) => theme.fontSizeLg};
   }
   h3 {
     font-size: ${({ theme }) => theme.fontSizeMd};
+  }
+`;
+
+const StyledLink = styled(Link)`
+  margin-top: auto;
+  padding-top: ${({ theme }) => theme.spaces.s200};
+  align-self: flex-end;
+  font-size: ${({ theme }) => theme.fontSizeSm};
+  text-decoration: none;
+  color: ${({ theme }) => theme.linkColor};
+
+  &:hover {
+    text-decoration: underline;
+    color: ${({ theme }) => theme.linkColor};
   }
 `;
 
@@ -78,7 +100,6 @@ function getBlockComponent(block: DashboardBlock) {
     }
     case 'DashboardIndicatorPieChartBlock': {
       const pieChartBlock = block as DashboardIndicatorPieChartBlock;
-
       return <DashboardIndicatorPieChartBlockComponent {...pieChartBlock} />;
     }
     case 'DashboardIndicatorLineChartBlock': {
@@ -99,8 +120,9 @@ function getBlockComponent(block: DashboardBlock) {
 const DashboardCardContents = ({ block }: { block: DashboardBlock }) => {
   const isSummaryBlock = block.blockType === 'DashboardIndicatorSummaryBlock';
   const title = !isSummaryBlock && 'indicator' in block ? block.indicator?.name : undefined;
-
   const helpText = !isSummaryBlock && 'helpText' in block ? block.helpText : undefined;
+
+
   const component = getBlockComponent(block);
 
   return (
@@ -119,18 +141,38 @@ const DashboardRowBlock = ({
   bottomMargin = true,
 }: DashboardRowBlockProps) => {
   const columnWidth = 12 / blocks.length;
+  const chartTypes = [
+    'DashboardIndicatorPieChartBlock',
+    'DashboardIndicatorLineChartBlock',
+    'DashboardIndicatorBarChartBlock',
+    'DashboardIndicatorAreaChartBlock',
+  ];
 
   return (
     <DashboardRowSection id={id ?? undefined} $topMargin={topMargin} $bottomMargin={bottomMargin}>
       <Container>
         <StyledRow>
-          {blocks.map((block, index) => (
-            <Col key={`${block.id}-${index}`} md={columnWidth}>
-              <StyledCard outline>
-                <DashboardCardContents block={block} />
-              </StyledCard>
-            </Col>
-          ))}
+          {blocks.map((block) => {
+            const { blockType } = block;
+            const isChart = chartTypes.includes(blockType);
+            const indicatorId =
+              isChart && 'indicator' in block && block.indicator
+                ? block.indicator.id
+                : undefined;
+
+            return (
+              <Col key={block.id} md={columnWidth}>
+                <StyledCard outline>
+                  <DashboardCardContents block={block} />
+                  {isChart && indicatorId && (
+                    <StyledLink href={`/indicators/${indicatorId}`}>
+                      See full data →
+                    </StyledLink>
+                  )}
+                </StyledCard>
+              </Col>
+            );
+          })}
         </StyledRow>
       </Container>
     </DashboardRowSection>

--- a/src/fragments/dashboard-indicator-block.fragment.ts
+++ b/src/fragments/dashboard-indicator-block.fragment.ts
@@ -2,6 +2,7 @@ import { gql } from '@apollo/client';
 
 export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
   fragment DashboardIndicatorFragment on Indicator {
+    id
     name
     description
     showTrendline


### PR DESCRIPTION
Add “See full data” link to the Indicator dashboard Chart cards redirecting to the indicator page

<img width="1421" alt="Screenshot 2025-07-03 at 18 03 17" src="https://github.com/user-attachments/assets/a9b708b9-9e69-4cbb-a2cb-63705a1552a7" />
 