### PR TITLE
Handle undefined href in RichText

### DIFF
--- a/components/common/RichText.tsx
+++ b/components/common/RichText.tsx
@@ -256,12 +256,18 @@ export default function RichText(props: RichTextProps) {
             </a>
           );
         }
+        const href = attribs?.href;
+
+        if (!href || typeof href !== 'string') {
+          return <span>{domToReact(children, options)}</span>;
+        }
+
         // Internal link
         if (
-          cutHttp(attribs.href.split('.')[0]) === currentDomain ||
-          attribs.href.startsWith('#')
+          cutHttp(href.split('.')[0]) === currentDomain ||
+          href.startsWith('#')
         ) {
-          return <a href={attribs.href}>{domToReact(children, options)}</a>;
+          return <a href={href}>{domToReact(children, options)}</a>;
         }
         // Assumed external link, open in new tab
         return (


### PR DESCRIPTION
Fix TypeError in RichText caused by undefined href attributes

Sentry: TypeError: t.href is undefined
Asana - https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1210797966604497?focus=true

