### PR TITLE
Update robots file to be generated dynamically

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,8 @@
-import { MetadataRoute } from 'next';
+import type { MetadataRoute } from 'next';
 
 import { deploymentType } from '@/common/environment';
+
+export const dynamic = 'force-dynamic';
 
 export default function robots(): MetadataRoute.Robots {
   return {


### PR DESCRIPTION
It seems `DEPLOYMENT_TYPE` is only available at runtime, which causes an incorrect `robots.txt` file to be generated in production as its currently statically generated. This change forces `robots.txt` to be generated dynamically for each request, ensuring we get the correct `production` runtime variable.