### PR TITLE
Fix continuous action filter

### DIFF
--- a/src/components/actions/ActionListFilters.tsx
+++ b/src/components/actions/ActionListFilters.tsx
@@ -934,7 +934,7 @@ class ContinuousActionFilter implements ActionListFilter<string | undefined> {
             role="switch"
             id={this.id}
             checked={value === '1'}
-            onChange={(e) => onChange(this.id, e.target.checked ? '1' : '0')}
+            onChange={(e) => onChange(this.id, e.target.checked ? '1' : '')}
           />
           <label htmlFor={this.id}>{this.label}</label>
         </FormGroup>


### PR DESCRIPTION
## Description
Previously the filter that makes the action list only show continuous actions did not work properly: if clicked once, it would work, but after turning it off again still only continuous actions remained on the list. By removing the url query parameter when the filter is toggled off, the filter works as expected.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
[Slack thread](https://kausaltech.slack.com/archives/C031Z5WMGJ0/p1758661184831889)

------

## ✅ Pre-Merge Checklist

### Testing
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    Go to action list of a plan with this particular filter (e.g. San Diego), see if the filter "Show only continuous actions" works as expected when toggled on and off.

### Internationalization & Accessibility
- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [x] **Dependencies are merged** (if applicable. If the change depends on other PR's e.g. kausal_common)

-----

## Screenshots/Videos (if applicable)
\-

## Additional Notes
This is a hotfix and probably not the best one: the url query parameter that the filter produces seems to behave exactly the same way whether the parameter says `continuous=0` or `continuous=1`, so there might be deeper root issues here. Someone with more knowledge of the frontend code might want to dig deeper!
