### PR TITLE
Fix bug which made secondary navigation disappear everywhere

### DIFF
--- a/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/ContentPage.tsx
+++ b/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/ContentPage.tsx
@@ -166,7 +166,7 @@ export default function ContentPage({ page }: { page: GeneralPlanPage }) {
 
   // Restrict the secondary nav to be shown on StaticPages only currently
   const siblings = secondaryNavParent
-    ? typenameMatches(secondaryNavParent, 'StaticPage')
+    ? typenameMatches(page, 'StaticPage')
       ? (secondaryNavParent.children ?? [])
       : []
     : [];


### PR DESCRIPTION
Bug Introduced in 08ccd270060b21d679ed801878dd973dcc14514e The conditional was refactored to check for the wrong page's type

## Description
Check correct page's type

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related issue
E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs
Describe or link possible requirements, dependencies and related PRs here

------

## ✅ Pre-Merge Checklist

### Testing
- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [X] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
    Verify you're looking at a page in some plan with the setting "children use secondary navigation" checked. There should be a menu displayed at the top of the page for all those children pages.
### Internationalization & Accessibility
- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies
- [ ] **Dependencies are merged** (if applicable. If the change depends on other PR's e.g. kausal_common)

-----

## Screenshots/Videos (if applicable)
<img width="970" height="235" alt="image" src="https://github.com/user-attachments/assets/d92790e3-213f-461f-9bf2-e6c4f4eb6726" />

<img width="411" height="382" alt="image" src="https://github.com/user-attachments/assets/d7fd61fd-3448-4e9e-858c-1b03d597ab05" />

