### PR TITLE
Override legends for area charts to match pie

### DIFF
--- a/src/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
+++ b/src/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
@@ -3,7 +3,12 @@
 import React from 'react';
 
 import { LineChart } from 'echarts/charts';
-import { GridComponent, LegendComponent, TooltipComponent } from 'echarts/components';
+import {
+  GridComponent,
+  LegendComponent,
+  type LegendComponentOption,
+  TooltipComponent,
+} from 'echarts/components';
 import * as echarts from 'echarts/core';
 import { useTranslations } from 'next-intl';
 import { useTheme } from 'styled-components';
@@ -55,10 +60,20 @@ const DashboardIndicatorAreaChartBlock = ({ chartSeries, indicator, dimension }:
       ? buildTrendSeries(totalRaw, indicator, graphsTheme.trendLineColor ?? '#aaa', trendLabel)
       : [];
 
-  const legendData = [
+  const legendLabels: string[] = [
     ...(hasDimension ? dimSeries.map((d) => d.name) : [totalLabel]),
     ...(trendSeries.length ? [trendLabel] : []),
   ];
+
+  const areaLegendItems: LegendComponentOption['data'] = hasDimension
+    ? dimSeries.map((d) => ({ name: d.name, icon: 'roundRect' as const }))
+    : [{ name: totalLabel, icon: 'roundRect' as const }];
+
+  const trendLegendItems: LegendComponentOption['data'] = trendSeries.length
+    ? [{ name: trendLabel }]
+    : [];
+
+  const legendData: LegendComponentOption['data'] = [...areaLegendItems, ...trendLegendItems];
 
   const xCategories = Array.from(
     new Set([
@@ -106,7 +121,7 @@ const DashboardIndicatorAreaChartBlock = ({ chartSeries, indicator, dimension }:
       trigger: 'axis',
       appendTo: 'body',
       axisPointer: { type: 'line' },
-      formatter: buildTooltipFormatter(unit, legendData, t, dimension, indicator?.valueRounding),
+      formatter: buildTooltipFormatter(unit, legendLabels, t, dimension, indicator?.valueRounding),
     },
     grid: {
       left: 20,


### PR DESCRIPTION
Indicators Dashboard: Visually align area chart legends with pie (or bar) charts.
Asana - https://app.asana.com/1/1201243246741462/project/1209894862159781/task/1210912656811919?focus=true

* Override area charts legends to use `roundRect` icons (like pie-charts).

Before:

<img width="417" height="494" alt="before" src="https://github.com/user-attachments/assets/f6aa2e4b-0a1f-410d-b98f-2be133e8af67" />


After:

<img width="418" height="495" alt="after" src="https://github.com/user-attachments/assets/975ad6f4-8f1f-4edc-9b86-2f62337eebda" />
