### PR TITLE
CategoryPage: Group actions by category levels

### DIFF
--- a/e2e-tests/__generated__/graphql.ts
+++ b/e2e-tests/__generated__/graphql.ts
@@ -18,7 +18,6 @@ export type Scalars = {
   PointScalar: { input: any; output: any; }
   PositiveInt: { input: number; output: number; }
   UUID: { input: string; output: string; }
-  _Any: { input: any; output: any; }
 };
 
 /** An enumeration. */
@@ -202,12 +201,6 @@ export enum IndicatorTimeResolution {
   Year = 'YEAR'
 }
 
-export type InstanceContext = {
-  hostname: InputMaybe<Scalars['String']['input']>;
-  identifier: InputMaybe<Scalars['ID']['input']>;
-  locale: InputMaybe<Scalars['String']['input']>;
-};
-
 /** An enumeration. */
 export enum ModelAction {
   Add = 'ADD',
@@ -358,9 +351,13 @@ export type UserFeedbackMutationInput = {
   url: Scalars['String']['input'];
 };
 
+/** An enumeration. */
 export enum WorkflowState {
+  /** Approved */
   Approved = 'APPROVED',
+  /** Draft */
   Draft = 'DRAFT',
+  /** Published */
   Published = 'PUBLISHED'
 }
 
@@ -430,15 +427,15 @@ export type PlaywrightGetPlanInfoQuery = (
         ) | null, children: Array<(
           { id: string, page: { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' } }
           & { __typename: 'PageMenuItem' }
-        )> | null }
+        ) | null> | null }
         & { __typename: 'PageMenuItem' }
-      )> }
+      ) | null> }
       & { __typename: 'MainMenu' }
     ) | null }
     & { __typename: 'Plan' }
   ) | null, planIndicators: Array<(
     { id: string, name: string }
     & { __typename: 'Indicator' }
-  )> | null }
+  ) | null> | null }
   & { __typename: 'Query' }
 );

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -19,7 +19,6 @@ export type Scalars = {
   PointScalar: { input: any; output: any; }
   PositiveInt: { input: number; output: number; }
   UUID: { input: string; output: string; }
-  _Any: { input: any; output: any; }
 };
 
 /** An enumeration. */
@@ -203,12 +202,6 @@ export enum IndicatorTimeResolution {
   Year = 'YEAR'
 }
 
-export type InstanceContext = {
-  hostname: InputMaybe<Scalars['String']['input']>;
-  identifier: InputMaybe<Scalars['ID']['input']>;
-  locale: InputMaybe<Scalars['String']['input']>;
-};
-
 /** An enumeration. */
 export enum ModelAction {
   Add = 'ADD',
@@ -359,9 +352,13 @@ export type UserFeedbackMutationInput = {
   url: Scalars['String']['input'];
 };
 
+/** An enumeration. */
 export enum WorkflowState {
+  /** Approved */
   Approved = 'APPROVED',
+  /** Draft */
   Draft = 'DRAFT',
+  /** Published */
   Published = 'PUBLISHED'
 }
 
@@ -386,14 +383,14 @@ export type GetSitemapQuery = (
   { planIndicators: Array<(
     { id: string }
     & { __typename: 'Indicator' }
-  )> | null, plan: (
+  ) | null> | null, plan: (
     { primaryLanguage: string, otherLanguages: Array<string>, actions: Array<(
       { identifier: string }
       & { __typename: 'Action' }
     )>, pages: Array<(
       { urlPath: string }
       & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
-    )> | null }
+    ) | null> | null }
     & { __typename: 'Plan' }
   ) | null }
   & { __typename: 'Query' }
@@ -430,7 +427,7 @@ export type SearchQueryQueryVariables = Exact<{
 export type SearchQueryQuery = (
   { search: (
     { hits: Array<(
-      { id: string, title: string, url: string | null, highlight: string | null, plan: (
+      { id: string | null, title: string | null, url: string | null, highlight: string | null, plan: (
         { identifier: string, name: string, shortName: string | null, image: (
           { rendition: (
             { src: string }
@@ -442,7 +439,7 @@ export type SearchQueryQuery = (
           & { __typename: 'Organization' }
         ) }
         & { __typename: 'Plan' }
-      ), object: (
+      ) | null, object: (
         { identifier: string, primaryOrg: (
           { name: string, logo: (
             { rendition: (
@@ -471,9 +468,9 @@ export type SearchQueryQuery = (
         & { __typename: 'CategoryPage' }
       ) | null }
       & { __typename: 'SearchHit' }
-    )> }
+    ) | null> | null }
     & { __typename: 'SearchResults' }
-  ) }
+  ) | null }
   & { __typename: 'Query' }
 );
 
@@ -648,7 +645,7 @@ export type GetActionListQuery = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -674,7 +671,7 @@ export type GetActionListQuery = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )>, parent: (
+      )> | null, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -702,7 +699,7 @@ export type GetActionListQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -728,7 +725,7 @@ export type GetActionListQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -755,7 +752,7 @@ export type GetActionListQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -781,7 +778,7 @@ export type GetActionListQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -808,7 +805,7 @@ export type GetActionListQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -834,7 +831,7 @@ export type GetActionListQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null }
       & { __typename: 'Category' }
@@ -860,7 +857,7 @@ export type GetActionListQuery = (
       ) }
       & { __typename: 'Action' }
     ) | null, plan: (
-      { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+      { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
         { rendition: (
           { src: string }
           & { __typename: 'ImageRendition' }
@@ -986,7 +983,7 @@ export type GetActionListForBlockQuery = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -1012,7 +1009,7 @@ export type GetActionListForBlockQuery = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )>, parent: (
+      )> | null, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -1040,7 +1037,7 @@ export type GetActionListForBlockQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -1066,7 +1063,7 @@ export type GetActionListForBlockQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -1093,7 +1090,7 @@ export type GetActionListForBlockQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -1119,7 +1116,7 @@ export type GetActionListForBlockQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -1146,7 +1143,7 @@ export type GetActionListForBlockQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -1172,7 +1169,7 @@ export type GetActionListForBlockQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null }
       & { __typename: 'Category' }
@@ -1198,7 +1195,7 @@ export type GetActionListForBlockQuery = (
       ) }
       & { __typename: 'Action' }
     ) | null, plan: (
-      { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+      { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
         { rendition: (
           { src: string }
           & { __typename: 'ImageRendition' }
@@ -1273,10 +1270,10 @@ export type GetCategoriesForTreeMapQuery = (
       ) | null }
       & { __typename: 'Image' }
     ) | null, categoryPage: (
-      { id: string | null, title: string, path: string, slug: string, url: string | null, urlPath: string, depth: number | null, contentType: string, body: Array<{ __typename: 'ActionListBlock' | 'AdaptiveEmbedBlock' | 'CategoryListBlock' | 'IndicatorGroupBlock' | 'QuestionAnswerBlock' | 'RelatedIndicatorsBlock' } | (
+      { id: string | null, title: string, path: string, slug: string, url: string | null, urlPath: string, depth: number | null, contentType: string, body: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' } | { __typename: 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
         { value: string }
         & { __typename: 'RichTextBlock' }
-      )> | null }
+      ) | null> | null }
       & { __typename: 'CategoryPage' }
     ) | null, parent: (
       { id: string }
@@ -1290,9 +1287,9 @@ export type GetCategoriesForTreeMapQuery = (
     ), attributes: Array<{ __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeRichText' | 'AttributeText' } | (
       { value: number }
       & { __typename: 'AttributeNumericValue' }
-    )> }
+    )> | null }
     & { __typename: 'Category' }
-  )> | null }
+  ) | null> | null }
   & { __typename: 'Query' }
 );
 
@@ -1332,7 +1329,7 @@ export type PlanFragmentFragment = (
   )>, primaryOrgs: Array<(
     { id: string, abbreviation: string | null, name: string }
     & { __typename: 'Organization' }
-  )> }
+  ) | null> }
   & { __typename: 'Plan' }
 );
 
@@ -1356,7 +1353,7 @@ export type ActionFragmentFragment = (
     { identifier: ActionTimelinessIdentifier }
     & { __typename: 'ActionTimeliness' }
   ), plan?: (
-    { id: string, shortName: string | null, name: string, shortIdentifier: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+    { id: string, shortName: string | null, name: string, shortIdentifier: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
       { rendition: (
         { src: string }
         & { __typename: 'ImageRendition' }
@@ -1491,7 +1488,7 @@ export type DashboardActionListQuery = (
     )>, primaryOrgs: Array<(
       { id: string, abbreviation: string | null, name: string }
       & { __typename: 'Organization' }
-    )> }
+    ) | null> }
     & { __typename: 'Plan' }
   ) | null, planActions?: Array<(
     { id: string, identifier: string, name: string, viewUrl?: string, color: string | null, hasDependencyRelationships: boolean | null, manualStatusReason: string | null, completion: number | null, officialName: string | null, updatedAt: string, scheduleContinuous: boolean, startDate: string | null, endDate: string | null, order: number, indicatorsCount: number | null, hasIndicatorsWithGoals: boolean | null, status: (
@@ -1513,7 +1510,7 @@ export type DashboardActionListQuery = (
       { identifier: ActionTimelinessIdentifier }
       & { __typename: 'ActionTimeliness' }
     ), plan?: (
-      { id: string, shortName: string | null, name: string, shortIdentifier: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+      { id: string, shortName: string | null, name: string, shortIdentifier: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
         { rendition: (
           { src: string }
           & { __typename: 'ImageRendition' }
@@ -1618,7 +1615,7 @@ export type DashboardActionListQuery = (
       { identifier: ActionTimelinessIdentifier }
       & { __typename: 'ActionTimeliness' }
     ), plan?: (
-      { id: string, shortName: string | null, name: string, shortIdentifier: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+      { id: string, shortName: string | null, name: string, shortIdentifier: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
         { rendition: (
           { src: string }
           & { __typename: 'ImageRendition' }
@@ -1858,7 +1855,7 @@ export type IndicatorHightlightListQuery = (
       & { __typename: 'IndicatorValue' }
     ) | null }
     & { __typename: 'Indicator' }
-  )> | null }
+  ) | null> | null }
   & { __typename: 'Query' }
 );
 
@@ -1883,12 +1880,12 @@ export type IndicatorListQuery = (
             { unit: (
               { shortName: string | null }
               & { __typename: 'Unit' }
-            ), normalizer: (
+            ) | null, normalizer: (
               { name: string, id: string, identifier: string | null }
               & { __typename: 'CommonIndicator' }
-            ) }
+            ) | null }
             & { __typename: 'CommonIndicatorNormalization' }
-          )> }
+          ) | null> | null }
           & { __typename: 'CommonIndicator' }
         ) | null, categories: Array<(
           { id: string, name: string, parent: (
@@ -1906,7 +1903,7 @@ export type IndicatorListQuery = (
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )> }
+          ) | null> | null }
           & { __typename: 'IndicatorValue' }
         ) | null, unit: (
           { shortName: string | null }
@@ -1915,7 +1912,7 @@ export type IndicatorListQuery = (
         & { __typename: 'Indicator' }
       ) }
       & { __typename: 'IndicatorLevel' }
-    )>, categoryTypes: Array<(
+    ) | null>, categoryTypes: Array<(
       { name: string, id: string, identifier: string, categories: Array<(
         { id: string, identifier: string, order: number, name: string, parent: (
           { id: string }
@@ -1956,7 +1953,7 @@ export type IndicatorListQuery = (
       & { __typename: 'CommonIndicator' }
     ) | null }
     & { __typename: 'Indicator' }
-  )> | null, relatedPlanIndicators?: Array<(
+  ) | null> | null, relatedPlanIndicators?: Array<(
     { id: string, name: string, level: string | null, timeResolution: IndicatorTimeResolution, organization: (
       { id: string, name: string }
       & { __typename: 'Organization' }
@@ -1965,12 +1962,12 @@ export type IndicatorListQuery = (
         { unit: (
           { shortName: string | null }
           & { __typename: 'Unit' }
-        ), normalizer: (
+        ) | null, normalizer: (
           { name: string, id: string, identifier: string | null }
           & { __typename: 'CommonIndicator' }
-        ) }
+        ) | null }
         & { __typename: 'CommonIndicatorNormalization' }
-      )> }
+      ) | null> | null }
       & { __typename: 'CommonIndicator' }
     ) | null, latestGraph: (
       { id: string }
@@ -1979,7 +1976,7 @@ export type IndicatorListQuery = (
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )> }
+      ) | null> | null }
       & { __typename: 'IndicatorValue' }
     ) | null, unit: (
       { shortName: string | null }
@@ -2029,12 +2026,12 @@ export type IndicatorGraphDataQuery = (
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )>, categories: Array<(
+      ) | null> | null, categories: Array<(
         { id: string }
         & { __typename: 'DimensionCategory' }
       )> }
       & { __typename: 'IndicatorValue' }
-    )>, dimensions: Array<(
+    ) | null> | null, dimensions: Array<(
       { dimension: (
         { id: string, name: string, categories: Array<(
           { id: string, name: string }
@@ -2047,7 +2044,7 @@ export type IndicatorGraphDataQuery = (
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )>, scenario: (
+      ) | null> | null, scenario: (
         { id: string }
         & { __typename: 'Scenario' }
       ) | null }
@@ -2060,12 +2057,12 @@ export type IndicatorGraphDataQuery = (
         { unit: (
           { shortName: string | null }
           & { __typename: 'Unit' }
-        ), normalizer: (
+        ) | null, normalizer: (
           { name: string, id: string, identifier: string | null }
           & { __typename: 'CommonIndicator' }
-        ) }
+        ) | null }
         & { __typename: 'CommonIndicatorNormalization' }
-      )>, indicators: Array<(
+      ) | null> | null, indicators: Array<(
         { id: string, timeResolution: IndicatorTimeResolution, minValue: number | null, maxValue: number | null, organization: (
           { id: string, name: string, abbreviation: string | null }
           & { __typename: 'Organization' }
@@ -2076,12 +2073,12 @@ export type IndicatorGraphDataQuery = (
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )>, categories: Array<(
+          ) | null> | null, categories: Array<(
             { id: string }
             & { __typename: 'DimensionCategory' }
           )> }
           & { __typename: 'IndicatorValue' }
-        )>, dimensions: Array<(
+        ) | null> | null, dimensions: Array<(
           { dimension: (
             { id: string, name: string, categories: Array<(
               { id: string, name: string }
@@ -2094,7 +2091,7 @@ export type IndicatorGraphDataQuery = (
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )>, scenario: (
+          ) | null> | null, scenario: (
             { id: string }
             & { __typename: 'Scenario' }
           ) | null }
@@ -2139,7 +2136,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
       { id: string, values: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorValue' }
-      )>, goals: Array<(
+      ) | null> | null, goals: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorGoal' }
       ) | null> | null, unit: (
@@ -2165,7 +2162,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
     ) | (
       { value: string, id: string, key: string }
       & { __typename: 'AttributeRichText' | 'AttributeText' }
-    )>, parent: (
+    )> | null, parent: (
       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -2193,7 +2190,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -2219,7 +2216,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -2246,7 +2243,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -2272,7 +2269,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null, level: (
         { id: string, name: string, namePlural: string | null }
@@ -2299,7 +2296,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -2325,7 +2322,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     ) | null }
     & { __typename: 'Category' }
@@ -2424,7 +2421,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
       { id: string, values: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorValue' }
-      )>, goals: Array<(
+      ) | null> | null, goals: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorGoal' }
       ) | null> | null, unit: (
@@ -2450,7 +2447,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
     ) | (
       { value: string, id: string, key: string }
       & { __typename: 'AttributeRichText' | 'AttributeText' }
-    )>, parent: (
+    )> | null, parent: (
       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -2478,7 +2475,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -2504,7 +2501,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -2531,7 +2528,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -2557,7 +2554,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null, level: (
         { id: string, name: string, namePlural: string | null }
@@ -2584,7 +2581,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -2610,7 +2607,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     ) | null }
     & { __typename: 'Category' }
@@ -2695,7 +2692,7 @@ export type ActionCardFragment = (
       { id: string, values: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorValue' }
-      )>, goals: Array<(
+      ) | null> | null, goals: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorGoal' }
       ) | null> | null, unit: (
@@ -2721,7 +2718,7 @@ export type ActionCardFragment = (
     ) | (
       { value: string, id: string, key: string }
       & { __typename: 'AttributeRichText' | 'AttributeText' }
-    )>, parent: (
+    )> | null, parent: (
       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -2749,7 +2746,7 @@ export type ActionCardFragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -2775,7 +2772,7 @@ export type ActionCardFragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -2802,7 +2799,7 @@ export type ActionCardFragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -2828,7 +2825,7 @@ export type ActionCardFragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null, level: (
         { id: string, name: string, namePlural: string | null }
@@ -2855,7 +2852,7 @@ export type ActionCardFragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -2881,7 +2878,7 @@ export type ActionCardFragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     ) | null }
     & { __typename: 'Category' }
@@ -2907,7 +2904,7 @@ export type ActionCardFragment = (
     ) }
     & { __typename: 'Action' }
   ) | null, plan: (
-    { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+    { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
       { rendition: (
         { src: string }
         & { __typename: 'ImageRendition' }
@@ -3133,7 +3130,7 @@ export type CategoryFragmentFragment = (
     { id: string, values: Array<(
       { date: string | null, value: number }
       & { __typename: 'IndicatorValue' }
-    )>, goals: Array<(
+    ) | null> | null, goals: Array<(
       { date: string | null, value: number }
       & { __typename: 'IndicatorGoal' }
     ) | null> | null, unit: (
@@ -3159,7 +3156,7 @@ export type CategoryFragmentFragment = (
   ) | (
     { value: string, id: string, key: string }
     & { __typename: 'AttributeRichText' | 'AttributeText' }
-  )> }
+  )> | null }
   & { __typename: 'Category' }
 );
 
@@ -3192,7 +3189,7 @@ export type CategoryWithParentsFragmentFragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -3218,7 +3215,7 @@ export type CategoryWithParentsFragmentFragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null, level: (
         { id: string, name: string, namePlural: string | null }
@@ -3245,7 +3242,7 @@ export type CategoryWithParentsFragmentFragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -3271,7 +3268,7 @@ export type CategoryWithParentsFragmentFragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     ) | null, level: (
       { id: string, name: string, namePlural: string | null }
@@ -3298,7 +3295,7 @@ export type CategoryWithParentsFragmentFragment = (
       { id: string, values: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorValue' }
-      )>, goals: Array<(
+      ) | null> | null, goals: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorGoal' }
       ) | null> | null, unit: (
@@ -3324,7 +3321,7 @@ export type CategoryWithParentsFragmentFragment = (
     ) | (
       { value: string, id: string, key: string }
       & { __typename: 'AttributeRichText' | 'AttributeText' }
-    )> }
+    )> | null }
     & { __typename: 'Category' }
   ) | null }
   & { __typename: 'Category' }
@@ -3356,7 +3353,7 @@ export type CategoryRecursiveFragmentFragment = (
     { id: string, values: Array<(
       { date: string | null, value: number }
       & { __typename: 'IndicatorValue' }
-    )>, goals: Array<(
+    ) | null> | null, goals: Array<(
       { date: string | null, value: number }
       & { __typename: 'IndicatorGoal' }
     ) | null> | null, unit: (
@@ -3382,7 +3379,7 @@ export type CategoryRecursiveFragmentFragment = (
   ) | (
     { value: string, id: string, key: string }
     & { __typename: 'AttributeRichText' | 'AttributeText' }
-  )>, parent: (
+  )> | null, parent: (
     { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -3410,7 +3407,7 @@ export type CategoryRecursiveFragmentFragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -3436,7 +3433,7 @@ export type CategoryRecursiveFragmentFragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null, level: (
         { id: string, name: string, namePlural: string | null }
@@ -3463,7 +3460,7 @@ export type CategoryRecursiveFragmentFragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -3489,7 +3486,7 @@ export type CategoryRecursiveFragmentFragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     ) | null, level: (
       { id: string, name: string, namePlural: string | null }
@@ -3516,7 +3513,7 @@ export type CategoryRecursiveFragmentFragment = (
       { id: string, values: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorValue' }
-      )>, goals: Array<(
+      ) | null> | null, goals: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorGoal' }
       ) | null> | null, unit: (
@@ -3542,7 +3539,7 @@ export type CategoryRecursiveFragmentFragment = (
     ) | (
       { value: string, id: string, key: string }
       & { __typename: 'AttributeRichText' | 'AttributeText' }
-    )> }
+    )> | null }
     & { __typename: 'Category' }
   ) | null }
   & { __typename: 'Category' }
@@ -3783,7 +3780,7 @@ type StreamFieldFragment_AccessibilityStatementContactInformationBlock_Fragment 
 );
 
 type StreamFieldFragment_ActionCategoryFilterCardsBlock_Fragment = (
-  { id: string | null, blockType: string, field: string, cards: Array<(
+  { id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
     { heading: string | null, lead: string | null, category: (
       { id: string, type: (
         { identifier: string }
@@ -3792,22 +3789,16 @@ type StreamFieldFragment_ActionCategoryFilterCardsBlock_Fragment = (
       & { __typename: 'Category' }
     ) | null }
     & { __typename: 'ActionCategoryFilterCardBlock' }
-  )> | null }
+  ) | null> | null }
   & { __typename: 'ActionCategoryFilterCardsBlock' }
 );
 
 type StreamFieldFragment_ActionListBlock_Fragment = (
-  { heading: string | null, helpText: string | null, id: string | null, blockType: string, field: string, categoryFilter: (
-    { id: string, type: (
-      { id: string }
-      & { __typename: 'CategoryType' }
-    ) }
+  { id: string | null, heading: string | null, helpText: string | null, blockType: string, field: string, categoryFilter: (
+    { id: string }
     & { __typename: 'Category' }
   ) | null, groupByCategoryLevel: (
-    { id: string, type: (
-      { id: string }
-      & { __typename: 'CategoryType' }
-    ) }
+    { id: string }
     & { __typename: 'CategoryLevel' }
   ) | null }
   & { __typename: 'ActionListBlock' }
@@ -3822,7 +3813,7 @@ type StreamFieldFragment_AdaptiveEmbedBlock_Fragment = (
 );
 
 type StreamFieldFragment_CardListBlock_Fragment = (
-  { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<(
+  { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
     { heading: string | null, content: string | null, link: string | null, image: (
       { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
         { id: string, width: number, height: number, src: string }
@@ -3843,12 +3834,12 @@ type StreamFieldFragment_CardListBlock_Fragment = (
       & { __typename: 'Image' }
     ) | null }
     & { __typename: 'CardBlock' }
-  )> | null }
+  ) | null> | null }
   & { __typename: 'CardListBlock' }
 );
 
 type StreamFieldFragment_CartographyVisualisationBlock_Fragment = (
-  { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string, account: (
+  { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string | null, account: (
     { provider: CartographyProviderCredentialsProvider, account: string, publicAccessToken: string }
     & { __typename: 'CartographyProviderCredentials' }
   ) }
@@ -3883,7 +3874,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -3909,7 +3900,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )>, parent: (
+      )> | null, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -3937,7 +3928,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -3963,7 +3954,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -3990,7 +3981,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -4016,7 +4007,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -4043,7 +4034,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -4069,7 +4060,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null }
       & { __typename: 'Category' }
@@ -4102,7 +4093,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -4128,7 +4119,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     )> }
     & { __typename: 'Category' }
@@ -4143,10 +4134,10 @@ type StreamFieldFragment_CategoryTreeMapBlock_Fragment = (
       & { __typename: 'Unit' }
     ) | null }
     & { __typename: 'AttributeType' }
-  ), treeMapCategoryType: (
+  ) | null, treeMapCategoryType: (
     { identifier: string }
     & { __typename: 'CategoryType' }
-  ) }
+  ) | null }
   & { __typename: 'CategoryTreeMapBlock' }
 );
 
@@ -4163,7 +4154,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
         { id: string, name: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -4210,7 +4201,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )>, parent: (
+      )> | null, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -4238,7 +4229,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -4264,7 +4255,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -4291,7 +4282,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -4317,7 +4308,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -4344,7 +4335,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -4370,7 +4361,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null }
       & { __typename: 'Category' }
@@ -4555,7 +4546,7 @@ type StreamFieldFragment_DashboardRowBlock_Fragment = (
 );
 
 type StreamFieldFragment_FrontPageHeroBlock_Fragment = (
-  { layout: string, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
+  { layout: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
     { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
       { id: string, width: number, height: number, src: string }
       & { __typename: 'ImageRendition' }
@@ -4586,7 +4577,7 @@ type StreamFieldFragment_IndicatorBlock_Fragment = (
 );
 
 type StreamFieldFragment_IndicatorGroupBlock_Fragment = (
-  { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<(
+  { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
     { style: string | null, indicator: (
       { id: string, identifier: string | null, name: string, description: string | null, timeResolution: IndicatorTimeResolution, level: string | null, unit: (
         { id: string, name: string }
@@ -4601,7 +4592,7 @@ type StreamFieldFragment_IndicatorGroupBlock_Fragment = (
       & { __typename: 'Indicator' }
     ) | null }
     & { __typename: 'IndicatorBlock' }
-  )> | null }
+  ) | null> | null }
   & { __typename: 'IndicatorGroupBlock' }
 );
 
@@ -4638,28 +4629,28 @@ type StreamFieldFragment_IndicatorShowcaseBlock_Fragment = (
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )>, categories: Array<(
+      ) | null> | null, categories: Array<(
         { id: string }
         & { __typename: 'DimensionCategory' }
       )> }
       & { __typename: 'IndicatorValue' }
-    )>, goals: Array<(
+    ) | null> | null, goals: Array<(
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )> }
+      ) | null> | null }
       & { __typename: 'IndicatorGoal' }
     ) | null> | null, common: (
       { id: string, normalizations: Array<(
         { unit: (
           { shortName: string | null, name: string }
           & { __typename: 'Unit' }
-        ), normalizer: (
+        ) | null, normalizer: (
           { name: string, id: string, identifier: string | null }
           & { __typename: 'CommonIndicator' }
-        ) }
+        ) | null }
         & { __typename: 'CommonIndicatorNormalization' }
-      )> }
+      ) | null> | null }
       & { __typename: 'CommonIndicator' }
     ) | null }
     & { __typename: 'Indicator' }
@@ -4711,10 +4702,10 @@ type StreamFieldFragment_PathsOutcomeBlock_Fragment = (
 );
 
 type StreamFieldFragment_QuestionAnswerBlock_Fragment = (
-  { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<(
-    { question: string, answer: string }
+  { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+    { question: string | null, answer: string | null }
     & { __typename: 'QuestionBlock' }
-  )> | null }
+  ) | null> | null }
   & { __typename: 'QuestionAnswerBlock' }
 );
 
@@ -4732,7 +4723,7 @@ export type GetActionDetailsQuery = (
   { action: (
     { id: string, identifier: string, name: string, officialName: string | null, leadParagraph: string, description: string | null, completion: number | null, color: string | null, updatedAt: string, manualStatusReason: string | null, scheduleContinuous: boolean, startDate: string | null, endDate: string | null, dateFormat: ActionDateFormat | null, workflowStatus: (
       { matchingVersion: (
-        { id: string, description: string | null }
+        { id: string | null, description: string | null }
         & { __typename: 'WorkflowStateDescription' }
       ) | null }
       & { __typename: 'WorkflowInfoNode' }
@@ -4792,7 +4783,7 @@ export type GetActionDetailsQuery = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -4818,7 +4809,7 @@ export type GetActionDetailsQuery = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )>, parent: (
+      )> | null, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -4846,7 +4837,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -4872,7 +4863,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -4899,7 +4890,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -4925,7 +4916,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -4952,7 +4943,7 @@ export type GetActionDetailsQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -4978,7 +4969,7 @@ export type GetActionDetailsQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null }
       & { __typename: 'Category' }
@@ -5038,7 +5029,7 @@ export type GetActionDetailsQuery = (
         ) | null, actions: Array<(
           { id: string, identifier: string, name: string }
           & { __typename: 'Action' }
-        )>, plans: Array<(
+        ) | null> | null, plans: Array<(
           { id: string }
           & { __typename: 'Plan' }
         )> }
@@ -5075,7 +5066,7 @@ export type GetActionDetailsQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -5101,7 +5092,7 @@ export type GetActionDetailsQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )>, parent: (
+        )> | null, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -5129,7 +5120,7 @@ export type GetActionDetailsQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -5155,7 +5146,7 @@ export type GetActionDetailsQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -5182,7 +5173,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -5208,7 +5199,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -5235,7 +5226,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -5261,7 +5252,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'Category' }
@@ -5287,7 +5278,7 @@ export type GetActionDetailsQuery = (
         ) }
         & { __typename: 'Action' }
       ) | null, plan: (
-        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
           { rendition: (
             { src: string }
             & { __typename: 'ImageRendition' }
@@ -5333,7 +5324,7 @@ export type GetActionDetailsQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -5359,7 +5350,7 @@ export type GetActionDetailsQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )>, parent: (
+        )> | null, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -5387,7 +5378,7 @@ export type GetActionDetailsQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -5413,7 +5404,7 @@ export type GetActionDetailsQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -5440,7 +5431,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -5466,7 +5457,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -5493,7 +5484,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -5519,7 +5510,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'Category' }
@@ -5545,7 +5536,7 @@ export type GetActionDetailsQuery = (
         ) }
         & { __typename: 'Action' }
       ) | null, plan: (
-        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
           { rendition: (
             { src: string }
             & { __typename: 'ImageRendition' }
@@ -5585,7 +5576,7 @@ export type GetActionDetailsQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -5611,7 +5602,7 @@ export type GetActionDetailsQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )>, parent: (
+        )> | null, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -5639,7 +5630,7 @@ export type GetActionDetailsQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -5665,7 +5656,7 @@ export type GetActionDetailsQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -5692,7 +5683,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -5718,7 +5709,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -5745,7 +5736,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -5771,7 +5762,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'Category' }
@@ -5797,7 +5788,7 @@ export type GetActionDetailsQuery = (
         ) }
         & { __typename: 'Action' }
       ) | null, plan: (
-        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
           { rendition: (
             { src: string }
             & { __typename: 'ImageRendition' }
@@ -5840,7 +5831,7 @@ export type GetActionDetailsQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -5866,7 +5857,7 @@ export type GetActionDetailsQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )>, parent: (
+        )> | null, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -5894,7 +5885,7 @@ export type GetActionDetailsQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -5920,7 +5911,7 @@ export type GetActionDetailsQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -5947,7 +5938,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -5973,7 +5964,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -6000,7 +5991,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -6026,7 +6017,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'Category' }
@@ -6095,8 +6086,8 @@ export type GetActionDetailsQuery = (
         & { __typename: 'DataPoint' }
       )> }
       & { __typename: 'Dataset' }
-    )>, plan: (
-      { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, image: (
+    ) | null> | null, plan: (
+      { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, image: (
         { rendition: (
           { src: string }
           & { __typename: 'ImageRendition' }
@@ -6141,7 +6132,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -6167,7 +6158,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -6195,7 +6186,7 @@ export type GetActionDetailsQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -6221,7 +6212,7 @@ export type GetActionDetailsQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -6248,7 +6239,7 @@ export type GetActionDetailsQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -6274,7 +6265,7 @@ export type GetActionDetailsQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -6301,7 +6292,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -6327,7 +6318,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -6353,7 +6344,7 @@ export type GetActionDetailsQuery = (
           ) }
           & { __typename: 'Action' }
         ) | null, plan: (
-          { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+          { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
             { rendition: (
               { src: string }
               & { __typename: 'ImageRendition' }
@@ -6396,7 +6387,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -6422,7 +6413,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -6450,7 +6441,7 @@ export type GetActionDetailsQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -6476,7 +6467,7 @@ export type GetActionDetailsQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -6503,7 +6494,7 @@ export type GetActionDetailsQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -6529,7 +6520,7 @@ export type GetActionDetailsQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -6556,7 +6547,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -6582,7 +6573,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -6608,7 +6599,7 @@ export type GetActionDetailsQuery = (
           ) }
           & { __typename: 'Action' }
         ) | null, plan: (
-          { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+          { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
             { rendition: (
               { src: string }
               & { __typename: 'ImageRendition' }
@@ -6628,13 +6619,13 @@ export type GetActionDetailsQuery = (
         { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, meta: (
           { restricted: boolean | null, hidden: boolean | null }
           & { __typename: 'FieldBlockMetaData' }
-        ) | null, fields: Array<(
-          { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+        ) | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+          { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
             { choiceLabel: string | null, choiceValue: string | null }
             & { __typename: 'FormChoiceBlock' }
-          )> }
+          ) | null> | null }
           & { __typename: 'FormFieldBlock' }
-        )> }
+        ) | null> | null }
         & { __typename: 'ActionContactFormBlock' }
       ) | (
         { id: string | null, meta: (
@@ -6683,13 +6674,13 @@ export type GetActionDetailsQuery = (
           { id: string | null }
           & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
         ) | (
-          { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
-            { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+          { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+            { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
               { choiceLabel: string | null, choiceValue: string | null }
               & { __typename: 'FormChoiceBlock' }
-            )> }
+            ) | null> | null }
             & { __typename: 'FormFieldBlock' }
-          )> }
+          ) | null> | null }
           & { __typename: 'ActionContactFormBlock' }
         ) | (
           { id: string | null, attributeType: (
@@ -6751,7 +6742,7 @@ export type GetActionDetailsQuery = (
                     { id: string, values: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorValue' }
-                    )>, goals: Array<(
+                    ) | null> | null, goals: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorGoal' }
                     ) | null> | null, unit: (
@@ -6777,7 +6768,7 @@ export type GetActionDetailsQuery = (
                   ) | (
                     { value: string, id: string, key: string }
                     & { __typename: 'AttributeRichText' | 'AttributeText' }
-                  )>, parent: (
+                  )> | null, parent: (
                     { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -6805,7 +6796,7 @@ export type GetActionDetailsQuery = (
                           { id: string, values: Array<(
                             { date: string | null, value: number }
                             & { __typename: 'IndicatorValue' }
-                          )>, goals: Array<(
+                          ) | null> | null, goals: Array<(
                             { date: string | null, value: number }
                             & { __typename: 'IndicatorGoal' }
                           ) | null> | null, unit: (
@@ -6831,7 +6822,7 @@ export type GetActionDetailsQuery = (
                         ) | (
                           { value: string, id: string, key: string }
                           & { __typename: 'AttributeRichText' | 'AttributeText' }
-                        )> }
+                        )> | null }
                         & { __typename: 'Category' }
                       ) | null, level: (
                         { id: string, name: string, namePlural: string | null }
@@ -6858,7 +6849,7 @@ export type GetActionDetailsQuery = (
                         { id: string, values: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorValue' }
-                        )>, goals: Array<(
+                        ) | null> | null, goals: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorGoal' }
                         ) | null> | null, unit: (
@@ -6884,7 +6875,7 @@ export type GetActionDetailsQuery = (
                       ) | (
                         { value: string, id: string, key: string }
                         & { __typename: 'AttributeRichText' | 'AttributeText' }
-                      )> }
+                      )> | null }
                       & { __typename: 'Category' }
                     ) | null, level: (
                       { id: string, name: string, namePlural: string | null }
@@ -6911,7 +6902,7 @@ export type GetActionDetailsQuery = (
                       { id: string, values: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorValue' }
-                      )>, goals: Array<(
+                      ) | null> | null, goals: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorGoal' }
                       ) | null> | null, unit: (
@@ -6937,7 +6928,7 @@ export type GetActionDetailsQuery = (
                     ) | (
                       { value: string, id: string, key: string }
                       & { __typename: 'AttributeRichText' | 'AttributeText' }
-                    )> }
+                    )> | null }
                     & { __typename: 'Category' }
                   ) | null }
                   & { __typename: 'Category' }
@@ -7059,7 +7050,7 @@ export type GetActionDetailsQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -7085,7 +7076,7 @@ export type GetActionDetailsQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )>, parent: (
+                )> | null, parent: (
                   { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                     { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -7113,7 +7104,7 @@ export type GetActionDetailsQuery = (
                         { id: string, values: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorValue' }
-                        )>, goals: Array<(
+                        ) | null> | null, goals: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorGoal' }
                         ) | null> | null, unit: (
@@ -7139,7 +7130,7 @@ export type GetActionDetailsQuery = (
                       ) | (
                         { value: string, id: string, key: string }
                         & { __typename: 'AttributeRichText' | 'AttributeText' }
-                      )> }
+                      )> | null }
                       & { __typename: 'Category' }
                     ) | null, level: (
                       { id: string, name: string, namePlural: string | null }
@@ -7166,7 +7157,7 @@ export type GetActionDetailsQuery = (
                       { id: string, values: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorValue' }
-                      )>, goals: Array<(
+                      ) | null> | null, goals: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorGoal' }
                       ) | null> | null, unit: (
@@ -7192,7 +7183,7 @@ export type GetActionDetailsQuery = (
                     ) | (
                       { value: string, id: string, key: string }
                       & { __typename: 'AttributeRichText' | 'AttributeText' }
-                    )> }
+                    )> | null }
                     & { __typename: 'Category' }
                   ) | null, level: (
                     { id: string, name: string, namePlural: string | null }
@@ -7219,7 +7210,7 @@ export type GetActionDetailsQuery = (
                     { id: string, values: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorValue' }
-                    )>, goals: Array<(
+                    ) | null> | null, goals: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorGoal' }
                     ) | null> | null, unit: (
@@ -7245,7 +7236,7 @@ export type GetActionDetailsQuery = (
                   ) | (
                     { value: string, id: string, key: string }
                     & { __typename: 'AttributeRichText' | 'AttributeText' }
-                  )> }
+                  )> | null }
                   & { __typename: 'Category' }
                 ) | null }
                 & { __typename: 'Category' }
@@ -7306,13 +7297,13 @@ export type GetActionDetailsQuery = (
         { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, meta: (
           { restricted: boolean | null, hidden: boolean | null }
           & { __typename: 'FieldBlockMetaData' }
-        ) | null, fields: Array<(
-          { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+        ) | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+          { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
             { choiceLabel: string | null, choiceValue: string | null }
             & { __typename: 'FormChoiceBlock' }
-          )> }
+          ) | null> | null }
           & { __typename: 'FormFieldBlock' }
-        )> }
+        ) | null> | null }
         & { __typename: 'ActionContactFormBlock' }
       ) | (
         { id: string | null, meta: (
@@ -7361,13 +7352,13 @@ export type GetActionDetailsQuery = (
           { id: string | null }
           & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
         ) | (
-          { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
-            { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+          { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+            { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
               { choiceLabel: string | null, choiceValue: string | null }
               & { __typename: 'FormChoiceBlock' }
-            )> }
+            ) | null> | null }
             & { __typename: 'FormFieldBlock' }
-          )> }
+          ) | null> | null }
           & { __typename: 'ActionContactFormBlock' }
         ) | (
           { id: string | null, attributeType: (
@@ -7429,7 +7420,7 @@ export type GetActionDetailsQuery = (
                     { id: string, values: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorValue' }
-                    )>, goals: Array<(
+                    ) | null> | null, goals: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorGoal' }
                     ) | null> | null, unit: (
@@ -7455,7 +7446,7 @@ export type GetActionDetailsQuery = (
                   ) | (
                     { value: string, id: string, key: string }
                     & { __typename: 'AttributeRichText' | 'AttributeText' }
-                  )>, parent: (
+                  )> | null, parent: (
                     { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -7483,7 +7474,7 @@ export type GetActionDetailsQuery = (
                           { id: string, values: Array<(
                             { date: string | null, value: number }
                             & { __typename: 'IndicatorValue' }
-                          )>, goals: Array<(
+                          ) | null> | null, goals: Array<(
                             { date: string | null, value: number }
                             & { __typename: 'IndicatorGoal' }
                           ) | null> | null, unit: (
@@ -7509,7 +7500,7 @@ export type GetActionDetailsQuery = (
                         ) | (
                           { value: string, id: string, key: string }
                           & { __typename: 'AttributeRichText' | 'AttributeText' }
-                        )> }
+                        )> | null }
                         & { __typename: 'Category' }
                       ) | null, level: (
                         { id: string, name: string, namePlural: string | null }
@@ -7536,7 +7527,7 @@ export type GetActionDetailsQuery = (
                         { id: string, values: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorValue' }
-                        )>, goals: Array<(
+                        ) | null> | null, goals: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorGoal' }
                         ) | null> | null, unit: (
@@ -7562,7 +7553,7 @@ export type GetActionDetailsQuery = (
                       ) | (
                         { value: string, id: string, key: string }
                         & { __typename: 'AttributeRichText' | 'AttributeText' }
-                      )> }
+                      )> | null }
                       & { __typename: 'Category' }
                     ) | null, level: (
                       { id: string, name: string, namePlural: string | null }
@@ -7589,7 +7580,7 @@ export type GetActionDetailsQuery = (
                       { id: string, values: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorValue' }
-                      )>, goals: Array<(
+                      ) | null> | null, goals: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorGoal' }
                       ) | null> | null, unit: (
@@ -7615,7 +7606,7 @@ export type GetActionDetailsQuery = (
                     ) | (
                       { value: string, id: string, key: string }
                       & { __typename: 'AttributeRichText' | 'AttributeText' }
-                    )> }
+                    )> | null }
                     & { __typename: 'Category' }
                   ) | null }
                   & { __typename: 'Category' }
@@ -7737,7 +7728,7 @@ export type GetActionDetailsQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -7763,7 +7754,7 @@ export type GetActionDetailsQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )>, parent: (
+                )> | null, parent: (
                   { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                     { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -7791,7 +7782,7 @@ export type GetActionDetailsQuery = (
                         { id: string, values: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorValue' }
-                        )>, goals: Array<(
+                        ) | null> | null, goals: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorGoal' }
                         ) | null> | null, unit: (
@@ -7817,7 +7808,7 @@ export type GetActionDetailsQuery = (
                       ) | (
                         { value: string, id: string, key: string }
                         & { __typename: 'AttributeRichText' | 'AttributeText' }
-                      )> }
+                      )> | null }
                       & { __typename: 'Category' }
                     ) | null, level: (
                       { id: string, name: string, namePlural: string | null }
@@ -7844,7 +7835,7 @@ export type GetActionDetailsQuery = (
                       { id: string, values: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorValue' }
-                      )>, goals: Array<(
+                      ) | null> | null, goals: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorGoal' }
                       ) | null> | null, unit: (
@@ -7870,7 +7861,7 @@ export type GetActionDetailsQuery = (
                     ) | (
                       { value: string, id: string, key: string }
                       & { __typename: 'AttributeRichText' | 'AttributeText' }
-                    )> }
+                    )> | null }
                     & { __typename: 'Category' }
                   ) | null, level: (
                     { id: string, name: string, namePlural: string | null }
@@ -7897,7 +7888,7 @@ export type GetActionDetailsQuery = (
                     { id: string, values: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorValue' }
-                    )>, goals: Array<(
+                    ) | null> | null, goals: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorGoal' }
                     ) | null> | null, unit: (
@@ -7923,7 +7914,7 @@ export type GetActionDetailsQuery = (
                   ) | (
                     { value: string, id: string, key: string }
                     & { __typename: 'AttributeRichText' | 'AttributeText' }
-                  )> }
+                  )> | null }
                   & { __typename: 'Category' }
                 ) | null }
                 & { __typename: 'Category' }
@@ -8077,7 +8068,7 @@ export type ActionDependenciesFragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -8103,7 +8094,7 @@ export type ActionDependenciesFragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )>, parent: (
+        )> | null, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -8131,7 +8122,7 @@ export type ActionDependenciesFragment = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -8157,7 +8148,7 @@ export type ActionDependenciesFragment = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -8184,7 +8175,7 @@ export type ActionDependenciesFragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -8210,7 +8201,7 @@ export type ActionDependenciesFragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -8237,7 +8228,7 @@ export type ActionDependenciesFragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -8263,7 +8254,7 @@ export type ActionDependenciesFragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'Category' }
@@ -8289,7 +8280,7 @@ export type ActionDependenciesFragment = (
         ) }
         & { __typename: 'Action' }
       ) | null, plan: (
-        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
           { rendition: (
             { src: string }
             & { __typename: 'ImageRendition' }
@@ -8332,7 +8323,7 @@ export type ActionDependenciesFragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -8358,7 +8349,7 @@ export type ActionDependenciesFragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )>, parent: (
+        )> | null, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -8386,7 +8377,7 @@ export type ActionDependenciesFragment = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -8412,7 +8403,7 @@ export type ActionDependenciesFragment = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -8439,7 +8430,7 @@ export type ActionDependenciesFragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -8465,7 +8456,7 @@ export type ActionDependenciesFragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -8492,7 +8483,7 @@ export type ActionDependenciesFragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -8518,7 +8509,7 @@ export type ActionDependenciesFragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'Category' }
@@ -8544,7 +8535,7 @@ export type ActionDependenciesFragment = (
         ) }
         & { __typename: 'Action' }
       ) | null, plan: (
-        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
           { rendition: (
             { src: string }
             & { __typename: 'ImageRendition' }
@@ -8613,13 +8604,13 @@ type ActionMainContentBlocksFragment_ActionContactFormBlock_Fragment = (
   { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, meta: (
     { restricted: boolean | null, hidden: boolean | null }
     & { __typename: 'FieldBlockMetaData' }
-  ) | null, fields: Array<(
-    { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+  ) | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+    { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
       { choiceLabel: string | null, choiceValue: string | null }
       & { __typename: 'FormChoiceBlock' }
-    )> }
+    ) | null> | null }
     & { __typename: 'FormFieldBlock' }
-  )> }
+  ) | null> | null }
   & { __typename: 'ActionContactFormBlock' }
 );
 
@@ -8674,13 +8665,13 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
     { id: string | null }
     & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
   ) | (
-    { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
-      { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+    { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+      { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
         { choiceLabel: string | null, choiceValue: string | null }
         & { __typename: 'FormChoiceBlock' }
-      )> }
+      ) | null> | null }
       & { __typename: 'FormFieldBlock' }
-    )> }
+    ) | null> | null }
     & { __typename: 'ActionContactFormBlock' }
   ) | (
     { id: string | null, attributeType: (
@@ -8742,7 +8733,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -8768,7 +8759,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )>, parent: (
+            )> | null, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                   { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -8796,7 +8787,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
                     { id: string, values: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorValue' }
-                    )>, goals: Array<(
+                    ) | null> | null, goals: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorGoal' }
                     ) | null> | null, unit: (
@@ -8822,7 +8813,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
                   ) | (
                     { value: string, id: string, key: string }
                     & { __typename: 'AttributeRichText' | 'AttributeText' }
-                  )> }
+                  )> | null }
                   & { __typename: 'Category' }
                 ) | null, level: (
                   { id: string, name: string, namePlural: string | null }
@@ -8849,7 +8840,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -8875,7 +8866,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -8902,7 +8893,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -8928,7 +8919,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null }
             & { __typename: 'Category' }
@@ -9062,7 +9053,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -9088,7 +9079,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -9116,7 +9107,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -9142,7 +9133,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -9169,7 +9160,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -9195,7 +9186,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -9222,7 +9213,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -9248,7 +9239,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -9342,7 +9333,7 @@ export type ReportComparisonBlockActionContentFragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -9368,7 +9359,7 @@ export type ReportComparisonBlockActionContentFragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -9396,7 +9387,7 @@ export type ReportComparisonBlockActionContentFragment = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -9422,7 +9413,7 @@ export type ReportComparisonBlockActionContentFragment = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -9449,7 +9440,7 @@ export type ReportComparisonBlockActionContentFragment = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -9475,7 +9466,7 @@ export type ReportComparisonBlockActionContentFragment = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -9502,7 +9493,7 @@ export type ReportComparisonBlockActionContentFragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -9528,7 +9519,7 @@ export type ReportComparisonBlockActionContentFragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -9620,7 +9611,7 @@ export type ActionCardWithDependencyRoleFragment = (
       { id: string, values: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorValue' }
-      )>, goals: Array<(
+      ) | null> | null, goals: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorGoal' }
       ) | null> | null, unit: (
@@ -9646,7 +9637,7 @@ export type ActionCardWithDependencyRoleFragment = (
     ) | (
       { value: string, id: string, key: string }
       & { __typename: 'AttributeRichText' | 'AttributeText' }
-    )>, parent: (
+    )> | null, parent: (
       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -9674,7 +9665,7 @@ export type ActionCardWithDependencyRoleFragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -9700,7 +9691,7 @@ export type ActionCardWithDependencyRoleFragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -9727,7 +9718,7 @@ export type ActionCardWithDependencyRoleFragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -9753,7 +9744,7 @@ export type ActionCardWithDependencyRoleFragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null, level: (
         { id: string, name: string, namePlural: string | null }
@@ -9780,7 +9771,7 @@ export type ActionCardWithDependencyRoleFragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -9806,7 +9797,7 @@ export type ActionCardWithDependencyRoleFragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     ) | null }
     & { __typename: 'Category' }
@@ -9832,7 +9823,7 @@ export type ActionCardWithDependencyRoleFragment = (
     ) }
     & { __typename: 'Action' }
   ) | null, plan: (
-    { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+    { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
       { rendition: (
         { src: string }
         & { __typename: 'ImageRendition' }
@@ -9988,13 +9979,13 @@ export type TemplatedCategoryPageFragmentFragment = (
       ) }
       & { __typename: 'CategoryPageAttributeTypeBlock' }
     ) | { __typename: 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' } | (
-      { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
-        { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+      { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
           { choiceLabel: string | null, choiceValue: string | null }
           & { __typename: 'FormChoiceBlock' }
-        )> }
+        ) | null> | null }
         & { __typename: 'FormFieldBlock' }
-      )> }
+      ) | null> | null }
       & { __typename: 'CategoryPageContactFormBlock' }
     ) | (
       { id: string | null, heading: string | null, helpText: string | null, datasetSchema: (
@@ -10054,7 +10045,22 @@ export type GetContentPageQuery = (
   { planPage: (
     { id: string | null, slug: string, title: string, lastPublishedAt: string | null, body: Array<(
       { id: string | null, blockType: string, field: string }
-      & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' }
+      & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' | 'ActionLinksBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorHighlightsBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'UpdatedAtColumnBlock' }
     ) | (
       { id: string | null, blockType: string, field: string, blocks: Array<(
         { id: string | null, field: string }
@@ -10083,9 +10089,900 @@ export type GetContentPageQuery = (
       )> }
       & { __typename: 'AccessibilityStatementContactInformationBlock' }
     ) | (
+      { id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { heading: string | null, lead: string | null, category: (
+          { id: string, type: (
+            { identifier: string }
+            & { __typename: 'CategoryType' }
+          ) }
+          & { __typename: 'Category' }
+        ) | null }
+        & { __typename: 'ActionCategoryFilterCardBlock' }
+      ) | null> | null }
+      & { __typename: 'ActionCategoryFilterCardsBlock' }
+    ) | (
+      { id: string | null, heading: string | null, helpText: string | null, blockType: string, field: string, categoryFilter: (
+        { id: string }
+        & { __typename: 'Category' }
+      ) | null, groupByCategoryLevel: (
+        { id: string }
+        & { __typename: 'CategoryLevel' }
+      ) | null }
+      & { __typename: 'ActionListBlock' }
+    ) | (
+      { fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
+        { html: string | null }
+        & { __typename: 'EmbedHTMLValue' }
+      ) | null }
+      & { __typename: 'AdaptiveEmbedBlock' }
+    ) | (
+      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { heading: string | null, content: string | null, link: string | null, image: (
+          { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, large: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, small: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, social: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, rendition: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null }
+          & { __typename: 'Image' }
+        ) | null }
+        & { __typename: 'CardBlock' }
+      ) | null> | null }
+      & { __typename: 'CardListBlock' }
+    ) | (
+      { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string | null, account: (
+        { provider: CartographyProviderCredentialsProvider, account: string, publicAccessToken: string }
+        & { __typename: 'CartographyProviderCredentials' }
+      ) }
+      & { __typename: 'CartographyVisualisationBlock' }
+    ) | (
+      { style: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, categoryType: (
+        { id: string, hideCategoryIdentifiers: boolean, categories: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, indicators: Array<(
+            { id: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null, parent: (
+            { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+              { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+                { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+                  { id: string, name: string, namePlural: string | null }
+                  & { __typename: 'CategoryLevel' }
+                ) | null, image: (
+                  { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, large: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, small: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, social: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, rendition: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, indicators: Array<(
+                  { id: string, values: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorValue' }
+                  ) | null> | null, goals: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorGoal' }
+                  ) | null> | null, unit: (
+                    { name: string, shortName: string | null }
+                    & { __typename: 'Unit' }
+                  ) }
+                  & { __typename: 'Indicator' }
+                )>, iconImage: (
+                  { rendition: (
+                    { src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, categoryPage: (
+                  { id: string | null, title: string, urlPath: string, live: boolean }
+                  & { __typename: 'CategoryPage' }
+                ) | null, type: (
+                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                  & { __typename: 'CategoryType' }
+                ), attributes: Array<(
+                  { id: string, key: string }
+                  & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+                ) | (
+                  { value: string, id: string, key: string }
+                  & { __typename: 'AttributeRichText' | 'AttributeText' }
+                )> | null }
+                & { __typename: 'Category' }
+              ) | null, level: (
+                { id: string, name: string, namePlural: string | null }
+                & { __typename: 'CategoryLevel' }
+              ) | null, image: (
+                { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, large: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, small: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, social: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, rendition: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, indicators: Array<(
+                { id: string, values: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorValue' }
+                ) | null> | null, goals: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorGoal' }
+                ) | null> | null, unit: (
+                  { name: string, shortName: string | null }
+                  & { __typename: 'Unit' }
+                ) }
+                & { __typename: 'Indicator' }
+              )>, iconImage: (
+                { rendition: (
+                  { src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, categoryPage: (
+                { id: string | null, title: string, urlPath: string, live: boolean }
+                & { __typename: 'CategoryPage' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename: 'CategoryType' }
+              ), attributes: Array<(
+                { id: string, key: string }
+                & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+              ) | (
+                { value: string, id: string, key: string }
+                & { __typename: 'AttributeRichText' | 'AttributeText' }
+              )> | null }
+              & { __typename: 'Category' }
+            ) | null, level: (
+              { id: string, name: string, namePlural: string | null }
+              & { __typename: 'CategoryLevel' }
+            ) | null, image: (
+              { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, large: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, small: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, social: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, rendition: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, indicators: Array<(
+              { id: string, values: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorValue' }
+              ) | null> | null, goals: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorGoal' }
+              ) | null> | null, unit: (
+                { name: string, shortName: string | null }
+                & { __typename: 'Unit' }
+              ) }
+              & { __typename: 'Indicator' }
+            )>, iconImage: (
+              { rendition: (
+                { src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, categoryPage: (
+              { id: string | null, title: string, urlPath: string, live: boolean }
+              & { __typename: 'CategoryPage' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename: 'CategoryType' }
+            ), attributes: Array<(
+              { id: string, key: string }
+              & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+            ) | (
+              { value: string, id: string, key: string }
+              & { __typename: 'AttributeRichText' | 'AttributeText' }
+            )> | null }
+            & { __typename: 'Category' }
+          ) | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'CategoryType' }
+      ) | null, category: (
+        { id: string, children: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, indicators: Array<(
+            { id: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'Category' }
+      ) | null }
+      & { __typename: 'CategoryListBlock' }
+    ) | (
+      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, valueAttribute: (
+        { identifier: string, unit: (
+          { shortName: string | null }
+          & { __typename: 'Unit' }
+        ) | null }
+        & { __typename: 'AttributeType' }
+      ) | null, treeMapCategoryType: (
+        { identifier: string }
+        & { __typename: 'CategoryType' }
+      ) | null }
+      & { __typename: 'CategoryTreeMapBlock' }
+    ) | (
+      { heading: string | null, helpText: string | null, id: string | null, blockType: string, field: string, categoryLevel: (
+        { id: string, name: string, namePlural: string | null }
+        & { __typename: 'CategoryLevel' }
+      ), groupByCategoryLevel: (
+        { id: string }
+        & { __typename: 'CategoryLevel' }
+      ) | null, categoryBlockType: (
+        { id: string, identifier: string, hideCategoryIdentifiers: boolean, categories: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, indicators: Array<(
+            { id: string, name: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null, parent: (
+            { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+              { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+                { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+                  { id: string, name: string, namePlural: string | null }
+                  & { __typename: 'CategoryLevel' }
+                ) | null, image: (
+                  { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, large: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, small: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, social: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, rendition: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, indicators: Array<(
+                  { id: string, values: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorValue' }
+                  ) | null> | null, goals: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorGoal' }
+                  ) | null> | null, unit: (
+                    { name: string, shortName: string | null }
+                    & { __typename: 'Unit' }
+                  ) }
+                  & { __typename: 'Indicator' }
+                )>, iconImage: (
+                  { rendition: (
+                    { src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, categoryPage: (
+                  { id: string | null, title: string, urlPath: string, live: boolean }
+                  & { __typename: 'CategoryPage' }
+                ) | null, type: (
+                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                  & { __typename: 'CategoryType' }
+                ), attributes: Array<(
+                  { id: string, key: string }
+                  & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+                ) | (
+                  { value: string, id: string, key: string }
+                  & { __typename: 'AttributeRichText' | 'AttributeText' }
+                )> | null }
+                & { __typename: 'Category' }
+              ) | null, level: (
+                { id: string, name: string, namePlural: string | null }
+                & { __typename: 'CategoryLevel' }
+              ) | null, image: (
+                { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, large: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, small: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, social: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, rendition: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, indicators: Array<(
+                { id: string, values: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorValue' }
+                ) | null> | null, goals: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorGoal' }
+                ) | null> | null, unit: (
+                  { name: string, shortName: string | null }
+                  & { __typename: 'Unit' }
+                ) }
+                & { __typename: 'Indicator' }
+              )>, iconImage: (
+                { rendition: (
+                  { src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, categoryPage: (
+                { id: string | null, title: string, urlPath: string, live: boolean }
+                & { __typename: 'CategoryPage' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename: 'CategoryType' }
+              ), attributes: Array<(
+                { id: string, key: string }
+                & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+              ) | (
+                { value: string, id: string, key: string }
+                & { __typename: 'AttributeRichText' | 'AttributeText' }
+              )> | null }
+              & { __typename: 'Category' }
+            ) | null, level: (
+              { id: string, name: string, namePlural: string | null }
+              & { __typename: 'CategoryLevel' }
+            ) | null, image: (
+              { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, large: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, small: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, social: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, rendition: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, indicators: Array<(
+              { id: string, values: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorValue' }
+              ) | null> | null, goals: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorGoal' }
+              ) | null> | null, unit: (
+                { name: string, shortName: string | null }
+                & { __typename: 'Unit' }
+              ) }
+              & { __typename: 'Indicator' }
+            )>, iconImage: (
+              { rendition: (
+                { src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, categoryPage: (
+              { id: string | null, title: string, urlPath: string, live: boolean }
+              & { __typename: 'CategoryPage' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename: 'CategoryType' }
+            ), attributes: Array<(
+              { id: string, key: string }
+              & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+            ) | (
+              { value: string, id: string, key: string }
+              & { __typename: 'AttributeRichText' | 'AttributeText' }
+            )> | null }
+            & { __typename: 'Category' }
+          ) | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'CategoryType' }
+      ) }
+      & { __typename: 'CategoryTypeLevelListBlock' }
+    ) | (
       { value: string, id: string | null, blockType: string, field: string }
-      & { __typename: 'RichTextBlock' }
-    )> | null }
+      & { __typename: 'CharBlock' | 'RichTextBlock' | 'TextBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string, choices: Array<(
+        { key: string, value: string }
+        & { __typename: 'ChoiceOption' }
+      )> }
+      & { __typename: 'ChoiceBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, blocks: Array<(
+        { blockType: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+      ) | (
+        { id: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { id: string | null, barType: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorBarChartBlock' }
+      ) | (
+        { id: string | null, helpText: string | null, showTotalLine: boolean | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorLineChartBlock' }
+      ) | (
+        { helpText: string | null, year: number | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorPieChartBlock' }
+      ) | (
+        { id: string | null, blockType: string, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorSummaryBlock' }
+      ) | (
+        { text: string | null, blockType: string }
+        & { __typename: 'DashboardParagraphBlock' }
+      )> }
+      & { __typename: 'DashboardRowBlock' }
+    ) | (
+      { layout: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
+        { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, large: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, small: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, social: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, rendition: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null }
+        & { __typename: 'Image' }
+      ) | null }
+      & { __typename: 'FrontPageHeroBlock' }
+    ) | (
+      { style: string | null, id: string | null, blockType: string, field: string, indicator: (
+        { id: string }
+        & { __typename: 'Indicator' }
+      ) | null }
+      & { __typename: 'IndicatorBlock' }
+    ) | (
+      { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { style: string | null, indicator: (
+          { id: string, identifier: string | null, name: string, description: string | null, timeResolution: IndicatorTimeResolution, level: string | null, unit: (
+            { id: string, name: string }
+            & { __typename: 'Unit' }
+          ), latestValue: (
+            { id: string, date: string | null, value: number }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { id: string, date: string | null, value: number }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'IndicatorBlock' }
+      ) | null> | null }
+      & { __typename: 'IndicatorGroupBlock' }
+    ) | (
+      { title: string | null, body: string | null, id: string | null, blockType: string, field: string, blocks: Array<(
+        { id: string | null }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'URLBlock' | 'UpdatedAtColumnBlock' }
+      )>, indicator: (
+        { id: string, identifier: string | null, name: string, minValue: number | null, maxValue: number | null, unit: (
+          { id: string, shortName: string | null, name: string }
+          & { __typename: 'Unit' }
+        ), latestValue: (
+          { id: string, date: string | null, value: number }
+          & { __typename: 'IndicatorValue' }
+        ) | null, values: Array<(
+          { id: string, date: string | null, value: number, normalizedValues: Array<(
+            { normalizerId: string | null, value: number | null }
+            & { __typename: 'NormalizedValue' }
+          ) | null> | null, categories: Array<(
+            { id: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'IndicatorValue' }
+        ) | null> | null, goals: Array<(
+          { id: string, date: string | null, value: number, normalizedValues: Array<(
+            { normalizerId: string | null, value: number | null }
+            & { __typename: 'NormalizedValue' }
+          ) | null> | null }
+          & { __typename: 'IndicatorGoal' }
+        ) | null> | null, common: (
+          { id: string, normalizations: Array<(
+            { unit: (
+              { shortName: string | null, name: string }
+              & { __typename: 'Unit' }
+            ) | null, normalizer: (
+              { name: string, id: string, identifier: string | null }
+              & { __typename: 'CommonIndicator' }
+            ) | null }
+            & { __typename: 'CommonIndicatorNormalization' }
+          ) | null> | null }
+          & { __typename: 'CommonIndicator' }
+        ) | null }
+        & { __typename: 'Indicator' }
+      ) | null, linkButton: (
+        { blockType: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'UpdatedAtColumnBlock' }
+      ) | (
+        { text: string | null, blockType: string, page: (
+          { url: string | null, urlPath: string, slug: string }
+          & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
+        ) | null }
+        & { __typename: 'PageLinkBlock' }
+      ) | null }
+      & { __typename: 'IndicatorShowcaseBlock' }
+    ) | (
+      { width: string | null, id: string | null, blockType: string, field: string, image: (
+        { title: string, altText: string, width: number, height: number, imageCredit: string, renditionUncropped: (
+          { src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null }
+        & { __typename: 'Image' }
+      ) | null }
+      & { __typename: 'LargeImageBlock' }
+    ) | (
+      { heading: string | null, helpText: string | null, outcomeNodeId: string | null, id: string | null, blockType: string, field: string }
+      & { __typename: 'PathsOutcomeBlock' }
+    ) | (
+      { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { question: string | null, answer: string | null }
+        & { __typename: 'QuestionBlock' }
+      ) | null> | null }
+      & { __typename: 'QuestionAnswerBlock' }
+    ) | null> | null }
     & { __typename: 'AccessibilityStatementPage' }
   ) | (
     { leadContent: string | null, defaultView: ActionListPageView, headingHierarchyDepth: number, includeRelatedPlans: boolean | null, id: string | null, slug: string, title: string, lastPublishedAt: string | null, primaryFilters: Array<(
@@ -10244,7 +11141,7 @@ export type GetContentPageQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -10270,7 +11167,7 @@ export type GetContentPageQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       )>, parent: (
         { id: string, identifier: string, name: string, color: string, iconSvgUrl: string | null, level: (
@@ -10380,7 +11277,7 @@ export type GetContentPageQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -10406,7 +11303,7 @@ export type GetContentPageQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -10434,7 +11331,7 @@ export type GetContentPageQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -10460,7 +11357,7 @@ export type GetContentPageQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -10487,7 +11384,7 @@ export type GetContentPageQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -10513,7 +11410,7 @@ export type GetContentPageQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -10540,7 +11437,7 @@ export type GetContentPageQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -10566,7 +11463,7 @@ export type GetContentPageQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -10611,7 +11508,7 @@ export type GetContentPageQuery = (
           & { __typename: 'AttributeType' }
         ) }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )>, datasets: Array<(
+      )> | null, datasets: Array<(
         { uuid: string, schema: (
           { uuid: string, name: string, timeResolution: DatasetSchemaTimeResolution, metrics: Array<(
             { unit: string }
@@ -10638,20 +11535,71 @@ export type GetContentPageQuery = (
           & { __typename: 'DataPoint' }
         )> }
         & { __typename: 'Dataset' }
-      )> }
+      ) | null> | null }
       & { __typename: 'Category' }
     ) | null, body: Array<(
-      { heading: string | null, helpText: string | null, id: string | null, blockType: string, field: string, categoryFilter: (
-        { id: string, type: (
-          { id: string }
-          & { __typename: 'CategoryType' }
-        ) }
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' | 'ActionLinksBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorHighlightsBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'UpdatedAtColumnBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, blocks: Array<(
+        { id: string | null, field: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'UpdatedAtColumnBlock' }
+      ) | (
+        { value: string, id: string | null, field: string }
+        & { __typename: 'CharBlock' }
+      )> }
+      & { __typename: 'AccessibilityStatementContactInformationBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { heading: string | null, lead: string | null, category: (
+          { id: string, type: (
+            { identifier: string }
+            & { __typename: 'CategoryType' }
+          ) }
+          & { __typename: 'Category' }
+        ) | null }
+        & { __typename: 'ActionCategoryFilterCardBlock' }
+      ) | null> | null }
+      & { __typename: 'ActionCategoryFilterCardsBlock' }
+    ) | (
+      { id: string | null, heading: string | null, helpText: string | null, blockType: string, field: string, categoryFilter: (
+        { id: string }
         & { __typename: 'Category' }
       ) | null, groupByCategoryLevel: (
-        { id: string, type: (
-          { id: string }
-          & { __typename: 'CategoryType' }
-        ) }
+        { id: string }
         & { __typename: 'CategoryLevel' }
       ) | null }
       & { __typename: 'ActionListBlock' }
@@ -10662,394 +11610,31 @@ export type GetContentPageQuery = (
       ) | null }
       & { __typename: 'AdaptiveEmbedBlock' }
     ) | (
-      { style: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, categoryType: (
-        { id: string, hideCategoryIdentifiers: boolean, categories: Array<(
-          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
-            { id: string, name: string, namePlural: string | null }
-            & { __typename: 'CategoryLevel' }
-          ) | null, image: (
-            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, large: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, small: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, social: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, rendition: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null }
-            & { __typename: 'Image' }
-          ) | null, indicators: Array<(
-            { id: string, values: Array<(
-              { date: string | null, value: number }
-              & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
-              { date: string | null, value: number }
-              & { __typename: 'IndicatorGoal' }
-            ) | null> | null, unit: (
-              { name: string, shortName: string | null }
-              & { __typename: 'Unit' }
-            ) }
-            & { __typename: 'Indicator' }
-          )>, iconImage: (
-            { rendition: (
-              { src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null }
-            & { __typename: 'Image' }
-          ) | null, categoryPage: (
-            { id: string | null, title: string, urlPath: string, live: boolean }
-            & { __typename: 'CategoryPage' }
-          ) | null, type: (
-            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
-            & { __typename: 'CategoryType' }
-          ), attributes: Array<(
-            { id: string, key: string }
-            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
-          ) | (
-            { value: string, id: string, key: string }
-            & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
-            { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
-              { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
-                { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
-                  { id: string, name: string, namePlural: string | null }
-                  & { __typename: 'CategoryLevel' }
-                ) | null, image: (
-                  { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
-                    { id: string, width: number, height: number, src: string }
-                    & { __typename: 'ImageRendition' }
-                  ) | null, large: (
-                    { id: string, width: number, height: number, src: string }
-                    & { __typename: 'ImageRendition' }
-                  ) | null, small: (
-                    { id: string, width: number, height: number, src: string }
-                    & { __typename: 'ImageRendition' }
-                  ) | null, social: (
-                    { id: string, width: number, height: number, src: string }
-                    & { __typename: 'ImageRendition' }
-                  ) | null, rendition: (
-                    { id: string, width: number, height: number, src: string }
-                    & { __typename: 'ImageRendition' }
-                  ) | null }
-                  & { __typename: 'Image' }
-                ) | null, indicators: Array<(
-                  { id: string, values: Array<(
-                    { date: string | null, value: number }
-                    & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
-                    { date: string | null, value: number }
-                    & { __typename: 'IndicatorGoal' }
-                  ) | null> | null, unit: (
-                    { name: string, shortName: string | null }
-                    & { __typename: 'Unit' }
-                  ) }
-                  & { __typename: 'Indicator' }
-                )>, iconImage: (
-                  { rendition: (
-                    { src: string }
-                    & { __typename: 'ImageRendition' }
-                  ) | null }
-                  & { __typename: 'Image' }
-                ) | null, categoryPage: (
-                  { id: string | null, title: string, urlPath: string, live: boolean }
-                  & { __typename: 'CategoryPage' }
-                ) | null, type: (
-                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
-                  & { __typename: 'CategoryType' }
-                ), attributes: Array<(
-                  { id: string, key: string }
-                  & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
-                ) | (
-                  { value: string, id: string, key: string }
-                  & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
-                & { __typename: 'Category' }
-              ) | null, level: (
-                { id: string, name: string, namePlural: string | null }
-                & { __typename: 'CategoryLevel' }
-              ) | null, image: (
-                { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
-                  { id: string, width: number, height: number, src: string }
-                  & { __typename: 'ImageRendition' }
-                ) | null, large: (
-                  { id: string, width: number, height: number, src: string }
-                  & { __typename: 'ImageRendition' }
-                ) | null, small: (
-                  { id: string, width: number, height: number, src: string }
-                  & { __typename: 'ImageRendition' }
-                ) | null, social: (
-                  { id: string, width: number, height: number, src: string }
-                  & { __typename: 'ImageRendition' }
-                ) | null, rendition: (
-                  { id: string, width: number, height: number, src: string }
-                  & { __typename: 'ImageRendition' }
-                ) | null }
-                & { __typename: 'Image' }
-              ) | null, indicators: Array<(
-                { id: string, values: Array<(
-                  { date: string | null, value: number }
-                  & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
-                  { date: string | null, value: number }
-                  & { __typename: 'IndicatorGoal' }
-                ) | null> | null, unit: (
-                  { name: string, shortName: string | null }
-                  & { __typename: 'Unit' }
-                ) }
-                & { __typename: 'Indicator' }
-              )>, iconImage: (
-                { rendition: (
-                  { src: string }
-                  & { __typename: 'ImageRendition' }
-                ) | null }
-                & { __typename: 'Image' }
-              ) | null, categoryPage: (
-                { id: string | null, title: string, urlPath: string, live: boolean }
-                & { __typename: 'CategoryPage' }
-              ) | null, type: (
-                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
-                & { __typename: 'CategoryType' }
-              ), attributes: Array<(
-                { id: string, key: string }
-                & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
-              ) | (
-                { value: string, id: string, key: string }
-                & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
-              & { __typename: 'Category' }
-            ) | null, level: (
-              { id: string, name: string, namePlural: string | null }
-              & { __typename: 'CategoryLevel' }
-            ) | null, image: (
-              { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
-                { id: string, width: number, height: number, src: string }
-                & { __typename: 'ImageRendition' }
-              ) | null, large: (
-                { id: string, width: number, height: number, src: string }
-                & { __typename: 'ImageRendition' }
-              ) | null, small: (
-                { id: string, width: number, height: number, src: string }
-                & { __typename: 'ImageRendition' }
-              ) | null, social: (
-                { id: string, width: number, height: number, src: string }
-                & { __typename: 'ImageRendition' }
-              ) | null, rendition: (
-                { id: string, width: number, height: number, src: string }
-                & { __typename: 'ImageRendition' }
-              ) | null }
-              & { __typename: 'Image' }
-            ) | null, indicators: Array<(
-              { id: string, values: Array<(
-                { date: string | null, value: number }
-                & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
-                { date: string | null, value: number }
-                & { __typename: 'IndicatorGoal' }
-              ) | null> | null, unit: (
-                { name: string, shortName: string | null }
-                & { __typename: 'Unit' }
-              ) }
-              & { __typename: 'Indicator' }
-            )>, iconImage: (
-              { rendition: (
-                { src: string }
-                & { __typename: 'ImageRendition' }
-              ) | null }
-              & { __typename: 'Image' }
-            ) | null, categoryPage: (
-              { id: string | null, title: string, urlPath: string, live: boolean }
-              & { __typename: 'CategoryPage' }
-            ) | null, type: (
-              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
-              & { __typename: 'CategoryType' }
-            ), attributes: Array<(
-              { id: string, key: string }
-              & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
-            ) | (
-              { value: string, id: string, key: string }
-              & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
-            & { __typename: 'Category' }
+      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { heading: string | null, content: string | null, link: string | null, image: (
+          { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, large: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, small: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, social: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, rendition: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
           ) | null }
-          & { __typename: 'Category' }
-        )> }
-        & { __typename: 'CategoryType' }
-      ) | null, category: (
-        { id: string, children: Array<(
-          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
-            { id: string, name: string, namePlural: string | null }
-            & { __typename: 'CategoryLevel' }
-          ) | null, image: (
-            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, large: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, small: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, social: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, rendition: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null }
-            & { __typename: 'Image' }
-          ) | null, indicators: Array<(
-            { id: string, values: Array<(
-              { date: string | null, value: number }
-              & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
-              { date: string | null, value: number }
-              & { __typename: 'IndicatorGoal' }
-            ) | null> | null, unit: (
-              { name: string, shortName: string | null }
-              & { __typename: 'Unit' }
-            ) }
-            & { __typename: 'Indicator' }
-          )>, iconImage: (
-            { rendition: (
-              { src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null }
-            & { __typename: 'Image' }
-          ) | null, categoryPage: (
-            { id: string | null, title: string, urlPath: string, live: boolean }
-            & { __typename: 'CategoryPage' }
-          ) | null, type: (
-            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
-            & { __typename: 'CategoryType' }
-          ), attributes: Array<(
-            { id: string, key: string }
-            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
-          ) | (
-            { value: string, id: string, key: string }
-            & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
-          & { __typename: 'Category' }
-        )> }
-        & { __typename: 'Category' }
-      ) | null }
-      & { __typename: 'CategoryListBlock' }
-    ) | (
-      { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<(
-        { style: string | null, indicator: (
-          { id: string, identifier: string | null, name: string, description: string | null, timeResolution: IndicatorTimeResolution, level: string | null, unit: (
-            { id: string, name: string }
-            & { __typename: 'Unit' }
-          ), latestValue: (
-            { id: string, date: string | null, value: number }
-            & { __typename: 'IndicatorValue' }
-          ) | null, goals: Array<(
-            { id: string, date: string | null, value: number }
-            & { __typename: 'IndicatorGoal' }
-          ) | null> | null }
-          & { __typename: 'Indicator' }
+          & { __typename: 'Image' }
         ) | null }
-        & { __typename: 'IndicatorBlock' }
-      )> | null }
-      & { __typename: 'IndicatorGroupBlock' }
+        & { __typename: 'CardBlock' }
+      ) | null> | null }
+      & { __typename: 'CardListBlock' }
     ) | (
-      { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<(
-        { question: string, answer: string }
-        & { __typename: 'QuestionBlock' }
-      )> | null }
-      & { __typename: 'QuestionAnswerBlock' }
-    ) | (
-      { id: string | null, blockType: string, field: string }
-      & { __typename: 'RelatedIndicatorsBlock' }
-    ) | (
-      { value: string, id: string | null, blockType: string, field: string }
-      & { __typename: 'RichTextBlock' }
-    )> | null, layout: (
-      { iconSize: string | null, layoutMainTop: Array<(
-        { attributeType: (
-          { identifier: string }
-          & { __typename: 'AttributeType' }
-        ) }
-        & { __typename: 'CategoryPageAttributeTypeBlock' }
-      ) | (
-        { blocks: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
-          { value: string }
-          & { __typename: 'ChoiceBlock' }
-        )> }
-        & { __typename: 'CategoryPageProgressBlock' }
-      )> | null, layoutMainBottom: Array<(
-        { attributeType: (
-          { identifier: string }
-          & { __typename: 'AttributeType' }
-        ) }
-        & { __typename: 'CategoryPageAttributeTypeBlock' }
-      ) | { __typename: 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' } | (
-        { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
-          { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
-            { choiceLabel: string | null, choiceValue: string | null }
-            & { __typename: 'FormChoiceBlock' }
-          )> }
-          & { __typename: 'FormFieldBlock' }
-        )> }
-        & { __typename: 'CategoryPageContactFormBlock' }
-      ) | (
-        { id: string | null, heading: string | null, helpText: string | null, datasetSchema: (
-          { uuid: string }
-          & { __typename: 'DatasetSchema' }
-        ) }
-        & { __typename: 'CategoryTypeDatasetsBlock' }
-      )> | null, layoutAside: Array<(
-        { attributeType: (
-          { identifier: string }
-          & { __typename: 'AttributeType' }
-        ) }
-        & { __typename: 'CategoryPageAttributeTypeBlock' }
-      )> | null }
-      & { __typename: 'CategoryTypePageLevelLayout' }
-    ) | null }
-    & { __typename: 'CategoryPage' }
-  ) | (
-    { contentType: string, id: string | null, slug: string, title: string, lastPublishedAt: string | null }
-    & { __typename: 'CategoryTypePage' }
-  ) | (
-    { id: string | null, slug: string, title: string, lastPublishedAt: string | null }
-    & { __typename: 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' }
-  ) | (
-    { leadContent: string | null, id: string | null, slug: string, title: string, lastPublishedAt: string | null }
-    & { __typename: 'PrivacyPolicyPage' }
-  ) | (
-    { leadParagraph: string | null, id: string | null, slug: string, title: string, lastPublishedAt: string | null, headerImage: (
-      { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
-        { id: string, width: number, height: number, src: string }
-        & { __typename: 'ImageRendition' }
-      ) | null, large: (
-        { id: string, width: number, height: number, src: string }
-        & { __typename: 'ImageRendition' }
-      ) | null, small: (
-        { id: string, width: number, height: number, src: string }
-        & { __typename: 'ImageRendition' }
-      ) | null, social: (
-        { id: string, width: number, height: number, src: string }
-        & { __typename: 'ImageRendition' }
-      ) | null, rendition: (
-        { id: string, width: number, height: number, src: string }
-        & { __typename: 'ImageRendition' }
-      ) | null }
-      & { __typename: 'Image' }
-    ) | null, body: Array<(
-      { fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
-        { html: string | null }
-        & { __typename: 'EmbedHTMLValue' }
-      ) | null }
-      & { __typename: 'AdaptiveEmbedBlock' }
-    ) | (
-      { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string, account: (
+      { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string | null, account: (
         { provider: CartographyProviderCredentialsProvider, account: string, publicAccessToken: string }
         & { __typename: 'CartographyProviderCredentials' }
       ) }
@@ -11082,7 +11667,7 @@ export type GetContentPageQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -11108,7 +11693,7 @@ export type GetContentPageQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -11136,7 +11721,7 @@ export type GetContentPageQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -11162,7 +11747,7 @@ export type GetContentPageQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -11189,7 +11774,7 @@ export type GetContentPageQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -11215,7 +11800,7 @@ export type GetContentPageQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -11242,7 +11827,7 @@ export type GetContentPageQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -11268,7 +11853,7 @@ export type GetContentPageQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -11301,7 +11886,7 @@ export type GetContentPageQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -11327,7 +11912,7 @@ export type GetContentPageQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         )> }
         & { __typename: 'Category' }
@@ -11340,10 +11925,10 @@ export type GetContentPageQuery = (
           & { __typename: 'Unit' }
         ) | null }
         & { __typename: 'AttributeType' }
-      ), treeMapCategoryType: (
+      ) | null, treeMapCategoryType: (
         { identifier: string }
         & { __typename: 'CategoryType' }
-      ) }
+      ) | null }
       & { __typename: 'CategoryTreeMapBlock' }
     ) | (
       { heading: string | null, helpText: string | null, id: string | null, blockType: string, field: string, categoryLevel: (
@@ -11358,7 +11943,7 @@ export type GetContentPageQuery = (
             { id: string, name: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -11405,7 +11990,7 @@ export type GetContentPageQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -11433,7 +12018,7 @@ export type GetContentPageQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -11459,7 +12044,7 @@ export type GetContentPageQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -11486,7 +12071,7 @@ export type GetContentPageQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -11512,7 +12097,7 @@ export type GetContentPageQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -11539,7 +12124,7 @@ export type GetContentPageQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -11565,7 +12150,7 @@ export type GetContentPageQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -11573,6 +12158,15 @@ export type GetContentPageQuery = (
         & { __typename: 'CategoryType' }
       ) }
       & { __typename: 'CategoryTypeLevelListBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string }
+      & { __typename: 'CharBlock' | 'RichTextBlock' | 'TextBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string, choices: Array<(
+        { key: string, value: string }
+        & { __typename: 'ChoiceOption' }
+      )> }
+      & { __typename: 'ChoiceBlock' }
     ) | (
       { id: string | null, blockType: string, field: string, blocks: Array<(
         { blockType: string }
@@ -11733,7 +12327,34 @@ export type GetContentPageQuery = (
       )> }
       & { __typename: 'DashboardRowBlock' }
     ) | (
-      { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<(
+      { layout: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
+        { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, large: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, small: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, social: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, rendition: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null }
+        & { __typename: 'Image' }
+      ) | null }
+      & { __typename: 'FrontPageHeroBlock' }
+    ) | (
+      { style: string | null, id: string | null, blockType: string, field: string, indicator: (
+        { id: string }
+        & { __typename: 'Indicator' }
+      ) | null }
+      & { __typename: 'IndicatorBlock' }
+    ) | (
+      { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
         { style: string | null, indicator: (
           { id: string, identifier: string | null, name: string, description: string | null, timeResolution: IndicatorTimeResolution, level: string | null, unit: (
             { id: string, name: string }
@@ -11748,8 +12369,95 @@ export type GetContentPageQuery = (
           & { __typename: 'Indicator' }
         ) | null }
         & { __typename: 'IndicatorBlock' }
-      )> | null }
+      ) | null> | null }
       & { __typename: 'IndicatorGroupBlock' }
+    ) | (
+      { title: string | null, body: string | null, id: string | null, blockType: string, field: string, blocks: Array<(
+        { id: string | null }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'URLBlock' | 'UpdatedAtColumnBlock' }
+      )>, indicator: (
+        { id: string, identifier: string | null, name: string, minValue: number | null, maxValue: number | null, unit: (
+          { id: string, shortName: string | null, name: string }
+          & { __typename: 'Unit' }
+        ), latestValue: (
+          { id: string, date: string | null, value: number }
+          & { __typename: 'IndicatorValue' }
+        ) | null, values: Array<(
+          { id: string, date: string | null, value: number, normalizedValues: Array<(
+            { normalizerId: string | null, value: number | null }
+            & { __typename: 'NormalizedValue' }
+          ) | null> | null, categories: Array<(
+            { id: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'IndicatorValue' }
+        ) | null> | null, goals: Array<(
+          { id: string, date: string | null, value: number, normalizedValues: Array<(
+            { normalizerId: string | null, value: number | null }
+            & { __typename: 'NormalizedValue' }
+          ) | null> | null }
+          & { __typename: 'IndicatorGoal' }
+        ) | null> | null, common: (
+          { id: string, normalizations: Array<(
+            { unit: (
+              { shortName: string | null, name: string }
+              & { __typename: 'Unit' }
+            ) | null, normalizer: (
+              { name: string, id: string, identifier: string | null }
+              & { __typename: 'CommonIndicator' }
+            ) | null }
+            & { __typename: 'CommonIndicatorNormalization' }
+          ) | null> | null }
+          & { __typename: 'CommonIndicator' }
+        ) | null }
+        & { __typename: 'Indicator' }
+      ) | null, linkButton: (
+        { blockType: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'UpdatedAtColumnBlock' }
+      ) | (
+        { text: string | null, blockType: string, page: (
+          { url: string | null, urlPath: string, slug: string }
+          & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
+        ) | null }
+        & { __typename: 'PageLinkBlock' }
+      ) | null }
+      & { __typename: 'IndicatorShowcaseBlock' }
     ) | (
       { width: string | null, id: string | null, blockType: string, field: string, image: (
         { title: string, altText: string, width: number, height: number, imageCredit: string, renditionUncropped: (
@@ -11763,15 +12471,1023 @@ export type GetContentPageQuery = (
       { heading: string | null, helpText: string | null, outcomeNodeId: string | null, id: string | null, blockType: string, field: string }
       & { __typename: 'PathsOutcomeBlock' }
     ) | (
-      { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<(
-        { question: string, answer: string }
+      { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { question: string | null, answer: string | null }
         & { __typename: 'QuestionBlock' }
-      )> | null }
+      ) | null> | null }
       & { __typename: 'QuestionAnswerBlock' }
+    ) | null> | null, layout: (
+      { iconSize: string | null, layoutMainTop: Array<(
+        { attributeType: (
+          { identifier: string }
+          & { __typename: 'AttributeType' }
+        ) }
+        & { __typename: 'CategoryPageAttributeTypeBlock' }
+      ) | (
+        { blocks: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+          { value: string }
+          & { __typename: 'ChoiceBlock' }
+        )> }
+        & { __typename: 'CategoryPageProgressBlock' }
+      )> | null, layoutMainBottom: Array<(
+        { attributeType: (
+          { identifier: string }
+          & { __typename: 'AttributeType' }
+        ) }
+        & { __typename: 'CategoryPageAttributeTypeBlock' }
+      ) | { __typename: 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' } | (
+        { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+          { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+            { choiceLabel: string | null, choiceValue: string | null }
+            & { __typename: 'FormChoiceBlock' }
+          ) | null> | null }
+          & { __typename: 'FormFieldBlock' }
+        ) | null> | null }
+        & { __typename: 'CategoryPageContactFormBlock' }
+      ) | (
+        { id: string | null, heading: string | null, helpText: string | null, datasetSchema: (
+          { uuid: string }
+          & { __typename: 'DatasetSchema' }
+        ) }
+        & { __typename: 'CategoryTypeDatasetsBlock' }
+      )> | null, layoutAside: Array<(
+        { attributeType: (
+          { identifier: string }
+          & { __typename: 'AttributeType' }
+        ) }
+        & { __typename: 'CategoryPageAttributeTypeBlock' }
+      )> | null }
+      & { __typename: 'CategoryTypePageLevelLayout' }
+    ) | null }
+    & { __typename: 'CategoryPage' }
+  ) | (
+    { contentType: string, id: string | null, slug: string, title: string, lastPublishedAt: string | null }
+    & { __typename: 'CategoryTypePage' }
+  ) | (
+    { id: string | null, slug: string, title: string, lastPublishedAt: string | null }
+    & { __typename: 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' }
+  ) | (
+    { leadContent: string | null, id: string | null, slug: string, title: string, lastPublishedAt: string | null }
+    & { __typename: 'PrivacyPolicyPage' }
+  ) | (
+    { leadParagraph: string | null, id: string | null, slug: string, title: string, lastPublishedAt: string | null, headerImage: (
+      { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null, large: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null, small: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null, social: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null, rendition: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null }
+      & { __typename: 'Image' }
+    ) | null, body: Array<(
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' | 'ActionLinksBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorHighlightsBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'UpdatedAtColumnBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, blocks: Array<(
+        { id: string | null, field: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'UpdatedAtColumnBlock' }
+      ) | (
+        { value: string, id: string | null, field: string }
+        & { __typename: 'CharBlock' }
+      )> }
+      & { __typename: 'AccessibilityStatementContactInformationBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { heading: string | null, lead: string | null, category: (
+          { id: string, type: (
+            { identifier: string }
+            & { __typename: 'CategoryType' }
+          ) }
+          & { __typename: 'Category' }
+        ) | null }
+        & { __typename: 'ActionCategoryFilterCardBlock' }
+      ) | null> | null }
+      & { __typename: 'ActionCategoryFilterCardsBlock' }
+    ) | (
+      { id: string | null, heading: string | null, helpText: string | null, blockType: string, field: string, categoryFilter: (
+        { id: string }
+        & { __typename: 'Category' }
+      ) | null, groupByCategoryLevel: (
+        { id: string }
+        & { __typename: 'CategoryLevel' }
+      ) | null }
+      & { __typename: 'ActionListBlock' }
+    ) | (
+      { fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
+        { html: string | null }
+        & { __typename: 'EmbedHTMLValue' }
+      ) | null }
+      & { __typename: 'AdaptiveEmbedBlock' }
+    ) | (
+      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { heading: string | null, content: string | null, link: string | null, image: (
+          { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, large: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, small: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, social: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, rendition: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null }
+          & { __typename: 'Image' }
+        ) | null }
+        & { __typename: 'CardBlock' }
+      ) | null> | null }
+      & { __typename: 'CardListBlock' }
+    ) | (
+      { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string | null, account: (
+        { provider: CartographyProviderCredentialsProvider, account: string, publicAccessToken: string }
+        & { __typename: 'CartographyProviderCredentials' }
+      ) }
+      & { __typename: 'CartographyVisualisationBlock' }
+    ) | (
+      { style: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, categoryType: (
+        { id: string, hideCategoryIdentifiers: boolean, categories: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, indicators: Array<(
+            { id: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null, parent: (
+            { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+              { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+                { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+                  { id: string, name: string, namePlural: string | null }
+                  & { __typename: 'CategoryLevel' }
+                ) | null, image: (
+                  { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, large: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, small: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, social: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, rendition: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, indicators: Array<(
+                  { id: string, values: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorValue' }
+                  ) | null> | null, goals: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorGoal' }
+                  ) | null> | null, unit: (
+                    { name: string, shortName: string | null }
+                    & { __typename: 'Unit' }
+                  ) }
+                  & { __typename: 'Indicator' }
+                )>, iconImage: (
+                  { rendition: (
+                    { src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, categoryPage: (
+                  { id: string | null, title: string, urlPath: string, live: boolean }
+                  & { __typename: 'CategoryPage' }
+                ) | null, type: (
+                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                  & { __typename: 'CategoryType' }
+                ), attributes: Array<(
+                  { id: string, key: string }
+                  & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+                ) | (
+                  { value: string, id: string, key: string }
+                  & { __typename: 'AttributeRichText' | 'AttributeText' }
+                )> | null }
+                & { __typename: 'Category' }
+              ) | null, level: (
+                { id: string, name: string, namePlural: string | null }
+                & { __typename: 'CategoryLevel' }
+              ) | null, image: (
+                { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, large: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, small: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, social: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, rendition: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, indicators: Array<(
+                { id: string, values: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorValue' }
+                ) | null> | null, goals: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorGoal' }
+                ) | null> | null, unit: (
+                  { name: string, shortName: string | null }
+                  & { __typename: 'Unit' }
+                ) }
+                & { __typename: 'Indicator' }
+              )>, iconImage: (
+                { rendition: (
+                  { src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, categoryPage: (
+                { id: string | null, title: string, urlPath: string, live: boolean }
+                & { __typename: 'CategoryPage' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename: 'CategoryType' }
+              ), attributes: Array<(
+                { id: string, key: string }
+                & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+              ) | (
+                { value: string, id: string, key: string }
+                & { __typename: 'AttributeRichText' | 'AttributeText' }
+              )> | null }
+              & { __typename: 'Category' }
+            ) | null, level: (
+              { id: string, name: string, namePlural: string | null }
+              & { __typename: 'CategoryLevel' }
+            ) | null, image: (
+              { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, large: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, small: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, social: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, rendition: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, indicators: Array<(
+              { id: string, values: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorValue' }
+              ) | null> | null, goals: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorGoal' }
+              ) | null> | null, unit: (
+                { name: string, shortName: string | null }
+                & { __typename: 'Unit' }
+              ) }
+              & { __typename: 'Indicator' }
+            )>, iconImage: (
+              { rendition: (
+                { src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, categoryPage: (
+              { id: string | null, title: string, urlPath: string, live: boolean }
+              & { __typename: 'CategoryPage' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename: 'CategoryType' }
+            ), attributes: Array<(
+              { id: string, key: string }
+              & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+            ) | (
+              { value: string, id: string, key: string }
+              & { __typename: 'AttributeRichText' | 'AttributeText' }
+            )> | null }
+            & { __typename: 'Category' }
+          ) | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'CategoryType' }
+      ) | null, category: (
+        { id: string, children: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, indicators: Array<(
+            { id: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'Category' }
+      ) | null }
+      & { __typename: 'CategoryListBlock' }
+    ) | (
+      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, valueAttribute: (
+        { identifier: string, unit: (
+          { shortName: string | null }
+          & { __typename: 'Unit' }
+        ) | null }
+        & { __typename: 'AttributeType' }
+      ) | null, treeMapCategoryType: (
+        { identifier: string }
+        & { __typename: 'CategoryType' }
+      ) | null }
+      & { __typename: 'CategoryTreeMapBlock' }
+    ) | (
+      { heading: string | null, helpText: string | null, id: string | null, blockType: string, field: string, categoryLevel: (
+        { id: string, name: string, namePlural: string | null }
+        & { __typename: 'CategoryLevel' }
+      ), groupByCategoryLevel: (
+        { id: string }
+        & { __typename: 'CategoryLevel' }
+      ) | null, categoryBlockType: (
+        { id: string, identifier: string, hideCategoryIdentifiers: boolean, categories: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, indicators: Array<(
+            { id: string, name: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null, parent: (
+            { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+              { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+                { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+                  { id: string, name: string, namePlural: string | null }
+                  & { __typename: 'CategoryLevel' }
+                ) | null, image: (
+                  { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, large: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, small: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, social: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, rendition: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, indicators: Array<(
+                  { id: string, values: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorValue' }
+                  ) | null> | null, goals: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorGoal' }
+                  ) | null> | null, unit: (
+                    { name: string, shortName: string | null }
+                    & { __typename: 'Unit' }
+                  ) }
+                  & { __typename: 'Indicator' }
+                )>, iconImage: (
+                  { rendition: (
+                    { src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, categoryPage: (
+                  { id: string | null, title: string, urlPath: string, live: boolean }
+                  & { __typename: 'CategoryPage' }
+                ) | null, type: (
+                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                  & { __typename: 'CategoryType' }
+                ), attributes: Array<(
+                  { id: string, key: string }
+                  & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+                ) | (
+                  { value: string, id: string, key: string }
+                  & { __typename: 'AttributeRichText' | 'AttributeText' }
+                )> | null }
+                & { __typename: 'Category' }
+              ) | null, level: (
+                { id: string, name: string, namePlural: string | null }
+                & { __typename: 'CategoryLevel' }
+              ) | null, image: (
+                { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, large: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, small: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, social: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, rendition: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, indicators: Array<(
+                { id: string, values: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorValue' }
+                ) | null> | null, goals: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorGoal' }
+                ) | null> | null, unit: (
+                  { name: string, shortName: string | null }
+                  & { __typename: 'Unit' }
+                ) }
+                & { __typename: 'Indicator' }
+              )>, iconImage: (
+                { rendition: (
+                  { src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, categoryPage: (
+                { id: string | null, title: string, urlPath: string, live: boolean }
+                & { __typename: 'CategoryPage' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename: 'CategoryType' }
+              ), attributes: Array<(
+                { id: string, key: string }
+                & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+              ) | (
+                { value: string, id: string, key: string }
+                & { __typename: 'AttributeRichText' | 'AttributeText' }
+              )> | null }
+              & { __typename: 'Category' }
+            ) | null, level: (
+              { id: string, name: string, namePlural: string | null }
+              & { __typename: 'CategoryLevel' }
+            ) | null, image: (
+              { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, large: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, small: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, social: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, rendition: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, indicators: Array<(
+              { id: string, values: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorValue' }
+              ) | null> | null, goals: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorGoal' }
+              ) | null> | null, unit: (
+                { name: string, shortName: string | null }
+                & { __typename: 'Unit' }
+              ) }
+              & { __typename: 'Indicator' }
+            )>, iconImage: (
+              { rendition: (
+                { src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, categoryPage: (
+              { id: string | null, title: string, urlPath: string, live: boolean }
+              & { __typename: 'CategoryPage' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename: 'CategoryType' }
+            ), attributes: Array<(
+              { id: string, key: string }
+              & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+            ) | (
+              { value: string, id: string, key: string }
+              & { __typename: 'AttributeRichText' | 'AttributeText' }
+            )> | null }
+            & { __typename: 'Category' }
+          ) | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'CategoryType' }
+      ) }
+      & { __typename: 'CategoryTypeLevelListBlock' }
     ) | (
       { value: string, id: string | null, blockType: string, field: string }
-      & { __typename: 'RichTextBlock' }
-    )> | null, siblings: Array<(
+      & { __typename: 'CharBlock' | 'RichTextBlock' | 'TextBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string, choices: Array<(
+        { key: string, value: string }
+        & { __typename: 'ChoiceOption' }
+      )> }
+      & { __typename: 'ChoiceBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, blocks: Array<(
+        { blockType: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+      ) | (
+        { id: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { id: string | null, barType: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorBarChartBlock' }
+      ) | (
+        { id: string | null, helpText: string | null, showTotalLine: boolean | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorLineChartBlock' }
+      ) | (
+        { helpText: string | null, year: number | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorPieChartBlock' }
+      ) | (
+        { id: string | null, blockType: string, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorSummaryBlock' }
+      ) | (
+        { text: string | null, blockType: string }
+        & { __typename: 'DashboardParagraphBlock' }
+      )> }
+      & { __typename: 'DashboardRowBlock' }
+    ) | (
+      { layout: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
+        { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, large: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, small: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, social: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, rendition: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null }
+        & { __typename: 'Image' }
+      ) | null }
+      & { __typename: 'FrontPageHeroBlock' }
+    ) | (
+      { style: string | null, id: string | null, blockType: string, field: string, indicator: (
+        { id: string }
+        & { __typename: 'Indicator' }
+      ) | null }
+      & { __typename: 'IndicatorBlock' }
+    ) | (
+      { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { style: string | null, indicator: (
+          { id: string, identifier: string | null, name: string, description: string | null, timeResolution: IndicatorTimeResolution, level: string | null, unit: (
+            { id: string, name: string }
+            & { __typename: 'Unit' }
+          ), latestValue: (
+            { id: string, date: string | null, value: number }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { id: string, date: string | null, value: number }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'IndicatorBlock' }
+      ) | null> | null }
+      & { __typename: 'IndicatorGroupBlock' }
+    ) | (
+      { title: string | null, body: string | null, id: string | null, blockType: string, field: string, blocks: Array<(
+        { id: string | null }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'URLBlock' | 'UpdatedAtColumnBlock' }
+      )>, indicator: (
+        { id: string, identifier: string | null, name: string, minValue: number | null, maxValue: number | null, unit: (
+          { id: string, shortName: string | null, name: string }
+          & { __typename: 'Unit' }
+        ), latestValue: (
+          { id: string, date: string | null, value: number }
+          & { __typename: 'IndicatorValue' }
+        ) | null, values: Array<(
+          { id: string, date: string | null, value: number, normalizedValues: Array<(
+            { normalizerId: string | null, value: number | null }
+            & { __typename: 'NormalizedValue' }
+          ) | null> | null, categories: Array<(
+            { id: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'IndicatorValue' }
+        ) | null> | null, goals: Array<(
+          { id: string, date: string | null, value: number, normalizedValues: Array<(
+            { normalizerId: string | null, value: number | null }
+            & { __typename: 'NormalizedValue' }
+          ) | null> | null }
+          & { __typename: 'IndicatorGoal' }
+        ) | null> | null, common: (
+          { id: string, normalizations: Array<(
+            { unit: (
+              { shortName: string | null, name: string }
+              & { __typename: 'Unit' }
+            ) | null, normalizer: (
+              { name: string, id: string, identifier: string | null }
+              & { __typename: 'CommonIndicator' }
+            ) | null }
+            & { __typename: 'CommonIndicatorNormalization' }
+          ) | null> | null }
+          & { __typename: 'CommonIndicator' }
+        ) | null }
+        & { __typename: 'Indicator' }
+      ) | null, linkButton: (
+        { blockType: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'UpdatedAtColumnBlock' }
+      ) | (
+        { text: string | null, blockType: string, page: (
+          { url: string | null, urlPath: string, slug: string }
+          & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
+        ) | null }
+        & { __typename: 'PageLinkBlock' }
+      ) | null }
+      & { __typename: 'IndicatorShowcaseBlock' }
+    ) | (
+      { width: string | null, id: string | null, blockType: string, field: string, image: (
+        { title: string, altText: string, width: number, height: number, imageCredit: string, renditionUncropped: (
+          { src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null }
+        & { __typename: 'Image' }
+      ) | null }
+      & { __typename: 'LargeImageBlock' }
+    ) | (
+      { heading: string | null, helpText: string | null, outcomeNodeId: string | null, id: string | null, blockType: string, field: string }
+      & { __typename: 'PathsOutcomeBlock' }
+    ) | (
+      { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { question: string | null, answer: string | null }
+        & { __typename: 'QuestionBlock' }
+      ) | null> | null }
+      & { __typename: 'QuestionAnswerBlock' }
+    ) | null> | null, siblings: Array<(
       { id: string | null, title: string, slug: string, live: boolean, urlPath: string }
       & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
     )>, parent: (
@@ -11853,7 +13569,52 @@ export type GetHomePageQuery = (
     & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PrivacyPolicyPage' | 'StaticPage' }
   ) | (
     { id: string | null, slug: string, lastPublishedAt: string | null, body: Array<(
-      { id: string | null, blockType: string, field: string, cards: Array<(
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' | 'ActionLinksBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorHighlightsBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'UpdatedAtColumnBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, blocks: Array<(
+        { id: string | null, field: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'UpdatedAtColumnBlock' }
+      ) | (
+        { value: string, id: string | null, field: string }
+        & { __typename: 'CharBlock' }
+      )> }
+      & { __typename: 'AccessibilityStatementContactInformationBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
         { heading: string | null, lead: string | null, category: (
           { id: string, type: (
             { identifier: string }
@@ -11862,11 +13623,17 @@ export type GetHomePageQuery = (
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'ActionCategoryFilterCardBlock' }
-      )> | null }
+      ) | null> | null }
       & { __typename: 'ActionCategoryFilterCardsBlock' }
     ) | (
-      { id: string | null, blockType: string, field: string }
-      & { __typename: 'ActionHighlightsBlock' | 'ActionStatusGraphsBlock' | 'IndicatorHighlightsBlock' | 'RelatedPlanListBlock' }
+      { id: string | null, heading: string | null, helpText: string | null, blockType: string, field: string, categoryFilter: (
+        { id: string }
+        & { __typename: 'Category' }
+      ) | null, groupByCategoryLevel: (
+        { id: string }
+        & { __typename: 'CategoryLevel' }
+      ) | null }
+      & { __typename: 'ActionListBlock' }
     ) | (
       { fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
         { html: string | null }
@@ -11874,7 +13641,7 @@ export type GetHomePageQuery = (
       ) | null }
       & { __typename: 'AdaptiveEmbedBlock' }
     ) | (
-      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<(
+      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
         { heading: string | null, content: string | null, link: string | null, image: (
           { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
             { id: string, width: number, height: number, src: string }
@@ -11895,8 +13662,14 @@ export type GetHomePageQuery = (
           & { __typename: 'Image' }
         ) | null }
         & { __typename: 'CardBlock' }
-      )> | null }
+      ) | null> | null }
       & { __typename: 'CardListBlock' }
+    ) | (
+      { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string | null, account: (
+        { provider: CartographyProviderCredentialsProvider, account: string, publicAccessToken: string }
+        & { __typename: 'CartographyProviderCredentials' }
+      ) }
+      & { __typename: 'CartographyVisualisationBlock' }
     ) | (
       { style: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, categoryType: (
         { id: string, hideCategoryIdentifiers: boolean, categories: Array<(
@@ -11925,7 +13698,7 @@ export type GetHomePageQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -11951,7 +13724,7 @@ export type GetHomePageQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -11979,7 +13752,7 @@ export type GetHomePageQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -12005,7 +13778,7 @@ export type GetHomePageQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -12032,7 +13805,7 @@ export type GetHomePageQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -12058,7 +13831,7 @@ export type GetHomePageQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -12085,7 +13858,7 @@ export type GetHomePageQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -12111,7 +13884,7 @@ export type GetHomePageQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -12144,7 +13917,7 @@ export type GetHomePageQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -12170,7 +13943,7 @@ export type GetHomePageQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         )> }
         & { __typename: 'Category' }
@@ -12183,11 +13956,248 @@ export type GetHomePageQuery = (
           & { __typename: 'Unit' }
         ) | null }
         & { __typename: 'AttributeType' }
-      ), treeMapCategoryType: (
+      ) | null, treeMapCategoryType: (
         { identifier: string }
         & { __typename: 'CategoryType' }
-      ) }
+      ) | null }
       & { __typename: 'CategoryTreeMapBlock' }
+    ) | (
+      { heading: string | null, helpText: string | null, id: string | null, blockType: string, field: string, categoryLevel: (
+        { id: string, name: string, namePlural: string | null }
+        & { __typename: 'CategoryLevel' }
+      ), groupByCategoryLevel: (
+        { id: string }
+        & { __typename: 'CategoryLevel' }
+      ) | null, categoryBlockType: (
+        { id: string, identifier: string, hideCategoryIdentifiers: boolean, categories: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, indicators: Array<(
+            { id: string, name: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null, parent: (
+            { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+              { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+                { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+                  { id: string, name: string, namePlural: string | null }
+                  & { __typename: 'CategoryLevel' }
+                ) | null, image: (
+                  { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, large: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, small: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, social: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, rendition: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, indicators: Array<(
+                  { id: string, values: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorValue' }
+                  ) | null> | null, goals: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorGoal' }
+                  ) | null> | null, unit: (
+                    { name: string, shortName: string | null }
+                    & { __typename: 'Unit' }
+                  ) }
+                  & { __typename: 'Indicator' }
+                )>, iconImage: (
+                  { rendition: (
+                    { src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, categoryPage: (
+                  { id: string | null, title: string, urlPath: string, live: boolean }
+                  & { __typename: 'CategoryPage' }
+                ) | null, type: (
+                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                  & { __typename: 'CategoryType' }
+                ), attributes: Array<(
+                  { id: string, key: string }
+                  & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+                ) | (
+                  { value: string, id: string, key: string }
+                  & { __typename: 'AttributeRichText' | 'AttributeText' }
+                )> | null }
+                & { __typename: 'Category' }
+              ) | null, level: (
+                { id: string, name: string, namePlural: string | null }
+                & { __typename: 'CategoryLevel' }
+              ) | null, image: (
+                { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, large: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, small: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, social: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, rendition: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, indicators: Array<(
+                { id: string, values: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorValue' }
+                ) | null> | null, goals: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorGoal' }
+                ) | null> | null, unit: (
+                  { name: string, shortName: string | null }
+                  & { __typename: 'Unit' }
+                ) }
+                & { __typename: 'Indicator' }
+              )>, iconImage: (
+                { rendition: (
+                  { src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, categoryPage: (
+                { id: string | null, title: string, urlPath: string, live: boolean }
+                & { __typename: 'CategoryPage' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename: 'CategoryType' }
+              ), attributes: Array<(
+                { id: string, key: string }
+                & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+              ) | (
+                { value: string, id: string, key: string }
+                & { __typename: 'AttributeRichText' | 'AttributeText' }
+              )> | null }
+              & { __typename: 'Category' }
+            ) | null, level: (
+              { id: string, name: string, namePlural: string | null }
+              & { __typename: 'CategoryLevel' }
+            ) | null, image: (
+              { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, large: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, small: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, social: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, rendition: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, indicators: Array<(
+              { id: string, values: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorValue' }
+              ) | null> | null, goals: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorGoal' }
+              ) | null> | null, unit: (
+                { name: string, shortName: string | null }
+                & { __typename: 'Unit' }
+              ) }
+              & { __typename: 'Indicator' }
+            )>, iconImage: (
+              { rendition: (
+                { src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, categoryPage: (
+              { id: string | null, title: string, urlPath: string, live: boolean }
+              & { __typename: 'CategoryPage' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename: 'CategoryType' }
+            ), attributes: Array<(
+              { id: string, key: string }
+              & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+            ) | (
+              { value: string, id: string, key: string }
+              & { __typename: 'AttributeRichText' | 'AttributeText' }
+            )> | null }
+            & { __typename: 'Category' }
+          ) | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'CategoryType' }
+      ) }
+      & { __typename: 'CategoryTypeLevelListBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string }
+      & { __typename: 'CharBlock' | 'RichTextBlock' | 'TextBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string, choices: Array<(
+        { key: string, value: string }
+        & { __typename: 'ChoiceOption' }
+      )> }
+      & { __typename: 'ChoiceBlock' }
     ) | (
       { id: string | null, blockType: string, field: string, blocks: Array<(
         { blockType: string }
@@ -12348,7 +14358,7 @@ export type GetHomePageQuery = (
       )> }
       & { __typename: 'DashboardRowBlock' }
     ) | (
-      { layout: string, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
+      { layout: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
         { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
           { id: string, width: number, height: number, src: string }
           & { __typename: 'ImageRendition' }
@@ -12369,7 +14379,13 @@ export type GetHomePageQuery = (
       ) | null }
       & { __typename: 'FrontPageHeroBlock' }
     ) | (
-      { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<(
+      { style: string | null, id: string | null, blockType: string, field: string, indicator: (
+        { id: string }
+        & { __typename: 'Indicator' }
+      ) | null }
+      & { __typename: 'IndicatorBlock' }
+    ) | (
+      { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
         { style: string | null, indicator: (
           { id: string, identifier: string | null, name: string, description: string | null, timeResolution: IndicatorTimeResolution, level: string | null, unit: (
             { id: string, name: string }
@@ -12384,7 +14400,7 @@ export type GetHomePageQuery = (
           & { __typename: 'Indicator' }
         ) | null }
         & { __typename: 'IndicatorBlock' }
-      )> | null }
+      ) | null> | null }
       & { __typename: 'IndicatorGroupBlock' }
     ) | (
       { title: string | null, body: string | null, id: string | null, blockType: string, field: string, blocks: Array<(
@@ -12419,28 +14435,28 @@ export type GetHomePageQuery = (
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )>, categories: Array<(
+          ) | null> | null, categories: Array<(
             { id: string }
             & { __typename: 'DimensionCategory' }
           )> }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )> }
+          ) | null> | null }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, common: (
           { id: string, normalizations: Array<(
             { unit: (
               { shortName: string | null, name: string }
               & { __typename: 'Unit' }
-            ), normalizer: (
+            ) | null, normalizer: (
               { name: string, id: string, identifier: string | null }
               & { __typename: 'CommonIndicator' }
-            ) }
+            ) | null }
             & { __typename: 'CommonIndicatorNormalization' }
-          )> }
+          ) | null> | null }
           & { __typename: 'CommonIndicator' }
         ) | null }
         & { __typename: 'Indicator' }
@@ -12486,9 +14502,12 @@ export type GetHomePageQuery = (
       { heading: string | null, helpText: string | null, outcomeNodeId: string | null, id: string | null, blockType: string, field: string }
       & { __typename: 'PathsOutcomeBlock' }
     ) | (
-      { value: string, id: string | null, blockType: string, field: string }
-      & { __typename: 'RichTextBlock' }
-    )> }
+      { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { question: string | null, answer: string | null }
+        & { __typename: 'QuestionBlock' }
+      ) | null> | null }
+      & { __typename: 'QuestionAnswerBlock' }
+    ) | null> | null }
     & { __typename: 'PlanRootPage' }
   ) | null, plan: (
     { id: string, primaryActionClassification: (
@@ -12606,7 +14625,7 @@ export type IndicatorDetailsQuery = (
     ) | null, values: Array<(
       { id: string, date: string | null, value: number }
       & { __typename: 'IndicatorValue' }
-    )>, goals: Array<(
+    ) | null> | null, goals: Array<(
       { id: string, date: string | null, value: number, scenario: (
         { id: string }
         & { __typename: 'Scenario' }
@@ -12636,15 +14655,27 @@ export type IndicatorDetailsQuery = (
         & { __typename: 'ActionImpact' }
       ) | null }
       & { __typename: 'Action' }
-    )>, relatedCauses: Array<(
+    ) | null> | null, relatedCauses: Array<(
       { id: string, effectType: RelatedIndicatorEffectType, confidenceLevel: RelatedIndicatorConfidenceLevel, causalIndicator: (
-        { id: string, name: string, level: string | null }
+        { id: string, name: string, level: string | null, plans: Array<(
+          { identifier: string, viewUrl: string | null, parent: (
+            { identifier: string }
+            & { __typename: 'Plan' }
+          ) | null }
+          & { __typename: 'Plan' }
+        )> }
         & { __typename: 'Indicator' }
       ) }
       & { __typename: 'RelatedIndicator' }
     )>, relatedEffects: Array<(
       { id: string, effectType: RelatedIndicatorEffectType, confidenceLevel: RelatedIndicatorConfidenceLevel, effectIndicator: (
-        { id: string, name: string, level: string | null }
+        { id: string, name: string, level: string | null, plans: Array<(
+          { identifier: string, viewUrl: string | null, parent: (
+            { identifier: string }
+            & { __typename: 'Plan' }
+          ) | null }
+          & { __typename: 'Plan' }
+        )> }
         & { __typename: 'Indicator' }
       ) }
       & { __typename: 'RelatedIndicator' }
@@ -12702,7 +14733,7 @@ export type OrganizationDetailsQuery = (
       ), primaryOrgs: Array<(
         { id: string, name: string }
         & { __typename: 'Organization' }
-      )>, actionImpacts: Array<(
+      ) | null>, actionImpacts: Array<(
         { id: string }
         & { __typename: 'ActionImpact' }
       )>, actionStatusSummaries: Array<(
@@ -12866,7 +14897,7 @@ export type OrganizationDetailsQuery = (
     ), primaryOrgs: Array<(
       { id: string, name: string }
       & { __typename: 'Organization' }
-    )>, actionImpacts: Array<(
+    ) | null>, actionImpacts: Array<(
       { id: string }
       & { __typename: 'ActionImpact' }
     )>, actionStatusSummaries: Array<(
@@ -13005,7 +15036,7 @@ export type OrgContentPlanFragment = (
   ), primaryOrgs: Array<(
     { id: string, name: string }
     & { __typename: 'Organization' }
-  )>, actionImpacts: Array<(
+  ) | null>, actionImpacts: Array<(
     { id: string }
     & { __typename: 'ActionImpact' }
   )>, actionStatusSummaries: Array<(
@@ -13144,7 +15175,7 @@ export type GetPlanContextQueryVariables = Exact<{
 
 export type GetPlanContextQuery = (
   { plan: (
-    { id: string, identifier: string, name: string, shortName: string | null, versionName: string, themeIdentifier: string | null, primaryLanguage: string, otherLanguages: Array<string>, hideActionIdentifiers: boolean, publishedAt: string | null, kausalPathsInstanceUuid: string, viewUrl: string | null, actionReportExportViewUrl: string | null, serveFileBaseUrl: string, adminUrl: string | null, accessibilityStatementUrl: string | null, externalFeedbackUrl: string | null, primaryActionClassification: (
+    { id: string, identifier: string, name: string, shortName: string | null, versionName: string, themeIdentifier: string | null, primaryLanguage: string, otherLanguages: Array<string>, hideActionIdentifiers: boolean | null, publishedAt: string | null, kausalPathsInstanceUuid: string, viewUrl: string | null, actionReportExportViewUrl: string | null, serveFileBaseUrl: string, adminUrl: string | null, accessibilityStatementUrl: string | null, externalFeedbackUrl: string | null, primaryActionClassification: (
       { id: string, identifier: string, hideCategoryIdentifiers: boolean, common: (
         { identifier: string }
         & { __typename: 'CommonCategoryType' }
@@ -13198,10 +15229,10 @@ export type GetPlanContextQuery = (
     )>, impactGroups: Array<(
       { id: string }
       & { __typename: 'ImpactGroup' }
-    )>, primaryOrgs: Array<(
+    ) | null>, primaryOrgs: Array<(
       { id: string }
       & { __typename: 'Organization' }
-    )>, generalContent: (
+    ) | null>, generalContent: (
       { id: string, siteTitle: string, siteDescription: string, officialNameDescription: string, copyrightText: string, creativeCommonsLicense: string, ownerUrl: string, ownerName: string, actionTerm: SiteGeneralContentActionTerm, actionTaskTerm: SiteGeneralContentActionTaskTerm, organizationTerm: SiteGeneralContentOrganizationTerm, sitewideAnnouncement: string | null }
       & { __typename: 'SiteGeneralContent' }
     ), mainMenu: (
@@ -13217,7 +15248,7 @@ export type GetPlanContextQuery = (
           & { __typename: 'PageMenuItem' }
         ) | null }
         & { __typename: 'PageMenuItem' }
-      )> }
+      ) | null> }
       & { __typename: 'MainMenu' }
     ) | null, footer: (
       { items: Array<{ __typename: 'ExternalLinkMenuItem' } | (
@@ -13233,9 +15264,9 @@ export type GetPlanContextQuery = (
             & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
           ) }
           & { __typename: 'PageMenuItem' }
-        )> | null }
+        ) | null> | null }
         & { __typename: 'PageMenuItem' }
-      )> }
+      ) | null> }
       & { __typename: 'Footer' }
     ) | null, features: (
       { allowPublicSiteLogin: boolean, hasActionContactPersonRoles: boolean, contactPersonsPublicData: PlanFeaturesContactPersonsPublicData, contactPersonsShowPicture: boolean, contactPersonsShowOrganizationAncestors: boolean, enableSearch: boolean, hasActionIdentifiers: boolean, hasActionOfficialName: boolean, hasActionLeadParagraph: boolean, hasActionPrimaryOrgs: boolean, showAdminLink: boolean, enableIndicatorComparison: boolean, minimalStatuses: boolean }
@@ -13252,7 +15283,7 @@ export type GetPlanContextQuery = (
         & { __typename: 'Organization' }
       ) }
       & { __typename: 'Plan' }
-    )>, supersededBy: (
+    ) | null>, supersededBy: (
       { name: string, shortName: string | null, versionName: string, identifier: string, viewUrl: string | null, publishedAt: string | null }
       & { __typename: 'Plan' }
     ) | null, supersededPlans: Array<(
@@ -13291,7 +15322,7 @@ export type GetPlanContextQuery = (
     ) | null, additionalLinks: (
       { items: Array<{ __typename: 'ExternalLinkMenuItem' } | (
         { id: string, crossPlanLink: boolean | null, viewUrl: string | null, page: (
-          { title: string, url: string | null, urlPath: string, slug: string, body: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'RichTextBlock' } | (
+          { title: string, url: string | null, urlPath: string, slug: string, body: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
             { blocks: Array<(
               { field: string }
               & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
@@ -13318,14 +15349,14 @@ export type GetPlanContextQuery = (
               & { __typename: 'CharBlock' }
             )> }
             & { __typename: 'AccessibilityStatementContactInformationBlock' }
-          )> | null }
+          ) | null> | null }
           & { __typename: 'AccessibilityStatementPage' }
         ) | (
           { title: string, url: string | null, urlPath: string, slug: string }
           & { __typename: 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
         ) }
         & { __typename: 'PageMenuItem' }
-      )> }
+      ) | null> }
       & { __typename: 'AdditionalLinks' }
     ) | null, actionListPage: (
       { includeRelatedPlans: boolean | null, actionDateFormat: string | null, taskDateFormat: string | null }
@@ -13333,14 +15364,14 @@ export type GetPlanContextQuery = (
     ) | null }
     & { __typename: 'Plan' }
   ) | null, workflowStates: Array<(
-    { id: string, description: string | null }
+    { id: string | null, description: string | null }
     & { __typename: 'WorkflowStateDescription' }
   ) | null> | null }
   & { __typename: 'Query' }
 );
 
 export type PlanContextFragment = (
-  { id: string, identifier: string, name: string, shortName: string | null, versionName: string, themeIdentifier: string | null, primaryLanguage: string, otherLanguages: Array<string>, hideActionIdentifiers: boolean, publishedAt: string | null, kausalPathsInstanceUuid: string, viewUrl: string | null, actionReportExportViewUrl: string | null, serveFileBaseUrl: string, adminUrl: string | null, accessibilityStatementUrl: string | null, externalFeedbackUrl: string | null, primaryActionClassification: (
+  { id: string, identifier: string, name: string, shortName: string | null, versionName: string, themeIdentifier: string | null, primaryLanguage: string, otherLanguages: Array<string>, hideActionIdentifiers: boolean | null, publishedAt: string | null, kausalPathsInstanceUuid: string, viewUrl: string | null, actionReportExportViewUrl: string | null, serveFileBaseUrl: string, adminUrl: string | null, accessibilityStatementUrl: string | null, externalFeedbackUrl: string | null, primaryActionClassification: (
     { id: string, identifier: string, hideCategoryIdentifiers: boolean, common: (
       { identifier: string }
       & { __typename: 'CommonCategoryType' }
@@ -13394,10 +15425,10 @@ export type PlanContextFragment = (
   )>, impactGroups: Array<(
     { id: string }
     & { __typename: 'ImpactGroup' }
-  )>, primaryOrgs: Array<(
+  ) | null>, primaryOrgs: Array<(
     { id: string }
     & { __typename: 'Organization' }
-  )>, generalContent: (
+  ) | null>, generalContent: (
     { id: string, siteTitle: string, siteDescription: string, officialNameDescription: string, copyrightText: string, creativeCommonsLicense: string, ownerUrl: string, ownerName: string, actionTerm: SiteGeneralContentActionTerm, actionTaskTerm: SiteGeneralContentActionTaskTerm, organizationTerm: SiteGeneralContentOrganizationTerm, sitewideAnnouncement: string | null }
     & { __typename: 'SiteGeneralContent' }
   ), mainMenu: (
@@ -13413,7 +15444,7 @@ export type PlanContextFragment = (
         & { __typename: 'PageMenuItem' }
       ) | null }
       & { __typename: 'PageMenuItem' }
-    )> }
+    ) | null> }
     & { __typename: 'MainMenu' }
   ) | null, footer: (
     { items: Array<{ __typename: 'ExternalLinkMenuItem' } | (
@@ -13429,9 +15460,9 @@ export type PlanContextFragment = (
           & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
         ) }
         & { __typename: 'PageMenuItem' }
-      )> | null }
+      ) | null> | null }
       & { __typename: 'PageMenuItem' }
-    )> }
+    ) | null> }
     & { __typename: 'Footer' }
   ) | null, features: (
     { allowPublicSiteLogin: boolean, hasActionContactPersonRoles: boolean, contactPersonsPublicData: PlanFeaturesContactPersonsPublicData, contactPersonsShowPicture: boolean, contactPersonsShowOrganizationAncestors: boolean, enableSearch: boolean, hasActionIdentifiers: boolean, hasActionOfficialName: boolean, hasActionLeadParagraph: boolean, hasActionPrimaryOrgs: boolean, showAdminLink: boolean, enableIndicatorComparison: boolean, minimalStatuses: boolean }
@@ -13448,7 +15479,7 @@ export type PlanContextFragment = (
       & { __typename: 'Organization' }
     ) }
     & { __typename: 'Plan' }
-  )>, supersededBy: (
+  ) | null>, supersededBy: (
     { name: string, shortName: string | null, versionName: string, identifier: string, viewUrl: string | null, publishedAt: string | null }
     & { __typename: 'Plan' }
   ) | null, supersededPlans: Array<(
@@ -13487,7 +15518,7 @@ export type PlanContextFragment = (
   ) | null, additionalLinks: (
     { items: Array<{ __typename: 'ExternalLinkMenuItem' } | (
       { id: string, crossPlanLink: boolean | null, viewUrl: string | null, page: (
-        { title: string, url: string | null, urlPath: string, slug: string, body: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'RichTextBlock' } | (
+        { title: string, url: string | null, urlPath: string, slug: string, body: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
           { blocks: Array<(
             { field: string }
             & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
@@ -13514,14 +15545,14 @@ export type PlanContextFragment = (
             & { __typename: 'CharBlock' }
           )> }
           & { __typename: 'AccessibilityStatementContactInformationBlock' }
-        )> | null }
+        ) | null> | null }
         & { __typename: 'AccessibilityStatementPage' }
       ) | (
         { title: string, url: string | null, urlPath: string, slug: string }
         & { __typename: 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
       ) }
       & { __typename: 'PageMenuItem' }
-    )> }
+    ) | null> }
     & { __typename: 'AdditionalLinks' }
   ) | null, actionListPage: (
     { includeRelatedPlans: boolean | null, actionDateFormat: string | null, taskDateFormat: string | null }
@@ -13582,12 +15613,12 @@ export type IndicatorSparklineGraphDataQuery = (
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )>, categories: Array<(
+      ) | null> | null, categories: Array<(
         { id: string }
         & { __typename: 'DimensionCategory' }
       )> }
       & { __typename: 'IndicatorValue' }
-    )>, dimensions: Array<(
+    ) | null> | null, dimensions: Array<(
       { dimension: (
         { id: string, name: string, categories: Array<(
           { id: string, name: string }
@@ -13600,7 +15631,7 @@ export type IndicatorSparklineGraphDataQuery = (
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )>, scenario: (
+      ) | null> | null, scenario: (
         { id: string }
         & { __typename: 'Scenario' }
       ) | null }
@@ -13613,12 +15644,12 @@ export type IndicatorSparklineGraphDataQuery = (
         { unit: (
           { shortName: string | null }
           & { __typename: 'Unit' }
-        ), normalizer: (
+        ) | null, normalizer: (
           { name: string, id: string, identifier: string | null }
           & { __typename: 'CommonIndicator' }
-        ) }
+        ) | null }
         & { __typename: 'CommonIndicatorNormalization' }
-      )>, indicators: Array<(
+      ) | null> | null, indicators: Array<(
         { id: string, timeResolution: IndicatorTimeResolution, minValue: number | null, maxValue: number | null, organization: (
           { id: string, name: string, abbreviation: string | null }
           & { __typename: 'Organization' }
@@ -13629,12 +15660,12 @@ export type IndicatorSparklineGraphDataQuery = (
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )>, categories: Array<(
+          ) | null> | null, categories: Array<(
             { id: string }
             & { __typename: 'DimensionCategory' }
           )> }
           & { __typename: 'IndicatorValue' }
-        )>, dimensions: Array<(
+        ) | null> | null, dimensions: Array<(
           { dimension: (
             { id: string, name: string, categories: Array<(
               { id: string, name: string }
@@ -13647,7 +15678,7 @@ export type IndicatorSparklineGraphDataQuery = (
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )>, scenario: (
+          ) | null> | null, scenario: (
             { id: string }
             & { __typename: 'Scenario' }
           ) | null }

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -19,7 +19,6 @@ export type Scalars = {
   PointScalar: { input: any; output: any; }
   PositiveInt: { input: number; output: number; }
   UUID: { input: string; output: string; }
-  _Any: { input: any; output: any; }
 };
 
 /** An enumeration. */
@@ -203,12 +202,6 @@ export enum IndicatorTimeResolution {
   Year = 'YEAR'
 }
 
-export type InstanceContext = {
-  hostname: InputMaybe<Scalars['String']['input']>;
-  identifier: InputMaybe<Scalars['ID']['input']>;
-  locale: InputMaybe<Scalars['String']['input']>;
-};
-
 /** An enumeration. */
 export enum ModelAction {
   Add = 'ADD',
@@ -359,9 +352,13 @@ export type UserFeedbackMutationInput = {
   url: Scalars['String']['input'];
 };
 
+/** An enumeration. */
 export enum WorkflowState {
+  /** Approved */
   Approved = 'APPROVED',
+  /** Draft */
   Draft = 'DRAFT',
+  /** Published */
   Published = 'PUBLISHED'
 }
 
@@ -386,14 +383,14 @@ export type GetSitemapQuery = (
   { planIndicators: Array<(
     { id: string }
     & { __typename: 'Indicator' }
-  )> | null, plan: (
+  ) | null> | null, plan: (
     { primaryLanguage: string, otherLanguages: Array<string>, actions: Array<(
       { identifier: string }
       & { __typename: 'Action' }
     )>, pages: Array<(
       { urlPath: string }
       & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
-    )> | null }
+    ) | null> | null }
     & { __typename: 'Plan' }
   ) | null }
   & { __typename: 'Query' }
@@ -430,7 +427,7 @@ export type SearchQueryQueryVariables = Exact<{
 export type SearchQueryQuery = (
   { search: (
     { hits: Array<(
-      { id: string, title: string, url: string | null, highlight: string | null, plan: (
+      { id: string | null, title: string | null, url: string | null, highlight: string | null, plan: (
         { identifier: string, name: string, shortName: string | null, image: (
           { rendition: (
             { src: string }
@@ -442,7 +439,7 @@ export type SearchQueryQuery = (
           & { __typename: 'Organization' }
         ) }
         & { __typename: 'Plan' }
-      ), object: (
+      ) | null, object: (
         { identifier: string, primaryOrg: (
           { name: string, logo: (
             { rendition: (
@@ -471,9 +468,9 @@ export type SearchQueryQuery = (
         & { __typename: 'CategoryPage' }
       ) | null }
       & { __typename: 'SearchHit' }
-    )> }
+    ) | null> | null }
     & { __typename: 'SearchResults' }
-  ) }
+  ) | null }
   & { __typename: 'Query' }
 );
 
@@ -648,7 +645,7 @@ export type GetActionListQuery = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -674,7 +671,7 @@ export type GetActionListQuery = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )>, parent: (
+      )> | null, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -702,7 +699,7 @@ export type GetActionListQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -728,7 +725,7 @@ export type GetActionListQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -755,7 +752,7 @@ export type GetActionListQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -781,7 +778,7 @@ export type GetActionListQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -808,7 +805,7 @@ export type GetActionListQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -834,7 +831,7 @@ export type GetActionListQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null }
       & { __typename: 'Category' }
@@ -860,7 +857,7 @@ export type GetActionListQuery = (
       ) }
       & { __typename: 'Action' }
     ) | null, plan: (
-      { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+      { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
         { rendition: (
           { src: string }
           & { __typename: 'ImageRendition' }
@@ -986,7 +983,7 @@ export type GetActionListForBlockQuery = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -1012,7 +1009,7 @@ export type GetActionListForBlockQuery = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )>, parent: (
+      )> | null, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -1040,7 +1037,7 @@ export type GetActionListForBlockQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -1066,7 +1063,7 @@ export type GetActionListForBlockQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -1093,7 +1090,7 @@ export type GetActionListForBlockQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -1119,7 +1116,7 @@ export type GetActionListForBlockQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -1146,7 +1143,7 @@ export type GetActionListForBlockQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -1172,7 +1169,7 @@ export type GetActionListForBlockQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null }
       & { __typename: 'Category' }
@@ -1198,7 +1195,7 @@ export type GetActionListForBlockQuery = (
       ) }
       & { __typename: 'Action' }
     ) | null, plan: (
-      { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+      { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
         { rendition: (
           { src: string }
           & { __typename: 'ImageRendition' }
@@ -1273,10 +1270,10 @@ export type GetCategoriesForTreeMapQuery = (
       ) | null }
       & { __typename: 'Image' }
     ) | null, categoryPage: (
-      { id: string | null, title: string, path: string, slug: string, url: string | null, urlPath: string, depth: number | null, contentType: string, body: Array<{ __typename: 'ActionListBlock' | 'AdaptiveEmbedBlock' | 'CategoryListBlock' | 'IndicatorGroupBlock' | 'QuestionAnswerBlock' | 'RelatedIndicatorsBlock' } | (
+      { id: string | null, title: string, path: string, slug: string, url: string | null, urlPath: string, depth: number | null, contentType: string, body: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' } | { __typename: 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
         { value: string }
         & { __typename: 'RichTextBlock' }
-      )> | null }
+      ) | null> | null }
       & { __typename: 'CategoryPage' }
     ) | null, parent: (
       { id: string }
@@ -1290,9 +1287,9 @@ export type GetCategoriesForTreeMapQuery = (
     ), attributes: Array<{ __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeRichText' | 'AttributeText' } | (
       { value: number }
       & { __typename: 'AttributeNumericValue' }
-    )> }
+    )> | null }
     & { __typename: 'Category' }
-  )> | null }
+  ) | null> | null }
   & { __typename: 'Query' }
 );
 
@@ -1332,7 +1329,7 @@ export type PlanFragmentFragment = (
   )>, primaryOrgs: Array<(
     { id: string, abbreviation: string | null, name: string }
     & { __typename: 'Organization' }
-  )> }
+  ) | null> }
   & { __typename: 'Plan' }
 );
 
@@ -1356,7 +1353,7 @@ export type ActionFragmentFragment = (
     { identifier: ActionTimelinessIdentifier }
     & { __typename: 'ActionTimeliness' }
   ), plan?: (
-    { id: string, shortName: string | null, name: string, shortIdentifier: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+    { id: string, shortName: string | null, name: string, shortIdentifier: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
       { rendition: (
         { src: string }
         & { __typename: 'ImageRendition' }
@@ -1491,7 +1488,7 @@ export type DashboardActionListQuery = (
     )>, primaryOrgs: Array<(
       { id: string, abbreviation: string | null, name: string }
       & { __typename: 'Organization' }
-    )> }
+    ) | null> }
     & { __typename: 'Plan' }
   ) | null, planActions?: Array<(
     { id: string, identifier: string, name: string, viewUrl?: string, color: string | null, hasDependencyRelationships: boolean | null, manualStatusReason: string | null, completion: number | null, officialName: string | null, updatedAt: string, scheduleContinuous: boolean, startDate: string | null, endDate: string | null, order: number, indicatorsCount: number | null, hasIndicatorsWithGoals: boolean | null, status: (
@@ -1513,7 +1510,7 @@ export type DashboardActionListQuery = (
       { identifier: ActionTimelinessIdentifier }
       & { __typename: 'ActionTimeliness' }
     ), plan?: (
-      { id: string, shortName: string | null, name: string, shortIdentifier: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+      { id: string, shortName: string | null, name: string, shortIdentifier: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
         { rendition: (
           { src: string }
           & { __typename: 'ImageRendition' }
@@ -1618,7 +1615,7 @@ export type DashboardActionListQuery = (
       { identifier: ActionTimelinessIdentifier }
       & { __typename: 'ActionTimeliness' }
     ), plan?: (
-      { id: string, shortName: string | null, name: string, shortIdentifier: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+      { id: string, shortName: string | null, name: string, shortIdentifier: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
         { rendition: (
           { src: string }
           & { __typename: 'ImageRendition' }
@@ -1858,7 +1855,7 @@ export type IndicatorHightlightListQuery = (
       & { __typename: 'IndicatorValue' }
     ) | null }
     & { __typename: 'Indicator' }
-  )> | null }
+  ) | null> | null }
   & { __typename: 'Query' }
 );
 
@@ -1883,12 +1880,12 @@ export type IndicatorListQuery = (
             { unit: (
               { shortName: string | null }
               & { __typename: 'Unit' }
-            ), normalizer: (
+            ) | null, normalizer: (
               { name: string, id: string, identifier: string | null }
               & { __typename: 'CommonIndicator' }
-            ) }
+            ) | null }
             & { __typename: 'CommonIndicatorNormalization' }
-          )> }
+          ) | null> | null }
           & { __typename: 'CommonIndicator' }
         ) | null, categories: Array<(
           { id: string, name: string, parent: (
@@ -1906,7 +1903,7 @@ export type IndicatorListQuery = (
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )> }
+          ) | null> | null }
           & { __typename: 'IndicatorValue' }
         ) | null, unit: (
           { shortName: string | null }
@@ -1915,7 +1912,7 @@ export type IndicatorListQuery = (
         & { __typename: 'Indicator' }
       ) }
       & { __typename: 'IndicatorLevel' }
-    )>, categoryTypes: Array<(
+    ) | null>, categoryTypes: Array<(
       { name: string, id: string, identifier: string, categories: Array<(
         { id: string, identifier: string, order: number, name: string, parent: (
           { id: string }
@@ -1956,7 +1953,7 @@ export type IndicatorListQuery = (
       & { __typename: 'CommonIndicator' }
     ) | null }
     & { __typename: 'Indicator' }
-  )> | null, relatedPlanIndicators?: Array<(
+  ) | null> | null, relatedPlanIndicators?: Array<(
     { id: string, name: string, level: string | null, timeResolution: IndicatorTimeResolution, organization: (
       { id: string, name: string }
       & { __typename: 'Organization' }
@@ -1965,12 +1962,12 @@ export type IndicatorListQuery = (
         { unit: (
           { shortName: string | null }
           & { __typename: 'Unit' }
-        ), normalizer: (
+        ) | null, normalizer: (
           { name: string, id: string, identifier: string | null }
           & { __typename: 'CommonIndicator' }
-        ) }
+        ) | null }
         & { __typename: 'CommonIndicatorNormalization' }
-      )> }
+      ) | null> | null }
       & { __typename: 'CommonIndicator' }
     ) | null, latestGraph: (
       { id: string }
@@ -1979,7 +1976,7 @@ export type IndicatorListQuery = (
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )> }
+      ) | null> | null }
       & { __typename: 'IndicatorValue' }
     ) | null, unit: (
       { shortName: string | null }
@@ -2029,12 +2026,12 @@ export type IndicatorGraphDataQuery = (
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )>, categories: Array<(
+      ) | null> | null, categories: Array<(
         { id: string }
         & { __typename: 'DimensionCategory' }
       )> }
       & { __typename: 'IndicatorValue' }
-    )>, dimensions: Array<(
+    ) | null> | null, dimensions: Array<(
       { dimension: (
         { id: string, name: string, categories: Array<(
           { id: string, name: string }
@@ -2047,7 +2044,7 @@ export type IndicatorGraphDataQuery = (
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )>, scenario: (
+      ) | null> | null, scenario: (
         { id: string }
         & { __typename: 'Scenario' }
       ) | null }
@@ -2060,12 +2057,12 @@ export type IndicatorGraphDataQuery = (
         { unit: (
           { shortName: string | null }
           & { __typename: 'Unit' }
-        ), normalizer: (
+        ) | null, normalizer: (
           { name: string, id: string, identifier: string | null }
           & { __typename: 'CommonIndicator' }
-        ) }
+        ) | null }
         & { __typename: 'CommonIndicatorNormalization' }
-      )>, indicators: Array<(
+      ) | null> | null, indicators: Array<(
         { id: string, timeResolution: IndicatorTimeResolution, minValue: number | null, maxValue: number | null, organization: (
           { id: string, name: string, abbreviation: string | null }
           & { __typename: 'Organization' }
@@ -2076,12 +2073,12 @@ export type IndicatorGraphDataQuery = (
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )>, categories: Array<(
+          ) | null> | null, categories: Array<(
             { id: string }
             & { __typename: 'DimensionCategory' }
           )> }
           & { __typename: 'IndicatorValue' }
-        )>, dimensions: Array<(
+        ) | null> | null, dimensions: Array<(
           { dimension: (
             { id: string, name: string, categories: Array<(
               { id: string, name: string }
@@ -2094,7 +2091,7 @@ export type IndicatorGraphDataQuery = (
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )>, scenario: (
+          ) | null> | null, scenario: (
             { id: string }
             & { __typename: 'Scenario' }
           ) | null }
@@ -2139,7 +2136,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
       { id: string, values: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorValue' }
-      )>, goals: Array<(
+      ) | null> | null, goals: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorGoal' }
       ) | null> | null, unit: (
@@ -2165,7 +2162,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
     ) | (
       { value: string, id: string, key: string }
       & { __typename: 'AttributeRichText' | 'AttributeText' }
-    )>, parent: (
+    )> | null, parent: (
       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -2193,7 +2190,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -2219,7 +2216,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -2246,7 +2243,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -2272,7 +2269,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null, level: (
         { id: string, name: string, namePlural: string | null }
@@ -2299,7 +2296,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -2325,7 +2322,7 @@ type AttributesBlockAttribute_AttributeCategoryChoice_Fragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     ) | null }
     & { __typename: 'Category' }
@@ -2424,7 +2421,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
       { id: string, values: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorValue' }
-      )>, goals: Array<(
+      ) | null> | null, goals: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorGoal' }
       ) | null> | null, unit: (
@@ -2450,7 +2447,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
     ) | (
       { value: string, id: string, key: string }
       & { __typename: 'AttributeRichText' | 'AttributeText' }
-    )>, parent: (
+    )> | null, parent: (
       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -2478,7 +2475,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -2504,7 +2501,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -2531,7 +2528,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -2557,7 +2554,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null, level: (
         { id: string, name: string, namePlural: string | null }
@@ -2584,7 +2581,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -2610,7 +2607,7 @@ type AttributesBlockAttributeWithNestedType_AttributeCategoryChoice_Fragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     ) | null }
     & { __typename: 'Category' }
@@ -2695,7 +2692,7 @@ export type ActionCardFragment = (
       { id: string, values: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorValue' }
-      )>, goals: Array<(
+      ) | null> | null, goals: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorGoal' }
       ) | null> | null, unit: (
@@ -2721,7 +2718,7 @@ export type ActionCardFragment = (
     ) | (
       { value: string, id: string, key: string }
       & { __typename: 'AttributeRichText' | 'AttributeText' }
-    )>, parent: (
+    )> | null, parent: (
       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -2749,7 +2746,7 @@ export type ActionCardFragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -2775,7 +2772,7 @@ export type ActionCardFragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -2802,7 +2799,7 @@ export type ActionCardFragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -2828,7 +2825,7 @@ export type ActionCardFragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null, level: (
         { id: string, name: string, namePlural: string | null }
@@ -2855,7 +2852,7 @@ export type ActionCardFragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -2881,7 +2878,7 @@ export type ActionCardFragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     ) | null }
     & { __typename: 'Category' }
@@ -2907,7 +2904,7 @@ export type ActionCardFragment = (
     ) }
     & { __typename: 'Action' }
   ) | null, plan: (
-    { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+    { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
       { rendition: (
         { src: string }
         & { __typename: 'ImageRendition' }
@@ -3133,7 +3130,7 @@ export type CategoryFragmentFragment = (
     { id: string, values: Array<(
       { date: string | null, value: number }
       & { __typename: 'IndicatorValue' }
-    )>, goals: Array<(
+    ) | null> | null, goals: Array<(
       { date: string | null, value: number }
       & { __typename: 'IndicatorGoal' }
     ) | null> | null, unit: (
@@ -3159,7 +3156,7 @@ export type CategoryFragmentFragment = (
   ) | (
     { value: string, id: string, key: string }
     & { __typename: 'AttributeRichText' | 'AttributeText' }
-  )> }
+  )> | null }
   & { __typename: 'Category' }
 );
 
@@ -3192,7 +3189,7 @@ export type CategoryWithParentsFragmentFragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -3218,7 +3215,7 @@ export type CategoryWithParentsFragmentFragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null, level: (
         { id: string, name: string, namePlural: string | null }
@@ -3245,7 +3242,7 @@ export type CategoryWithParentsFragmentFragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -3271,7 +3268,7 @@ export type CategoryWithParentsFragmentFragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     ) | null, level: (
       { id: string, name: string, namePlural: string | null }
@@ -3298,7 +3295,7 @@ export type CategoryWithParentsFragmentFragment = (
       { id: string, values: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorValue' }
-      )>, goals: Array<(
+      ) | null> | null, goals: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorGoal' }
       ) | null> | null, unit: (
@@ -3324,7 +3321,7 @@ export type CategoryWithParentsFragmentFragment = (
     ) | (
       { value: string, id: string, key: string }
       & { __typename: 'AttributeRichText' | 'AttributeText' }
-    )> }
+    )> | null }
     & { __typename: 'Category' }
   ) | null }
   & { __typename: 'Category' }
@@ -3356,7 +3353,7 @@ export type CategoryRecursiveFragmentFragment = (
     { id: string, values: Array<(
       { date: string | null, value: number }
       & { __typename: 'IndicatorValue' }
-    )>, goals: Array<(
+    ) | null> | null, goals: Array<(
       { date: string | null, value: number }
       & { __typename: 'IndicatorGoal' }
     ) | null> | null, unit: (
@@ -3382,7 +3379,7 @@ export type CategoryRecursiveFragmentFragment = (
   ) | (
     { value: string, id: string, key: string }
     & { __typename: 'AttributeRichText' | 'AttributeText' }
-  )>, parent: (
+  )> | null, parent: (
     { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -3410,7 +3407,7 @@ export type CategoryRecursiveFragmentFragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -3436,7 +3433,7 @@ export type CategoryRecursiveFragmentFragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null, level: (
         { id: string, name: string, namePlural: string | null }
@@ -3463,7 +3460,7 @@ export type CategoryRecursiveFragmentFragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -3489,7 +3486,7 @@ export type CategoryRecursiveFragmentFragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     ) | null, level: (
       { id: string, name: string, namePlural: string | null }
@@ -3516,7 +3513,7 @@ export type CategoryRecursiveFragmentFragment = (
       { id: string, values: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorValue' }
-      )>, goals: Array<(
+      ) | null> | null, goals: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorGoal' }
       ) | null> | null, unit: (
@@ -3542,7 +3539,7 @@ export type CategoryRecursiveFragmentFragment = (
     ) | (
       { value: string, id: string, key: string }
       & { __typename: 'AttributeRichText' | 'AttributeText' }
-    )> }
+    )> | null }
     & { __typename: 'Category' }
   ) | null }
   & { __typename: 'Category' }
@@ -3783,7 +3780,7 @@ type StreamFieldFragment_AccessibilityStatementContactInformationBlock_Fragment 
 );
 
 type StreamFieldFragment_ActionCategoryFilterCardsBlock_Fragment = (
-  { id: string | null, blockType: string, field: string, cards: Array<(
+  { id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
     { heading: string | null, lead: string | null, category: (
       { id: string, type: (
         { identifier: string }
@@ -3792,22 +3789,16 @@ type StreamFieldFragment_ActionCategoryFilterCardsBlock_Fragment = (
       & { __typename: 'Category' }
     ) | null }
     & { __typename: 'ActionCategoryFilterCardBlock' }
-  )> | null }
+  ) | null> | null }
   & { __typename: 'ActionCategoryFilterCardsBlock' }
 );
 
 type StreamFieldFragment_ActionListBlock_Fragment = (
-  { heading: string | null, helpText: string | null, id: string | null, blockType: string, field: string, categoryFilter: (
-    { id: string, type: (
-      { id: string }
-      & { __typename: 'CategoryType' }
-    ) }
+  { id: string | null, heading: string | null, helpText: string | null, blockType: string, field: string, categoryFilter: (
+    { id: string }
     & { __typename: 'Category' }
   ) | null, groupByCategoryLevel: (
-    { id: string, type: (
-      { id: string }
-      & { __typename: 'CategoryType' }
-    ) }
+    { id: string }
     & { __typename: 'CategoryLevel' }
   ) | null }
   & { __typename: 'ActionListBlock' }
@@ -3822,7 +3813,7 @@ type StreamFieldFragment_AdaptiveEmbedBlock_Fragment = (
 );
 
 type StreamFieldFragment_CardListBlock_Fragment = (
-  { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<(
+  { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
     { heading: string | null, content: string | null, link: string | null, image: (
       { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
         { id: string, width: number, height: number, src: string }
@@ -3843,12 +3834,12 @@ type StreamFieldFragment_CardListBlock_Fragment = (
       & { __typename: 'Image' }
     ) | null }
     & { __typename: 'CardBlock' }
-  )> | null }
+  ) | null> | null }
   & { __typename: 'CardListBlock' }
 );
 
 type StreamFieldFragment_CartographyVisualisationBlock_Fragment = (
-  { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string, account: (
+  { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string | null, account: (
     { provider: CartographyProviderCredentialsProvider, account: string, publicAccessToken: string }
     & { __typename: 'CartographyProviderCredentials' }
   ) }
@@ -3883,7 +3874,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -3909,7 +3900,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )>, parent: (
+      )> | null, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -3937,7 +3928,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -3963,7 +3954,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -3990,7 +3981,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -4016,7 +4007,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -4043,7 +4034,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -4069,7 +4060,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null }
       & { __typename: 'Category' }
@@ -4102,7 +4093,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -4128,7 +4119,7 @@ type StreamFieldFragment_CategoryListBlock_Fragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     )> }
     & { __typename: 'Category' }
@@ -4143,10 +4134,10 @@ type StreamFieldFragment_CategoryTreeMapBlock_Fragment = (
       & { __typename: 'Unit' }
     ) | null }
     & { __typename: 'AttributeType' }
-  ), treeMapCategoryType: (
+  ) | null, treeMapCategoryType: (
     { identifier: string }
     & { __typename: 'CategoryType' }
-  ) }
+  ) | null }
   & { __typename: 'CategoryTreeMapBlock' }
 );
 
@@ -4163,7 +4154,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
         { id: string, name: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -4210,7 +4201,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )>, parent: (
+      )> | null, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -4238,7 +4229,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -4264,7 +4255,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -4291,7 +4282,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -4317,7 +4308,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -4344,7 +4335,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -4370,7 +4361,7 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null }
       & { __typename: 'Category' }
@@ -4555,7 +4546,7 @@ type StreamFieldFragment_DashboardRowBlock_Fragment = (
 );
 
 type StreamFieldFragment_FrontPageHeroBlock_Fragment = (
-  { layout: string, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
+  { layout: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
     { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
       { id: string, width: number, height: number, src: string }
       & { __typename: 'ImageRendition' }
@@ -4638,28 +4629,28 @@ type StreamFieldFragment_IndicatorShowcaseBlock_Fragment = (
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )>, categories: Array<(
+      ) | null> | null, categories: Array<(
         { id: string }
         & { __typename: 'DimensionCategory' }
       )> }
       & { __typename: 'IndicatorValue' }
-    )>, goals: Array<(
+    ) | null> | null, goals: Array<(
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )> }
+      ) | null> | null }
       & { __typename: 'IndicatorGoal' }
     ) | null> | null, common: (
       { id: string, normalizations: Array<(
         { unit: (
           { shortName: string | null, name: string }
           & { __typename: 'Unit' }
-        ), normalizer: (
+        ) | null, normalizer: (
           { name: string, id: string, identifier: string | null }
           & { __typename: 'CommonIndicator' }
-        ) }
+        ) | null }
         & { __typename: 'CommonIndicatorNormalization' }
-      )> }
+      ) | null> | null }
       & { __typename: 'CommonIndicator' }
     ) | null }
     & { __typename: 'Indicator' }
@@ -4711,10 +4702,10 @@ type StreamFieldFragment_PathsOutcomeBlock_Fragment = (
 );
 
 type StreamFieldFragment_QuestionAnswerBlock_Fragment = (
-  { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<(
-    { question: string, answer: string }
+  { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+    { question: string | null, answer: string | null }
     & { __typename: 'QuestionBlock' }
-  )> | null }
+  ) | null> | null }
   & { __typename: 'QuestionAnswerBlock' }
 );
 
@@ -4732,7 +4723,7 @@ export type GetActionDetailsQuery = (
   { action: (
     { id: string, identifier: string, name: string, officialName: string | null, leadParagraph: string, description: string | null, completion: number | null, color: string | null, updatedAt: string, manualStatusReason: string | null, scheduleContinuous: boolean, startDate: string | null, endDate: string | null, dateFormat: ActionDateFormat | null, workflowStatus: (
       { matchingVersion: (
-        { id: string, description: string | null }
+        { id: string | null, description: string | null }
         & { __typename: 'WorkflowStateDescription' }
       ) | null }
       & { __typename: 'WorkflowInfoNode' }
@@ -4792,7 +4783,7 @@ export type GetActionDetailsQuery = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -4818,7 +4809,7 @@ export type GetActionDetailsQuery = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )>, parent: (
+      )> | null, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -4846,7 +4837,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -4872,7 +4863,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -4899,7 +4890,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -4925,7 +4916,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -4952,7 +4943,7 @@ export type GetActionDetailsQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -4978,7 +4969,7 @@ export type GetActionDetailsQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null }
       & { __typename: 'Category' }
@@ -5038,7 +5029,7 @@ export type GetActionDetailsQuery = (
         ) | null, actions: Array<(
           { id: string, identifier: string, name: string }
           & { __typename: 'Action' }
-        )>, plans: Array<(
+        ) | null> | null, plans: Array<(
           { id: string }
           & { __typename: 'Plan' }
         )> }
@@ -5075,7 +5066,7 @@ export type GetActionDetailsQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -5101,7 +5092,7 @@ export type GetActionDetailsQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )>, parent: (
+        )> | null, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -5129,7 +5120,7 @@ export type GetActionDetailsQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -5155,7 +5146,7 @@ export type GetActionDetailsQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -5182,7 +5173,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -5208,7 +5199,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -5235,7 +5226,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -5261,7 +5252,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'Category' }
@@ -5287,7 +5278,7 @@ export type GetActionDetailsQuery = (
         ) }
         & { __typename: 'Action' }
       ) | null, plan: (
-        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
           { rendition: (
             { src: string }
             & { __typename: 'ImageRendition' }
@@ -5333,7 +5324,7 @@ export type GetActionDetailsQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -5359,7 +5350,7 @@ export type GetActionDetailsQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )>, parent: (
+        )> | null, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -5387,7 +5378,7 @@ export type GetActionDetailsQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -5413,7 +5404,7 @@ export type GetActionDetailsQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -5440,7 +5431,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -5466,7 +5457,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -5493,7 +5484,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -5519,7 +5510,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'Category' }
@@ -5545,7 +5536,7 @@ export type GetActionDetailsQuery = (
         ) }
         & { __typename: 'Action' }
       ) | null, plan: (
-        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
           { rendition: (
             { src: string }
             & { __typename: 'ImageRendition' }
@@ -5585,7 +5576,7 @@ export type GetActionDetailsQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -5611,7 +5602,7 @@ export type GetActionDetailsQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )>, parent: (
+        )> | null, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -5639,7 +5630,7 @@ export type GetActionDetailsQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -5665,7 +5656,7 @@ export type GetActionDetailsQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -5692,7 +5683,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -5718,7 +5709,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -5745,7 +5736,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -5771,7 +5762,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'Category' }
@@ -5797,7 +5788,7 @@ export type GetActionDetailsQuery = (
         ) }
         & { __typename: 'Action' }
       ) | null, plan: (
-        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
           { rendition: (
             { src: string }
             & { __typename: 'ImageRendition' }
@@ -5840,7 +5831,7 @@ export type GetActionDetailsQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -5866,7 +5857,7 @@ export type GetActionDetailsQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )>, parent: (
+        )> | null, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -5894,7 +5885,7 @@ export type GetActionDetailsQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -5920,7 +5911,7 @@ export type GetActionDetailsQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -5947,7 +5938,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -5973,7 +5964,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -6000,7 +5991,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -6026,7 +6017,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'Category' }
@@ -6095,8 +6086,8 @@ export type GetActionDetailsQuery = (
         & { __typename: 'DataPoint' }
       )> }
       & { __typename: 'Dataset' }
-    )>, plan: (
-      { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, image: (
+    ) | null> | null, plan: (
+      { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, image: (
         { rendition: (
           { src: string }
           & { __typename: 'ImageRendition' }
@@ -6141,7 +6132,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -6167,7 +6158,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -6195,7 +6186,7 @@ export type GetActionDetailsQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -6221,7 +6212,7 @@ export type GetActionDetailsQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -6248,7 +6239,7 @@ export type GetActionDetailsQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -6274,7 +6265,7 @@ export type GetActionDetailsQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -6301,7 +6292,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -6327,7 +6318,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -6353,7 +6344,7 @@ export type GetActionDetailsQuery = (
           ) }
           & { __typename: 'Action' }
         ) | null, plan: (
-          { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+          { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
             { rendition: (
               { src: string }
               & { __typename: 'ImageRendition' }
@@ -6396,7 +6387,7 @@ export type GetActionDetailsQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -6422,7 +6413,7 @@ export type GetActionDetailsQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -6450,7 +6441,7 @@ export type GetActionDetailsQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -6476,7 +6467,7 @@ export type GetActionDetailsQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -6503,7 +6494,7 @@ export type GetActionDetailsQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -6529,7 +6520,7 @@ export type GetActionDetailsQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -6556,7 +6547,7 @@ export type GetActionDetailsQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -6582,7 +6573,7 @@ export type GetActionDetailsQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -6608,7 +6599,7 @@ export type GetActionDetailsQuery = (
           ) }
           & { __typename: 'Action' }
         ) | null, plan: (
-          { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+          { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
             { rendition: (
               { src: string }
               & { __typename: 'ImageRendition' }
@@ -6628,13 +6619,13 @@ export type GetActionDetailsQuery = (
         { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, meta: (
           { restricted: boolean | null, hidden: boolean | null }
           & { __typename: 'FieldBlockMetaData' }
-        ) | null, fields: Array<(
-          { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+        ) | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+          { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
             { choiceLabel: string | null, choiceValue: string | null }
             & { __typename: 'FormChoiceBlock' }
-          )> }
+          ) | null> | null }
           & { __typename: 'FormFieldBlock' }
-        )> }
+        ) | null> | null }
         & { __typename: 'ActionContactFormBlock' }
       ) | (
         { id: string | null, meta: (
@@ -6683,13 +6674,13 @@ export type GetActionDetailsQuery = (
           { id: string | null }
           & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
         ) | (
-          { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
-            { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+          { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+            { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
               { choiceLabel: string | null, choiceValue: string | null }
               & { __typename: 'FormChoiceBlock' }
-            )> }
+            ) | null> | null }
             & { __typename: 'FormFieldBlock' }
-          )> }
+          ) | null> | null }
           & { __typename: 'ActionContactFormBlock' }
         ) | (
           { id: string | null, attributeType: (
@@ -6751,7 +6742,7 @@ export type GetActionDetailsQuery = (
                     { id: string, values: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorValue' }
-                    )>, goals: Array<(
+                    ) | null> | null, goals: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorGoal' }
                     ) | null> | null, unit: (
@@ -6777,7 +6768,7 @@ export type GetActionDetailsQuery = (
                   ) | (
                     { value: string, id: string, key: string }
                     & { __typename: 'AttributeRichText' | 'AttributeText' }
-                  )>, parent: (
+                  )> | null, parent: (
                     { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -6805,7 +6796,7 @@ export type GetActionDetailsQuery = (
                           { id: string, values: Array<(
                             { date: string | null, value: number }
                             & { __typename: 'IndicatorValue' }
-                          )>, goals: Array<(
+                          ) | null> | null, goals: Array<(
                             { date: string | null, value: number }
                             & { __typename: 'IndicatorGoal' }
                           ) | null> | null, unit: (
@@ -6831,7 +6822,7 @@ export type GetActionDetailsQuery = (
                         ) | (
                           { value: string, id: string, key: string }
                           & { __typename: 'AttributeRichText' | 'AttributeText' }
-                        )> }
+                        )> | null }
                         & { __typename: 'Category' }
                       ) | null, level: (
                         { id: string, name: string, namePlural: string | null }
@@ -6858,7 +6849,7 @@ export type GetActionDetailsQuery = (
                         { id: string, values: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorValue' }
-                        )>, goals: Array<(
+                        ) | null> | null, goals: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorGoal' }
                         ) | null> | null, unit: (
@@ -6884,7 +6875,7 @@ export type GetActionDetailsQuery = (
                       ) | (
                         { value: string, id: string, key: string }
                         & { __typename: 'AttributeRichText' | 'AttributeText' }
-                      )> }
+                      )> | null }
                       & { __typename: 'Category' }
                     ) | null, level: (
                       { id: string, name: string, namePlural: string | null }
@@ -6911,7 +6902,7 @@ export type GetActionDetailsQuery = (
                       { id: string, values: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorValue' }
-                      )>, goals: Array<(
+                      ) | null> | null, goals: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorGoal' }
                       ) | null> | null, unit: (
@@ -6937,7 +6928,7 @@ export type GetActionDetailsQuery = (
                     ) | (
                       { value: string, id: string, key: string }
                       & { __typename: 'AttributeRichText' | 'AttributeText' }
-                    )> }
+                    )> | null }
                     & { __typename: 'Category' }
                   ) | null }
                   & { __typename: 'Category' }
@@ -7059,7 +7050,7 @@ export type GetActionDetailsQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -7085,7 +7076,7 @@ export type GetActionDetailsQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )>, parent: (
+                )> | null, parent: (
                   { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                     { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -7113,7 +7104,7 @@ export type GetActionDetailsQuery = (
                         { id: string, values: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorValue' }
-                        )>, goals: Array<(
+                        ) | null> | null, goals: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorGoal' }
                         ) | null> | null, unit: (
@@ -7139,7 +7130,7 @@ export type GetActionDetailsQuery = (
                       ) | (
                         { value: string, id: string, key: string }
                         & { __typename: 'AttributeRichText' | 'AttributeText' }
-                      )> }
+                      )> | null }
                       & { __typename: 'Category' }
                     ) | null, level: (
                       { id: string, name: string, namePlural: string | null }
@@ -7166,7 +7157,7 @@ export type GetActionDetailsQuery = (
                       { id: string, values: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorValue' }
-                      )>, goals: Array<(
+                      ) | null> | null, goals: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorGoal' }
                       ) | null> | null, unit: (
@@ -7192,7 +7183,7 @@ export type GetActionDetailsQuery = (
                     ) | (
                       { value: string, id: string, key: string }
                       & { __typename: 'AttributeRichText' | 'AttributeText' }
-                    )> }
+                    )> | null }
                     & { __typename: 'Category' }
                   ) | null, level: (
                     { id: string, name: string, namePlural: string | null }
@@ -7219,7 +7210,7 @@ export type GetActionDetailsQuery = (
                     { id: string, values: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorValue' }
-                    )>, goals: Array<(
+                    ) | null> | null, goals: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorGoal' }
                     ) | null> | null, unit: (
@@ -7245,7 +7236,7 @@ export type GetActionDetailsQuery = (
                   ) | (
                     { value: string, id: string, key: string }
                     & { __typename: 'AttributeRichText' | 'AttributeText' }
-                  )> }
+                  )> | null }
                   & { __typename: 'Category' }
                 ) | null }
                 & { __typename: 'Category' }
@@ -7306,13 +7297,13 @@ export type GetActionDetailsQuery = (
         { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, meta: (
           { restricted: boolean | null, hidden: boolean | null }
           & { __typename: 'FieldBlockMetaData' }
-        ) | null, fields: Array<(
-          { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+        ) | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+          { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
             { choiceLabel: string | null, choiceValue: string | null }
             & { __typename: 'FormChoiceBlock' }
-          )> }
+          ) | null> | null }
           & { __typename: 'FormFieldBlock' }
-        )> }
+        ) | null> | null }
         & { __typename: 'ActionContactFormBlock' }
       ) | (
         { id: string | null, meta: (
@@ -7361,13 +7352,13 @@ export type GetActionDetailsQuery = (
           { id: string | null }
           & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
         ) | (
-          { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
-            { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+          { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+            { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
               { choiceLabel: string | null, choiceValue: string | null }
               & { __typename: 'FormChoiceBlock' }
-            )> }
+            ) | null> | null }
             & { __typename: 'FormFieldBlock' }
-          )> }
+          ) | null> | null }
           & { __typename: 'ActionContactFormBlock' }
         ) | (
           { id: string | null, attributeType: (
@@ -7429,7 +7420,7 @@ export type GetActionDetailsQuery = (
                     { id: string, values: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorValue' }
-                    )>, goals: Array<(
+                    ) | null> | null, goals: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorGoal' }
                     ) | null> | null, unit: (
@@ -7455,7 +7446,7 @@ export type GetActionDetailsQuery = (
                   ) | (
                     { value: string, id: string, key: string }
                     & { __typename: 'AttributeRichText' | 'AttributeText' }
-                  )>, parent: (
+                  )> | null, parent: (
                     { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -7483,7 +7474,7 @@ export type GetActionDetailsQuery = (
                           { id: string, values: Array<(
                             { date: string | null, value: number }
                             & { __typename: 'IndicatorValue' }
-                          )>, goals: Array<(
+                          ) | null> | null, goals: Array<(
                             { date: string | null, value: number }
                             & { __typename: 'IndicatorGoal' }
                           ) | null> | null, unit: (
@@ -7509,7 +7500,7 @@ export type GetActionDetailsQuery = (
                         ) | (
                           { value: string, id: string, key: string }
                           & { __typename: 'AttributeRichText' | 'AttributeText' }
-                        )> }
+                        )> | null }
                         & { __typename: 'Category' }
                       ) | null, level: (
                         { id: string, name: string, namePlural: string | null }
@@ -7536,7 +7527,7 @@ export type GetActionDetailsQuery = (
                         { id: string, values: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorValue' }
-                        )>, goals: Array<(
+                        ) | null> | null, goals: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorGoal' }
                         ) | null> | null, unit: (
@@ -7562,7 +7553,7 @@ export type GetActionDetailsQuery = (
                       ) | (
                         { value: string, id: string, key: string }
                         & { __typename: 'AttributeRichText' | 'AttributeText' }
-                      )> }
+                      )> | null }
                       & { __typename: 'Category' }
                     ) | null, level: (
                       { id: string, name: string, namePlural: string | null }
@@ -7589,7 +7580,7 @@ export type GetActionDetailsQuery = (
                       { id: string, values: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorValue' }
-                      )>, goals: Array<(
+                      ) | null> | null, goals: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorGoal' }
                       ) | null> | null, unit: (
@@ -7615,7 +7606,7 @@ export type GetActionDetailsQuery = (
                     ) | (
                       { value: string, id: string, key: string }
                       & { __typename: 'AttributeRichText' | 'AttributeText' }
-                    )> }
+                    )> | null }
                     & { __typename: 'Category' }
                   ) | null }
                   & { __typename: 'Category' }
@@ -7737,7 +7728,7 @@ export type GetActionDetailsQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -7763,7 +7754,7 @@ export type GetActionDetailsQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )>, parent: (
+                )> | null, parent: (
                   { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                     { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -7791,7 +7782,7 @@ export type GetActionDetailsQuery = (
                         { id: string, values: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorValue' }
-                        )>, goals: Array<(
+                        ) | null> | null, goals: Array<(
                           { date: string | null, value: number }
                           & { __typename: 'IndicatorGoal' }
                         ) | null> | null, unit: (
@@ -7817,7 +7808,7 @@ export type GetActionDetailsQuery = (
                       ) | (
                         { value: string, id: string, key: string }
                         & { __typename: 'AttributeRichText' | 'AttributeText' }
-                      )> }
+                      )> | null }
                       & { __typename: 'Category' }
                     ) | null, level: (
                       { id: string, name: string, namePlural: string | null }
@@ -7844,7 +7835,7 @@ export type GetActionDetailsQuery = (
                       { id: string, values: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorValue' }
-                      )>, goals: Array<(
+                      ) | null> | null, goals: Array<(
                         { date: string | null, value: number }
                         & { __typename: 'IndicatorGoal' }
                       ) | null> | null, unit: (
@@ -7870,7 +7861,7 @@ export type GetActionDetailsQuery = (
                     ) | (
                       { value: string, id: string, key: string }
                       & { __typename: 'AttributeRichText' | 'AttributeText' }
-                    )> }
+                    )> | null }
                     & { __typename: 'Category' }
                   ) | null, level: (
                     { id: string, name: string, namePlural: string | null }
@@ -7897,7 +7888,7 @@ export type GetActionDetailsQuery = (
                     { id: string, values: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorValue' }
-                    )>, goals: Array<(
+                    ) | null> | null, goals: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorGoal' }
                     ) | null> | null, unit: (
@@ -7923,7 +7914,7 @@ export type GetActionDetailsQuery = (
                   ) | (
                     { value: string, id: string, key: string }
                     & { __typename: 'AttributeRichText' | 'AttributeText' }
-                  )> }
+                  )> | null }
                   & { __typename: 'Category' }
                 ) | null }
                 & { __typename: 'Category' }
@@ -8077,7 +8068,7 @@ export type ActionDependenciesFragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -8103,7 +8094,7 @@ export type ActionDependenciesFragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )>, parent: (
+        )> | null, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -8131,7 +8122,7 @@ export type ActionDependenciesFragment = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -8157,7 +8148,7 @@ export type ActionDependenciesFragment = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -8184,7 +8175,7 @@ export type ActionDependenciesFragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -8210,7 +8201,7 @@ export type ActionDependenciesFragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -8237,7 +8228,7 @@ export type ActionDependenciesFragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -8263,7 +8254,7 @@ export type ActionDependenciesFragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'Category' }
@@ -8289,7 +8280,7 @@ export type ActionDependenciesFragment = (
         ) }
         & { __typename: 'Action' }
       ) | null, plan: (
-        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
           { rendition: (
             { src: string }
             & { __typename: 'ImageRendition' }
@@ -8332,7 +8323,7 @@ export type ActionDependenciesFragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -8358,7 +8349,7 @@ export type ActionDependenciesFragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )>, parent: (
+        )> | null, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -8386,7 +8377,7 @@ export type ActionDependenciesFragment = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -8412,7 +8403,7 @@ export type ActionDependenciesFragment = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -8439,7 +8430,7 @@ export type ActionDependenciesFragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -8465,7 +8456,7 @@ export type ActionDependenciesFragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null, level: (
             { id: string, name: string, namePlural: string | null }
@@ -8492,7 +8483,7 @@ export type ActionDependenciesFragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -8518,7 +8509,7 @@ export type ActionDependenciesFragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'Category' }
@@ -8544,7 +8535,7 @@ export type ActionDependenciesFragment = (
         ) }
         & { __typename: 'Action' }
       ) | null, plan: (
-        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+        { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
           { rendition: (
             { src: string }
             & { __typename: 'ImageRendition' }
@@ -8613,13 +8604,13 @@ type ActionMainContentBlocksFragment_ActionContactFormBlock_Fragment = (
   { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, meta: (
     { restricted: boolean | null, hidden: boolean | null }
     & { __typename: 'FieldBlockMetaData' }
-  ) | null, fields: Array<(
-    { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+  ) | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+    { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
       { choiceLabel: string | null, choiceValue: string | null }
       & { __typename: 'FormChoiceBlock' }
-    )> }
+    ) | null> | null }
     & { __typename: 'FormFieldBlock' }
-  )> }
+  ) | null> | null }
   & { __typename: 'ActionContactFormBlock' }
 );
 
@@ -8674,13 +8665,13 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
     { id: string | null }
     & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
   ) | (
-    { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
-      { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+    { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+      { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
         { choiceLabel: string | null, choiceValue: string | null }
         & { __typename: 'FormChoiceBlock' }
-      )> }
+      ) | null> | null }
       & { __typename: 'FormFieldBlock' }
-    )> }
+    ) | null> | null }
     & { __typename: 'ActionContactFormBlock' }
   ) | (
     { id: string | null, attributeType: (
@@ -8742,7 +8733,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -8768,7 +8759,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )>, parent: (
+            )> | null, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                   { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -8796,7 +8787,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
                     { id: string, values: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorValue' }
-                    )>, goals: Array<(
+                    ) | null> | null, goals: Array<(
                       { date: string | null, value: number }
                       & { __typename: 'IndicatorGoal' }
                     ) | null> | null, unit: (
@@ -8822,7 +8813,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
                   ) | (
                     { value: string, id: string, key: string }
                     & { __typename: 'AttributeRichText' | 'AttributeText' }
-                  )> }
+                  )> | null }
                   & { __typename: 'Category' }
                 ) | null, level: (
                   { id: string, name: string, namePlural: string | null }
@@ -8849,7 +8840,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -8875,7 +8866,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -8902,7 +8893,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -8928,7 +8919,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null }
             & { __typename: 'Category' }
@@ -9062,7 +9053,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -9088,7 +9079,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -9116,7 +9107,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -9142,7 +9133,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -9169,7 +9160,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -9195,7 +9186,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -9222,7 +9213,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -9248,7 +9239,7 @@ type ActionMainContentBlocksFragment_ReportComparisonBlock_Fragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -9342,7 +9333,7 @@ export type ReportComparisonBlockActionContentFragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -9368,7 +9359,7 @@ export type ReportComparisonBlockActionContentFragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -9396,7 +9387,7 @@ export type ReportComparisonBlockActionContentFragment = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -9422,7 +9413,7 @@ export type ReportComparisonBlockActionContentFragment = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -9449,7 +9440,7 @@ export type ReportComparisonBlockActionContentFragment = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -9475,7 +9466,7 @@ export type ReportComparisonBlockActionContentFragment = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -9502,7 +9493,7 @@ export type ReportComparisonBlockActionContentFragment = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -9528,7 +9519,7 @@ export type ReportComparisonBlockActionContentFragment = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -9620,7 +9611,7 @@ export type ActionCardWithDependencyRoleFragment = (
       { id: string, values: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorValue' }
-      )>, goals: Array<(
+      ) | null> | null, goals: Array<(
         { date: string | null, value: number }
         & { __typename: 'IndicatorGoal' }
       ) | null> | null, unit: (
@@ -9646,7 +9637,7 @@ export type ActionCardWithDependencyRoleFragment = (
     ) | (
       { value: string, id: string, key: string }
       & { __typename: 'AttributeRichText' | 'AttributeText' }
-    )>, parent: (
+    )> | null, parent: (
       { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
         { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
           { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -9674,7 +9665,7 @@ export type ActionCardWithDependencyRoleFragment = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -9700,7 +9691,7 @@ export type ActionCardWithDependencyRoleFragment = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         ) | null, level: (
           { id: string, name: string, namePlural: string | null }
@@ -9727,7 +9718,7 @@ export type ActionCardWithDependencyRoleFragment = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -9753,7 +9744,7 @@ export type ActionCardWithDependencyRoleFragment = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       ) | null, level: (
         { id: string, name: string, namePlural: string | null }
@@ -9780,7 +9771,7 @@ export type ActionCardWithDependencyRoleFragment = (
         { id: string, values: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { date: string | null, value: number }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, unit: (
@@ -9806,7 +9797,7 @@ export type ActionCardWithDependencyRoleFragment = (
       ) | (
         { value: string, id: string, key: string }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )> }
+      )> | null }
       & { __typename: 'Category' }
     ) | null }
     & { __typename: 'Category' }
@@ -9832,7 +9823,7 @@ export type ActionCardWithDependencyRoleFragment = (
     ) }
     & { __typename: 'Action' }
   ) | null, plan: (
-    { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean, publishedAt: string | null, image: (
+    { id: string, shortName: string | null, versionName: string, viewUrl: string | null, hideActionIdentifiers: boolean | null, publishedAt: string | null, image: (
       { rendition: (
         { src: string }
         & { __typename: 'ImageRendition' }
@@ -9988,13 +9979,13 @@ export type TemplatedCategoryPageFragmentFragment = (
       ) }
       & { __typename: 'CategoryPageAttributeTypeBlock' }
     ) | { __typename: 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' } | (
-      { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
-        { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
+      { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
           { choiceLabel: string | null, choiceValue: string | null }
           & { __typename: 'FormChoiceBlock' }
-        )> }
+        ) | null> | null }
         & { __typename: 'FormFieldBlock' }
-      )> }
+      ) | null> | null }
       & { __typename: 'CategoryPageContactFormBlock' }
     ) | (
       { id: string | null, heading: string | null, helpText: string | null, datasetSchema: (
@@ -10054,7 +10045,22 @@ export type GetContentPageQuery = (
   { planPage: (
     { id: string | null, slug: string, title: string, lastPublishedAt: string | null, body: Array<(
       { id: string | null, blockType: string, field: string }
-      & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' }
+      & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' | 'ActionLinksBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorHighlightsBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'UpdatedAtColumnBlock' }
     ) | (
       { id: string | null, blockType: string, field: string, blocks: Array<(
         { id: string | null, field: string }
@@ -10083,9 +10089,900 @@ export type GetContentPageQuery = (
       )> }
       & { __typename: 'AccessibilityStatementContactInformationBlock' }
     ) | (
+      { id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { heading: string | null, lead: string | null, category: (
+          { id: string, type: (
+            { identifier: string }
+            & { __typename: 'CategoryType' }
+          ) }
+          & { __typename: 'Category' }
+        ) | null }
+        & { __typename: 'ActionCategoryFilterCardBlock' }
+      ) | null> | null }
+      & { __typename: 'ActionCategoryFilterCardsBlock' }
+    ) | (
+      { id: string | null, heading: string | null, helpText: string | null, blockType: string, field: string, categoryFilter: (
+        { id: string }
+        & { __typename: 'Category' }
+      ) | null, groupByCategoryLevel: (
+        { id: string }
+        & { __typename: 'CategoryLevel' }
+      ) | null }
+      & { __typename: 'ActionListBlock' }
+    ) | (
+      { fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
+        { html: string | null }
+        & { __typename: 'EmbedHTMLValue' }
+      ) | null }
+      & { __typename: 'AdaptiveEmbedBlock' }
+    ) | (
+      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { heading: string | null, content: string | null, link: string | null, image: (
+          { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, large: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, small: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, social: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, rendition: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null }
+          & { __typename: 'Image' }
+        ) | null }
+        & { __typename: 'CardBlock' }
+      ) | null> | null }
+      & { __typename: 'CardListBlock' }
+    ) | (
+      { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string | null, account: (
+        { provider: CartographyProviderCredentialsProvider, account: string, publicAccessToken: string }
+        & { __typename: 'CartographyProviderCredentials' }
+      ) }
+      & { __typename: 'CartographyVisualisationBlock' }
+    ) | (
+      { style: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, categoryType: (
+        { id: string, hideCategoryIdentifiers: boolean, categories: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, indicators: Array<(
+            { id: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null, parent: (
+            { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+              { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+                { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+                  { id: string, name: string, namePlural: string | null }
+                  & { __typename: 'CategoryLevel' }
+                ) | null, image: (
+                  { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, large: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, small: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, social: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, rendition: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, indicators: Array<(
+                  { id: string, values: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorValue' }
+                  ) | null> | null, goals: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorGoal' }
+                  ) | null> | null, unit: (
+                    { name: string, shortName: string | null }
+                    & { __typename: 'Unit' }
+                  ) }
+                  & { __typename: 'Indicator' }
+                )>, iconImage: (
+                  { rendition: (
+                    { src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, categoryPage: (
+                  { id: string | null, title: string, urlPath: string, live: boolean }
+                  & { __typename: 'CategoryPage' }
+                ) | null, type: (
+                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                  & { __typename: 'CategoryType' }
+                ), attributes: Array<(
+                  { id: string, key: string }
+                  & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+                ) | (
+                  { value: string, id: string, key: string }
+                  & { __typename: 'AttributeRichText' | 'AttributeText' }
+                )> | null }
+                & { __typename: 'Category' }
+              ) | null, level: (
+                { id: string, name: string, namePlural: string | null }
+                & { __typename: 'CategoryLevel' }
+              ) | null, image: (
+                { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, large: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, small: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, social: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, rendition: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, indicators: Array<(
+                { id: string, values: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorValue' }
+                ) | null> | null, goals: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorGoal' }
+                ) | null> | null, unit: (
+                  { name: string, shortName: string | null }
+                  & { __typename: 'Unit' }
+                ) }
+                & { __typename: 'Indicator' }
+              )>, iconImage: (
+                { rendition: (
+                  { src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, categoryPage: (
+                { id: string | null, title: string, urlPath: string, live: boolean }
+                & { __typename: 'CategoryPage' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename: 'CategoryType' }
+              ), attributes: Array<(
+                { id: string, key: string }
+                & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+              ) | (
+                { value: string, id: string, key: string }
+                & { __typename: 'AttributeRichText' | 'AttributeText' }
+              )> | null }
+              & { __typename: 'Category' }
+            ) | null, level: (
+              { id: string, name: string, namePlural: string | null }
+              & { __typename: 'CategoryLevel' }
+            ) | null, image: (
+              { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, large: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, small: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, social: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, rendition: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, indicators: Array<(
+              { id: string, values: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorValue' }
+              ) | null> | null, goals: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorGoal' }
+              ) | null> | null, unit: (
+                { name: string, shortName: string | null }
+                & { __typename: 'Unit' }
+              ) }
+              & { __typename: 'Indicator' }
+            )>, iconImage: (
+              { rendition: (
+                { src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, categoryPage: (
+              { id: string | null, title: string, urlPath: string, live: boolean }
+              & { __typename: 'CategoryPage' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename: 'CategoryType' }
+            ), attributes: Array<(
+              { id: string, key: string }
+              & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+            ) | (
+              { value: string, id: string, key: string }
+              & { __typename: 'AttributeRichText' | 'AttributeText' }
+            )> | null }
+            & { __typename: 'Category' }
+          ) | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'CategoryType' }
+      ) | null, category: (
+        { id: string, children: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, indicators: Array<(
+            { id: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'Category' }
+      ) | null }
+      & { __typename: 'CategoryListBlock' }
+    ) | (
+      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, valueAttribute: (
+        { identifier: string, unit: (
+          { shortName: string | null }
+          & { __typename: 'Unit' }
+        ) | null }
+        & { __typename: 'AttributeType' }
+      ) | null, treeMapCategoryType: (
+        { identifier: string }
+        & { __typename: 'CategoryType' }
+      ) | null }
+      & { __typename: 'CategoryTreeMapBlock' }
+    ) | (
+      { heading: string | null, helpText: string | null, id: string | null, blockType: string, field: string, categoryLevel: (
+        { id: string, name: string, namePlural: string | null }
+        & { __typename: 'CategoryLevel' }
+      ), groupByCategoryLevel: (
+        { id: string }
+        & { __typename: 'CategoryLevel' }
+      ) | null, categoryBlockType: (
+        { id: string, identifier: string, hideCategoryIdentifiers: boolean, categories: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, indicators: Array<(
+            { id: string, name: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null, parent: (
+            { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+              { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+                { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+                  { id: string, name: string, namePlural: string | null }
+                  & { __typename: 'CategoryLevel' }
+                ) | null, image: (
+                  { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, large: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, small: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, social: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, rendition: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, indicators: Array<(
+                  { id: string, values: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorValue' }
+                  ) | null> | null, goals: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorGoal' }
+                  ) | null> | null, unit: (
+                    { name: string, shortName: string | null }
+                    & { __typename: 'Unit' }
+                  ) }
+                  & { __typename: 'Indicator' }
+                )>, iconImage: (
+                  { rendition: (
+                    { src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, categoryPage: (
+                  { id: string | null, title: string, urlPath: string, live: boolean }
+                  & { __typename: 'CategoryPage' }
+                ) | null, type: (
+                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                  & { __typename: 'CategoryType' }
+                ), attributes: Array<(
+                  { id: string, key: string }
+                  & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+                ) | (
+                  { value: string, id: string, key: string }
+                  & { __typename: 'AttributeRichText' | 'AttributeText' }
+                )> | null }
+                & { __typename: 'Category' }
+              ) | null, level: (
+                { id: string, name: string, namePlural: string | null }
+                & { __typename: 'CategoryLevel' }
+              ) | null, image: (
+                { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, large: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, small: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, social: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, rendition: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, indicators: Array<(
+                { id: string, values: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorValue' }
+                ) | null> | null, goals: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorGoal' }
+                ) | null> | null, unit: (
+                  { name: string, shortName: string | null }
+                  & { __typename: 'Unit' }
+                ) }
+                & { __typename: 'Indicator' }
+              )>, iconImage: (
+                { rendition: (
+                  { src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, categoryPage: (
+                { id: string | null, title: string, urlPath: string, live: boolean }
+                & { __typename: 'CategoryPage' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename: 'CategoryType' }
+              ), attributes: Array<(
+                { id: string, key: string }
+                & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+              ) | (
+                { value: string, id: string, key: string }
+                & { __typename: 'AttributeRichText' | 'AttributeText' }
+              )> | null }
+              & { __typename: 'Category' }
+            ) | null, level: (
+              { id: string, name: string, namePlural: string | null }
+              & { __typename: 'CategoryLevel' }
+            ) | null, image: (
+              { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, large: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, small: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, social: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, rendition: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, indicators: Array<(
+              { id: string, values: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorValue' }
+              ) | null> | null, goals: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorGoal' }
+              ) | null> | null, unit: (
+                { name: string, shortName: string | null }
+                & { __typename: 'Unit' }
+              ) }
+              & { __typename: 'Indicator' }
+            )>, iconImage: (
+              { rendition: (
+                { src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, categoryPage: (
+              { id: string | null, title: string, urlPath: string, live: boolean }
+              & { __typename: 'CategoryPage' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename: 'CategoryType' }
+            ), attributes: Array<(
+              { id: string, key: string }
+              & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+            ) | (
+              { value: string, id: string, key: string }
+              & { __typename: 'AttributeRichText' | 'AttributeText' }
+            )> | null }
+            & { __typename: 'Category' }
+          ) | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'CategoryType' }
+      ) }
+      & { __typename: 'CategoryTypeLevelListBlock' }
+    ) | (
       { value: string, id: string | null, blockType: string, field: string }
-      & { __typename: 'RichTextBlock' }
-    )> | null }
+      & { __typename: 'CharBlock' | 'RichTextBlock' | 'TextBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string, choices: Array<(
+        { key: string, value: string }
+        & { __typename: 'ChoiceOption' }
+      )> }
+      & { __typename: 'ChoiceBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, blocks: Array<(
+        { blockType: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+      ) | (
+        { id: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { id: string | null, barType: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorBarChartBlock' }
+      ) | (
+        { id: string | null, helpText: string | null, showTotalLine: boolean | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorLineChartBlock' }
+      ) | (
+        { helpText: string | null, year: number | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorPieChartBlock' }
+      ) | (
+        { id: string | null, blockType: string, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorSummaryBlock' }
+      ) | (
+        { text: string | null, blockType: string }
+        & { __typename: 'DashboardParagraphBlock' }
+      )> }
+      & { __typename: 'DashboardRowBlock' }
+    ) | (
+      { layout: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
+        { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, large: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, small: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, social: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, rendition: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null }
+        & { __typename: 'Image' }
+      ) | null }
+      & { __typename: 'FrontPageHeroBlock' }
+    ) | (
+      { style: string | null, id: string | null, blockType: string, field: string, indicator: (
+        { id: string }
+        & { __typename: 'Indicator' }
+      ) | null }
+      & { __typename: 'IndicatorBlock' }
+    ) | (
+      { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { style: string | null, indicator: (
+          { id: string, identifier: string | null, name: string, description: string | null, timeResolution: IndicatorTimeResolution, level: string | null, unit: (
+            { id: string, name: string }
+            & { __typename: 'Unit' }
+          ), latestValue: (
+            { id: string, date: string | null, value: number }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { id: string, date: string | null, value: number }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'IndicatorBlock' }
+      ) | null> | null }
+      & { __typename: 'IndicatorGroupBlock' }
+    ) | (
+      { title: string | null, body: string | null, id: string | null, blockType: string, field: string, blocks: Array<(
+        { id: string | null }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'URLBlock' | 'UpdatedAtColumnBlock' }
+      )>, indicator: (
+        { id: string, identifier: string | null, name: string, minValue: number | null, maxValue: number | null, unit: (
+          { id: string, shortName: string | null, name: string }
+          & { __typename: 'Unit' }
+        ), latestValue: (
+          { id: string, date: string | null, value: number }
+          & { __typename: 'IndicatorValue' }
+        ) | null, values: Array<(
+          { id: string, date: string | null, value: number, normalizedValues: Array<(
+            { normalizerId: string | null, value: number | null }
+            & { __typename: 'NormalizedValue' }
+          ) | null> | null, categories: Array<(
+            { id: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'IndicatorValue' }
+        ) | null> | null, goals: Array<(
+          { id: string, date: string | null, value: number, normalizedValues: Array<(
+            { normalizerId: string | null, value: number | null }
+            & { __typename: 'NormalizedValue' }
+          ) | null> | null }
+          & { __typename: 'IndicatorGoal' }
+        ) | null> | null, common: (
+          { id: string, normalizations: Array<(
+            { unit: (
+              { shortName: string | null, name: string }
+              & { __typename: 'Unit' }
+            ) | null, normalizer: (
+              { name: string, id: string, identifier: string | null }
+              & { __typename: 'CommonIndicator' }
+            ) | null }
+            & { __typename: 'CommonIndicatorNormalization' }
+          ) | null> | null }
+          & { __typename: 'CommonIndicator' }
+        ) | null }
+        & { __typename: 'Indicator' }
+      ) | null, linkButton: (
+        { blockType: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'UpdatedAtColumnBlock' }
+      ) | (
+        { text: string | null, blockType: string, page: (
+          { url: string | null, urlPath: string, slug: string }
+          & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
+        ) | null }
+        & { __typename: 'PageLinkBlock' }
+      ) | null }
+      & { __typename: 'IndicatorShowcaseBlock' }
+    ) | (
+      { width: string | null, id: string | null, blockType: string, field: string, image: (
+        { title: string, altText: string, width: number, height: number, imageCredit: string, renditionUncropped: (
+          { src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null }
+        & { __typename: 'Image' }
+      ) | null }
+      & { __typename: 'LargeImageBlock' }
+    ) | (
+      { heading: string | null, helpText: string | null, outcomeNodeId: string | null, id: string | null, blockType: string, field: string }
+      & { __typename: 'PathsOutcomeBlock' }
+    ) | (
+      { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { question: string | null, answer: string | null }
+        & { __typename: 'QuestionBlock' }
+      ) | null> | null }
+      & { __typename: 'QuestionAnswerBlock' }
+    ) | null> | null }
     & { __typename: 'AccessibilityStatementPage' }
   ) | (
     { leadContent: string | null, defaultView: ActionListPageView, headingHierarchyDepth: number, includeRelatedPlans: boolean | null, id: string | null, slug: string, title: string, lastPublishedAt: string | null, primaryFilters: Array<(
@@ -10244,7 +11141,7 @@ export type GetContentPageQuery = (
           { id: string, values: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorValue' }
-          )>, goals: Array<(
+          ) | null> | null, goals: Array<(
             { date: string | null, value: number }
             & { __typename: 'IndicatorGoal' }
           ) | null> | null, unit: (
@@ -10270,7 +11167,7 @@ export type GetContentPageQuery = (
         ) | (
           { value: string, id: string, key: string }
           & { __typename: 'AttributeRichText' | 'AttributeText' }
-        )> }
+        )> | null }
         & { __typename: 'Category' }
       )>, parent: (
         { id: string, identifier: string, name: string, color: string, iconSvgUrl: string | null, level: (
@@ -10380,7 +11277,7 @@ export type GetContentPageQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -10406,7 +11303,7 @@ export type GetContentPageQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -10434,7 +11331,7 @@ export type GetContentPageQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -10460,7 +11357,7 @@ export type GetContentPageQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -10487,7 +11384,7 @@ export type GetContentPageQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -10513,7 +11410,7 @@ export type GetContentPageQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -10540,7 +11437,7 @@ export type GetContentPageQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -10566,7 +11463,7 @@ export type GetContentPageQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -10611,7 +11508,7 @@ export type GetContentPageQuery = (
           & { __typename: 'AttributeType' }
         ) }
         & { __typename: 'AttributeRichText' | 'AttributeText' }
-      )>, datasets: Array<(
+      )> | null, datasets: Array<(
         { uuid: string, schema: (
           { uuid: string, name: string, timeResolution: DatasetSchemaTimeResolution, metrics: Array<(
             { unit: string }
@@ -10638,20 +11535,71 @@ export type GetContentPageQuery = (
           & { __typename: 'DataPoint' }
         )> }
         & { __typename: 'Dataset' }
-      )> }
+      ) | null> | null }
       & { __typename: 'Category' }
     ) | null, body: Array<(
-      { heading: string | null, helpText: string | null, id: string | null, blockType: string, field: string, categoryFilter: (
-        { id: string, type: (
-          { id: string }
-          & { __typename: 'CategoryType' }
-        ) }
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' | 'ActionLinksBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorHighlightsBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'UpdatedAtColumnBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, blocks: Array<(
+        { id: string | null, field: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'UpdatedAtColumnBlock' }
+      ) | (
+        { value: string, id: string | null, field: string }
+        & { __typename: 'CharBlock' }
+      )> }
+      & { __typename: 'AccessibilityStatementContactInformationBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { heading: string | null, lead: string | null, category: (
+          { id: string, type: (
+            { identifier: string }
+            & { __typename: 'CategoryType' }
+          ) }
+          & { __typename: 'Category' }
+        ) | null }
+        & { __typename: 'ActionCategoryFilterCardBlock' }
+      ) | null> | null }
+      & { __typename: 'ActionCategoryFilterCardsBlock' }
+    ) | (
+      { id: string | null, heading: string | null, helpText: string | null, blockType: string, field: string, categoryFilter: (
+        { id: string }
         & { __typename: 'Category' }
       ) | null, groupByCategoryLevel: (
-        { id: string, type: (
-          { id: string }
-          & { __typename: 'CategoryType' }
-        ) }
+        { id: string }
         & { __typename: 'CategoryLevel' }
       ) | null }
       & { __typename: 'ActionListBlock' }
@@ -10662,394 +11610,31 @@ export type GetContentPageQuery = (
       ) | null }
       & { __typename: 'AdaptiveEmbedBlock' }
     ) | (
-      { style: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, categoryType: (
-        { id: string, hideCategoryIdentifiers: boolean, categories: Array<(
-          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
-            { id: string, name: string, namePlural: string | null }
-            & { __typename: 'CategoryLevel' }
-          ) | null, image: (
-            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, large: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, small: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, social: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, rendition: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null }
-            & { __typename: 'Image' }
-          ) | null, indicators: Array<(
-            { id: string, values: Array<(
-              { date: string | null, value: number }
-              & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
-              { date: string | null, value: number }
-              & { __typename: 'IndicatorGoal' }
-            ) | null> | null, unit: (
-              { name: string, shortName: string | null }
-              & { __typename: 'Unit' }
-            ) }
-            & { __typename: 'Indicator' }
-          )>, iconImage: (
-            { rendition: (
-              { src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null }
-            & { __typename: 'Image' }
-          ) | null, categoryPage: (
-            { id: string | null, title: string, urlPath: string, live: boolean }
-            & { __typename: 'CategoryPage' }
-          ) | null, type: (
-            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
-            & { __typename: 'CategoryType' }
-          ), attributes: Array<(
-            { id: string, key: string }
-            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
-          ) | (
-            { value: string, id: string, key: string }
-            & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
-            { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
-              { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
-                { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
-                  { id: string, name: string, namePlural: string | null }
-                  & { __typename: 'CategoryLevel' }
-                ) | null, image: (
-                  { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
-                    { id: string, width: number, height: number, src: string }
-                    & { __typename: 'ImageRendition' }
-                  ) | null, large: (
-                    { id: string, width: number, height: number, src: string }
-                    & { __typename: 'ImageRendition' }
-                  ) | null, small: (
-                    { id: string, width: number, height: number, src: string }
-                    & { __typename: 'ImageRendition' }
-                  ) | null, social: (
-                    { id: string, width: number, height: number, src: string }
-                    & { __typename: 'ImageRendition' }
-                  ) | null, rendition: (
-                    { id: string, width: number, height: number, src: string }
-                    & { __typename: 'ImageRendition' }
-                  ) | null }
-                  & { __typename: 'Image' }
-                ) | null, indicators: Array<(
-                  { id: string, values: Array<(
-                    { date: string | null, value: number }
-                    & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
-                    { date: string | null, value: number }
-                    & { __typename: 'IndicatorGoal' }
-                  ) | null> | null, unit: (
-                    { name: string, shortName: string | null }
-                    & { __typename: 'Unit' }
-                  ) }
-                  & { __typename: 'Indicator' }
-                )>, iconImage: (
-                  { rendition: (
-                    { src: string }
-                    & { __typename: 'ImageRendition' }
-                  ) | null }
-                  & { __typename: 'Image' }
-                ) | null, categoryPage: (
-                  { id: string | null, title: string, urlPath: string, live: boolean }
-                  & { __typename: 'CategoryPage' }
-                ) | null, type: (
-                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
-                  & { __typename: 'CategoryType' }
-                ), attributes: Array<(
-                  { id: string, key: string }
-                  & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
-                ) | (
-                  { value: string, id: string, key: string }
-                  & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
-                & { __typename: 'Category' }
-              ) | null, level: (
-                { id: string, name: string, namePlural: string | null }
-                & { __typename: 'CategoryLevel' }
-              ) | null, image: (
-                { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
-                  { id: string, width: number, height: number, src: string }
-                  & { __typename: 'ImageRendition' }
-                ) | null, large: (
-                  { id: string, width: number, height: number, src: string }
-                  & { __typename: 'ImageRendition' }
-                ) | null, small: (
-                  { id: string, width: number, height: number, src: string }
-                  & { __typename: 'ImageRendition' }
-                ) | null, social: (
-                  { id: string, width: number, height: number, src: string }
-                  & { __typename: 'ImageRendition' }
-                ) | null, rendition: (
-                  { id: string, width: number, height: number, src: string }
-                  & { __typename: 'ImageRendition' }
-                ) | null }
-                & { __typename: 'Image' }
-              ) | null, indicators: Array<(
-                { id: string, values: Array<(
-                  { date: string | null, value: number }
-                  & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
-                  { date: string | null, value: number }
-                  & { __typename: 'IndicatorGoal' }
-                ) | null> | null, unit: (
-                  { name: string, shortName: string | null }
-                  & { __typename: 'Unit' }
-                ) }
-                & { __typename: 'Indicator' }
-              )>, iconImage: (
-                { rendition: (
-                  { src: string }
-                  & { __typename: 'ImageRendition' }
-                ) | null }
-                & { __typename: 'Image' }
-              ) | null, categoryPage: (
-                { id: string | null, title: string, urlPath: string, live: boolean }
-                & { __typename: 'CategoryPage' }
-              ) | null, type: (
-                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
-                & { __typename: 'CategoryType' }
-              ), attributes: Array<(
-                { id: string, key: string }
-                & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
-              ) | (
-                { value: string, id: string, key: string }
-                & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
-              & { __typename: 'Category' }
-            ) | null, level: (
-              { id: string, name: string, namePlural: string | null }
-              & { __typename: 'CategoryLevel' }
-            ) | null, image: (
-              { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
-                { id: string, width: number, height: number, src: string }
-                & { __typename: 'ImageRendition' }
-              ) | null, large: (
-                { id: string, width: number, height: number, src: string }
-                & { __typename: 'ImageRendition' }
-              ) | null, small: (
-                { id: string, width: number, height: number, src: string }
-                & { __typename: 'ImageRendition' }
-              ) | null, social: (
-                { id: string, width: number, height: number, src: string }
-                & { __typename: 'ImageRendition' }
-              ) | null, rendition: (
-                { id: string, width: number, height: number, src: string }
-                & { __typename: 'ImageRendition' }
-              ) | null }
-              & { __typename: 'Image' }
-            ) | null, indicators: Array<(
-              { id: string, values: Array<(
-                { date: string | null, value: number }
-                & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
-                { date: string | null, value: number }
-                & { __typename: 'IndicatorGoal' }
-              ) | null> | null, unit: (
-                { name: string, shortName: string | null }
-                & { __typename: 'Unit' }
-              ) }
-              & { __typename: 'Indicator' }
-            )>, iconImage: (
-              { rendition: (
-                { src: string }
-                & { __typename: 'ImageRendition' }
-              ) | null }
-              & { __typename: 'Image' }
-            ) | null, categoryPage: (
-              { id: string | null, title: string, urlPath: string, live: boolean }
-              & { __typename: 'CategoryPage' }
-            ) | null, type: (
-              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
-              & { __typename: 'CategoryType' }
-            ), attributes: Array<(
-              { id: string, key: string }
-              & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
-            ) | (
-              { value: string, id: string, key: string }
-              & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
-            & { __typename: 'Category' }
+      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { heading: string | null, content: string | null, link: string | null, image: (
+          { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, large: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, small: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, social: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, rendition: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
           ) | null }
-          & { __typename: 'Category' }
-        )> }
-        & { __typename: 'CategoryType' }
-      ) | null, category: (
-        { id: string, children: Array<(
-          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
-            { id: string, name: string, namePlural: string | null }
-            & { __typename: 'CategoryLevel' }
-          ) | null, image: (
-            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, large: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, small: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, social: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null, rendition: (
-              { id: string, width: number, height: number, src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null }
-            & { __typename: 'Image' }
-          ) | null, indicators: Array<(
-            { id: string, values: Array<(
-              { date: string | null, value: number }
-              & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
-              { date: string | null, value: number }
-              & { __typename: 'IndicatorGoal' }
-            ) | null> | null, unit: (
-              { name: string, shortName: string | null }
-              & { __typename: 'Unit' }
-            ) }
-            & { __typename: 'Indicator' }
-          )>, iconImage: (
-            { rendition: (
-              { src: string }
-              & { __typename: 'ImageRendition' }
-            ) | null }
-            & { __typename: 'Image' }
-          ) | null, categoryPage: (
-            { id: string | null, title: string, urlPath: string, live: boolean }
-            & { __typename: 'CategoryPage' }
-          ) | null, type: (
-            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
-            & { __typename: 'CategoryType' }
-          ), attributes: Array<(
-            { id: string, key: string }
-            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
-          ) | (
-            { value: string, id: string, key: string }
-            & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
-          & { __typename: 'Category' }
-        )> }
-        & { __typename: 'Category' }
-      ) | null }
-      & { __typename: 'CategoryListBlock' }
-    ) | (
-      { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
-        { style: string | null, indicator: (
-          { id: string, identifier: string | null, name: string, description: string | null, timeResolution: IndicatorTimeResolution, level: string | null, unit: (
-            { id: string, name: string }
-            & { __typename: 'Unit' }
-          ), latestValue: (
-            { id: string, date: string | null, value: number }
-            & { __typename: 'IndicatorValue' }
-          ) | null, goals: Array<(
-            { id: string, date: string | null, value: number }
-            & { __typename: 'IndicatorGoal' }
-          ) | null> | null }
-          & { __typename: 'Indicator' }
+          & { __typename: 'Image' }
         ) | null }
-        & { __typename: 'IndicatorBlock' }
+        & { __typename: 'CardBlock' }
       ) | null> | null }
-      & { __typename: 'IndicatorGroupBlock' }
+      & { __typename: 'CardListBlock' }
     ) | (
-      { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<(
-        { question: string, answer: string }
-        & { __typename: 'QuestionBlock' }
-      )> | null }
-      & { __typename: 'QuestionAnswerBlock' }
-    ) | (
-      { id: string | null, blockType: string, field: string }
-      & { __typename: 'RelatedIndicatorsBlock' }
-    ) | (
-      { value: string, id: string | null, blockType: string, field: string }
-      & { __typename: 'RichTextBlock' }
-    )> | null, layout: (
-      { iconSize: string | null, layoutMainTop: Array<(
-        { attributeType: (
-          { identifier: string }
-          & { __typename: 'AttributeType' }
-        ) }
-        & { __typename: 'CategoryPageAttributeTypeBlock' }
-      ) | (
-        { blocks: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
-          { value: string }
-          & { __typename: 'ChoiceBlock' }
-        )> }
-        & { __typename: 'CategoryPageProgressBlock' }
-      )> | null, layoutMainBottom: Array<(
-        { attributeType: (
-          { identifier: string }
-          & { __typename: 'AttributeType' }
-        ) }
-        & { __typename: 'CategoryPageAttributeTypeBlock' }
-      ) | { __typename: 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' } | (
-        { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
-          { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
-            { choiceLabel: string | null, choiceValue: string | null }
-            & { __typename: 'FormChoiceBlock' }
-          )> }
-          & { __typename: 'FormFieldBlock' }
-        )> }
-        & { __typename: 'CategoryPageContactFormBlock' }
-      ) | (
-        { id: string | null, heading: string | null, helpText: string | null, datasetSchema: (
-          { uuid: string }
-          & { __typename: 'DatasetSchema' }
-        ) }
-        & { __typename: 'CategoryTypeDatasetsBlock' }
-      )> | null, layoutAside: Array<(
-        { attributeType: (
-          { identifier: string }
-          & { __typename: 'AttributeType' }
-        ) }
-        & { __typename: 'CategoryPageAttributeTypeBlock' }
-      )> | null }
-      & { __typename: 'CategoryTypePageLevelLayout' }
-    ) | null }
-    & { __typename: 'CategoryPage' }
-  ) | (
-    { contentType: string, id: string | null, slug: string, title: string, lastPublishedAt: string | null }
-    & { __typename: 'CategoryTypePage' }
-  ) | (
-    { id: string | null, slug: string, title: string, lastPublishedAt: string | null }
-    & { __typename: 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' }
-  ) | (
-    { leadContent: string | null, id: string | null, slug: string, title: string, lastPublishedAt: string | null }
-    & { __typename: 'PrivacyPolicyPage' }
-  ) | (
-    { leadParagraph: string | null, id: string | null, slug: string, title: string, lastPublishedAt: string | null, headerImage: (
-      { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
-        { id: string, width: number, height: number, src: string }
-        & { __typename: 'ImageRendition' }
-      ) | null, large: (
-        { id: string, width: number, height: number, src: string }
-        & { __typename: 'ImageRendition' }
-      ) | null, small: (
-        { id: string, width: number, height: number, src: string }
-        & { __typename: 'ImageRendition' }
-      ) | null, social: (
-        { id: string, width: number, height: number, src: string }
-        & { __typename: 'ImageRendition' }
-      ) | null, rendition: (
-        { id: string, width: number, height: number, src: string }
-        & { __typename: 'ImageRendition' }
-      ) | null }
-      & { __typename: 'Image' }
-    ) | null, body: Array<(
-      { fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
-        { html: string | null }
-        & { __typename: 'EmbedHTMLValue' }
-      ) | null }
-      & { __typename: 'AdaptiveEmbedBlock' }
-    ) | (
-      { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string, account: (
+      { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string | null, account: (
         { provider: CartographyProviderCredentialsProvider, account: string, publicAccessToken: string }
         & { __typename: 'CartographyProviderCredentials' }
       ) }
@@ -11082,7 +11667,7 @@ export type GetContentPageQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -11108,7 +11693,7 @@ export type GetContentPageQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -11136,7 +11721,7 @@ export type GetContentPageQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -11162,7 +11747,7 @@ export type GetContentPageQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -11189,7 +11774,7 @@ export type GetContentPageQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -11215,7 +11800,7 @@ export type GetContentPageQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -11242,7 +11827,7 @@ export type GetContentPageQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -11268,7 +11853,7 @@ export type GetContentPageQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -11301,7 +11886,7 @@ export type GetContentPageQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -11327,7 +11912,7 @@ export type GetContentPageQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         )> }
         & { __typename: 'Category' }
@@ -11340,10 +11925,10 @@ export type GetContentPageQuery = (
           & { __typename: 'Unit' }
         ) | null }
         & { __typename: 'AttributeType' }
-      ), treeMapCategoryType: (
+      ) | null, treeMapCategoryType: (
         { identifier: string }
         & { __typename: 'CategoryType' }
-      ) }
+      ) | null }
       & { __typename: 'CategoryTreeMapBlock' }
     ) | (
       { heading: string | null, helpText: string | null, id: string | null, blockType: string, field: string, categoryLevel: (
@@ -11358,7 +11943,7 @@ export type GetContentPageQuery = (
             { id: string, name: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -11405,7 +11990,7 @@ export type GetContentPageQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -11433,7 +12018,7 @@ export type GetContentPageQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -11459,7 +12044,7 @@ export type GetContentPageQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -11486,7 +12071,7 @@ export type GetContentPageQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -11512,7 +12097,7 @@ export type GetContentPageQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -11539,7 +12124,7 @@ export type GetContentPageQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -11565,7 +12150,7 @@ export type GetContentPageQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -11573,6 +12158,15 @@ export type GetContentPageQuery = (
         & { __typename: 'CategoryType' }
       ) }
       & { __typename: 'CategoryTypeLevelListBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string }
+      & { __typename: 'CharBlock' | 'RichTextBlock' | 'TextBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string, choices: Array<(
+        { key: string, value: string }
+        & { __typename: 'ChoiceOption' }
+      )> }
+      & { __typename: 'ChoiceBlock' }
     ) | (
       { id: string | null, blockType: string, field: string, blocks: Array<(
         { blockType: string }
@@ -11733,6 +12327,33 @@ export type GetContentPageQuery = (
       )> }
       & { __typename: 'DashboardRowBlock' }
     ) | (
+      { layout: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
+        { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, large: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, small: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, social: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, rendition: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null }
+        & { __typename: 'Image' }
+      ) | null }
+      & { __typename: 'FrontPageHeroBlock' }
+    ) | (
+      { style: string | null, id: string | null, blockType: string, field: string, indicator: (
+        { id: string }
+        & { __typename: 'Indicator' }
+      ) | null }
+      & { __typename: 'IndicatorBlock' }
+    ) | (
       { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
         { style: string | null, indicator: (
           { id: string, identifier: string | null, name: string, description: string | null, timeResolution: IndicatorTimeResolution, level: string | null, unit: (
@@ -11751,6 +12372,93 @@ export type GetContentPageQuery = (
       ) | null> | null }
       & { __typename: 'IndicatorGroupBlock' }
     ) | (
+      { title: string | null, body: string | null, id: string | null, blockType: string, field: string, blocks: Array<(
+        { id: string | null }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'URLBlock' | 'UpdatedAtColumnBlock' }
+      )>, indicator: (
+        { id: string, identifier: string | null, name: string, minValue: number | null, maxValue: number | null, unit: (
+          { id: string, shortName: string | null, name: string }
+          & { __typename: 'Unit' }
+        ), latestValue: (
+          { id: string, date: string | null, value: number }
+          & { __typename: 'IndicatorValue' }
+        ) | null, values: Array<(
+          { id: string, date: string | null, value: number, normalizedValues: Array<(
+            { normalizerId: string | null, value: number | null }
+            & { __typename: 'NormalizedValue' }
+          ) | null> | null, categories: Array<(
+            { id: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'IndicatorValue' }
+        ) | null> | null, goals: Array<(
+          { id: string, date: string | null, value: number, normalizedValues: Array<(
+            { normalizerId: string | null, value: number | null }
+            & { __typename: 'NormalizedValue' }
+          ) | null> | null }
+          & { __typename: 'IndicatorGoal' }
+        ) | null> | null, common: (
+          { id: string, normalizations: Array<(
+            { unit: (
+              { shortName: string | null, name: string }
+              & { __typename: 'Unit' }
+            ) | null, normalizer: (
+              { name: string, id: string, identifier: string | null }
+              & { __typename: 'CommonIndicator' }
+            ) | null }
+            & { __typename: 'CommonIndicatorNormalization' }
+          ) | null> | null }
+          & { __typename: 'CommonIndicator' }
+        ) | null }
+        & { __typename: 'Indicator' }
+      ) | null, linkButton: (
+        { blockType: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'UpdatedAtColumnBlock' }
+      ) | (
+        { text: string | null, blockType: string, page: (
+          { url: string | null, urlPath: string, slug: string }
+          & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
+        ) | null }
+        & { __typename: 'PageLinkBlock' }
+      ) | null }
+      & { __typename: 'IndicatorShowcaseBlock' }
+    ) | (
       { width: string | null, id: string | null, blockType: string, field: string, image: (
         { title: string, altText: string, width: number, height: number, imageCredit: string, renditionUncropped: (
           { src: string }
@@ -11763,15 +12471,1023 @@ export type GetContentPageQuery = (
       { heading: string | null, helpText: string | null, outcomeNodeId: string | null, id: string | null, blockType: string, field: string }
       & { __typename: 'PathsOutcomeBlock' }
     ) | (
-      { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<(
-        { question: string, answer: string }
+      { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { question: string | null, answer: string | null }
         & { __typename: 'QuestionBlock' }
-      )> | null }
+      ) | null> | null }
       & { __typename: 'QuestionAnswerBlock' }
+    ) | null> | null, layout: (
+      { iconSize: string | null, layoutMainTop: Array<(
+        { attributeType: (
+          { identifier: string }
+          & { __typename: 'AttributeType' }
+        ) }
+        & { __typename: 'CategoryPageAttributeTypeBlock' }
+      ) | (
+        { blocks: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+          { value: string }
+          & { __typename: 'ChoiceBlock' }
+        )> }
+        & { __typename: 'CategoryPageProgressBlock' }
+      )> | null, layoutMainBottom: Array<(
+        { attributeType: (
+          { identifier: string }
+          & { __typename: 'AttributeType' }
+        ) }
+        & { __typename: 'CategoryPageAttributeTypeBlock' }
+      ) | { __typename: 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' } | (
+        { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+          { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+            { choiceLabel: string | null, choiceValue: string | null }
+            & { __typename: 'FormChoiceBlock' }
+          ) | null> | null }
+          & { __typename: 'FormFieldBlock' }
+        ) | null> | null }
+        & { __typename: 'CategoryPageContactFormBlock' }
+      ) | (
+        { id: string | null, heading: string | null, helpText: string | null, datasetSchema: (
+          { uuid: string }
+          & { __typename: 'DatasetSchema' }
+        ) }
+        & { __typename: 'CategoryTypeDatasetsBlock' }
+      )> | null, layoutAside: Array<(
+        { attributeType: (
+          { identifier: string }
+          & { __typename: 'AttributeType' }
+        ) }
+        & { __typename: 'CategoryPageAttributeTypeBlock' }
+      )> | null }
+      & { __typename: 'CategoryTypePageLevelLayout' }
+    ) | null }
+    & { __typename: 'CategoryPage' }
+  ) | (
+    { contentType: string, id: string | null, slug: string, title: string, lastPublishedAt: string | null }
+    & { __typename: 'CategoryTypePage' }
+  ) | (
+    { id: string | null, slug: string, title: string, lastPublishedAt: string | null }
+    & { __typename: 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' }
+  ) | (
+    { leadContent: string | null, id: string | null, slug: string, title: string, lastPublishedAt: string | null }
+    & { __typename: 'PrivacyPolicyPage' }
+  ) | (
+    { leadParagraph: string | null, id: string | null, slug: string, title: string, lastPublishedAt: string | null, headerImage: (
+      { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null, large: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null, small: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null, social: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null, rendition: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null }
+      & { __typename: 'Image' }
+    ) | null, body: Array<(
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' | 'ActionLinksBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorHighlightsBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'UpdatedAtColumnBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, blocks: Array<(
+        { id: string | null, field: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'UpdatedAtColumnBlock' }
+      ) | (
+        { value: string, id: string | null, field: string }
+        & { __typename: 'CharBlock' }
+      )> }
+      & { __typename: 'AccessibilityStatementContactInformationBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { heading: string | null, lead: string | null, category: (
+          { id: string, type: (
+            { identifier: string }
+            & { __typename: 'CategoryType' }
+          ) }
+          & { __typename: 'Category' }
+        ) | null }
+        & { __typename: 'ActionCategoryFilterCardBlock' }
+      ) | null> | null }
+      & { __typename: 'ActionCategoryFilterCardsBlock' }
+    ) | (
+      { id: string | null, heading: string | null, helpText: string | null, blockType: string, field: string, categoryFilter: (
+        { id: string }
+        & { __typename: 'Category' }
+      ) | null, groupByCategoryLevel: (
+        { id: string }
+        & { __typename: 'CategoryLevel' }
+      ) | null }
+      & { __typename: 'ActionListBlock' }
+    ) | (
+      { fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
+        { html: string | null }
+        & { __typename: 'EmbedHTMLValue' }
+      ) | null }
+      & { __typename: 'AdaptiveEmbedBlock' }
+    ) | (
+      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { heading: string | null, content: string | null, link: string | null, image: (
+          { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, large: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, small: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, social: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null, rendition: (
+            { id: string, width: number, height: number, src: string }
+            & { __typename: 'ImageRendition' }
+          ) | null }
+          & { __typename: 'Image' }
+        ) | null }
+        & { __typename: 'CardBlock' }
+      ) | null> | null }
+      & { __typename: 'CardListBlock' }
+    ) | (
+      { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string | null, account: (
+        { provider: CartographyProviderCredentialsProvider, account: string, publicAccessToken: string }
+        & { __typename: 'CartographyProviderCredentials' }
+      ) }
+      & { __typename: 'CartographyVisualisationBlock' }
+    ) | (
+      { style: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, categoryType: (
+        { id: string, hideCategoryIdentifiers: boolean, categories: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, indicators: Array<(
+            { id: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null, parent: (
+            { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+              { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+                { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+                  { id: string, name: string, namePlural: string | null }
+                  & { __typename: 'CategoryLevel' }
+                ) | null, image: (
+                  { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, large: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, small: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, social: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, rendition: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, indicators: Array<(
+                  { id: string, values: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorValue' }
+                  ) | null> | null, goals: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorGoal' }
+                  ) | null> | null, unit: (
+                    { name: string, shortName: string | null }
+                    & { __typename: 'Unit' }
+                  ) }
+                  & { __typename: 'Indicator' }
+                )>, iconImage: (
+                  { rendition: (
+                    { src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, categoryPage: (
+                  { id: string | null, title: string, urlPath: string, live: boolean }
+                  & { __typename: 'CategoryPage' }
+                ) | null, type: (
+                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                  & { __typename: 'CategoryType' }
+                ), attributes: Array<(
+                  { id: string, key: string }
+                  & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+                ) | (
+                  { value: string, id: string, key: string }
+                  & { __typename: 'AttributeRichText' | 'AttributeText' }
+                )> | null }
+                & { __typename: 'Category' }
+              ) | null, level: (
+                { id: string, name: string, namePlural: string | null }
+                & { __typename: 'CategoryLevel' }
+              ) | null, image: (
+                { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, large: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, small: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, social: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, rendition: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, indicators: Array<(
+                { id: string, values: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorValue' }
+                ) | null> | null, goals: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorGoal' }
+                ) | null> | null, unit: (
+                  { name: string, shortName: string | null }
+                  & { __typename: 'Unit' }
+                ) }
+                & { __typename: 'Indicator' }
+              )>, iconImage: (
+                { rendition: (
+                  { src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, categoryPage: (
+                { id: string | null, title: string, urlPath: string, live: boolean }
+                & { __typename: 'CategoryPage' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename: 'CategoryType' }
+              ), attributes: Array<(
+                { id: string, key: string }
+                & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+              ) | (
+                { value: string, id: string, key: string }
+                & { __typename: 'AttributeRichText' | 'AttributeText' }
+              )> | null }
+              & { __typename: 'Category' }
+            ) | null, level: (
+              { id: string, name: string, namePlural: string | null }
+              & { __typename: 'CategoryLevel' }
+            ) | null, image: (
+              { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, large: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, small: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, social: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, rendition: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, indicators: Array<(
+              { id: string, values: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorValue' }
+              ) | null> | null, goals: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorGoal' }
+              ) | null> | null, unit: (
+                { name: string, shortName: string | null }
+                & { __typename: 'Unit' }
+              ) }
+              & { __typename: 'Indicator' }
+            )>, iconImage: (
+              { rendition: (
+                { src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, categoryPage: (
+              { id: string | null, title: string, urlPath: string, live: boolean }
+              & { __typename: 'CategoryPage' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename: 'CategoryType' }
+            ), attributes: Array<(
+              { id: string, key: string }
+              & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+            ) | (
+              { value: string, id: string, key: string }
+              & { __typename: 'AttributeRichText' | 'AttributeText' }
+            )> | null }
+            & { __typename: 'Category' }
+          ) | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'CategoryType' }
+      ) | null, category: (
+        { id: string, children: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, indicators: Array<(
+            { id: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'Category' }
+      ) | null }
+      & { __typename: 'CategoryListBlock' }
+    ) | (
+      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, valueAttribute: (
+        { identifier: string, unit: (
+          { shortName: string | null }
+          & { __typename: 'Unit' }
+        ) | null }
+        & { __typename: 'AttributeType' }
+      ) | null, treeMapCategoryType: (
+        { identifier: string }
+        & { __typename: 'CategoryType' }
+      ) | null }
+      & { __typename: 'CategoryTreeMapBlock' }
+    ) | (
+      { heading: string | null, helpText: string | null, id: string | null, blockType: string, field: string, categoryLevel: (
+        { id: string, name: string, namePlural: string | null }
+        & { __typename: 'CategoryLevel' }
+      ), groupByCategoryLevel: (
+        { id: string }
+        & { __typename: 'CategoryLevel' }
+      ) | null, categoryBlockType: (
+        { id: string, identifier: string, hideCategoryIdentifiers: boolean, categories: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, indicators: Array<(
+            { id: string, name: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null, parent: (
+            { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+              { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+                { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+                  { id: string, name: string, namePlural: string | null }
+                  & { __typename: 'CategoryLevel' }
+                ) | null, image: (
+                  { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, large: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, small: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, social: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, rendition: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, indicators: Array<(
+                  { id: string, values: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorValue' }
+                  ) | null> | null, goals: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorGoal' }
+                  ) | null> | null, unit: (
+                    { name: string, shortName: string | null }
+                    & { __typename: 'Unit' }
+                  ) }
+                  & { __typename: 'Indicator' }
+                )>, iconImage: (
+                  { rendition: (
+                    { src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, categoryPage: (
+                  { id: string | null, title: string, urlPath: string, live: boolean }
+                  & { __typename: 'CategoryPage' }
+                ) | null, type: (
+                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                  & { __typename: 'CategoryType' }
+                ), attributes: Array<(
+                  { id: string, key: string }
+                  & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+                ) | (
+                  { value: string, id: string, key: string }
+                  & { __typename: 'AttributeRichText' | 'AttributeText' }
+                )> | null }
+                & { __typename: 'Category' }
+              ) | null, level: (
+                { id: string, name: string, namePlural: string | null }
+                & { __typename: 'CategoryLevel' }
+              ) | null, image: (
+                { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, large: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, small: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, social: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, rendition: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, indicators: Array<(
+                { id: string, values: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorValue' }
+                ) | null> | null, goals: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorGoal' }
+                ) | null> | null, unit: (
+                  { name: string, shortName: string | null }
+                  & { __typename: 'Unit' }
+                ) }
+                & { __typename: 'Indicator' }
+              )>, iconImage: (
+                { rendition: (
+                  { src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, categoryPage: (
+                { id: string | null, title: string, urlPath: string, live: boolean }
+                & { __typename: 'CategoryPage' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename: 'CategoryType' }
+              ), attributes: Array<(
+                { id: string, key: string }
+                & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+              ) | (
+                { value: string, id: string, key: string }
+                & { __typename: 'AttributeRichText' | 'AttributeText' }
+              )> | null }
+              & { __typename: 'Category' }
+            ) | null, level: (
+              { id: string, name: string, namePlural: string | null }
+              & { __typename: 'CategoryLevel' }
+            ) | null, image: (
+              { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, large: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, small: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, social: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, rendition: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, indicators: Array<(
+              { id: string, values: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorValue' }
+              ) | null> | null, goals: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorGoal' }
+              ) | null> | null, unit: (
+                { name: string, shortName: string | null }
+                & { __typename: 'Unit' }
+              ) }
+              & { __typename: 'Indicator' }
+            )>, iconImage: (
+              { rendition: (
+                { src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, categoryPage: (
+              { id: string | null, title: string, urlPath: string, live: boolean }
+              & { __typename: 'CategoryPage' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename: 'CategoryType' }
+            ), attributes: Array<(
+              { id: string, key: string }
+              & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+            ) | (
+              { value: string, id: string, key: string }
+              & { __typename: 'AttributeRichText' | 'AttributeText' }
+            )> | null }
+            & { __typename: 'Category' }
+          ) | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'CategoryType' }
+      ) }
+      & { __typename: 'CategoryTypeLevelListBlock' }
     ) | (
       { value: string, id: string | null, blockType: string, field: string }
-      & { __typename: 'RichTextBlock' }
-    )> | null, siblings: Array<(
+      & { __typename: 'CharBlock' | 'RichTextBlock' | 'TextBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string, choices: Array<(
+        { key: string, value: string }
+        & { __typename: 'ChoiceOption' }
+      )> }
+      & { __typename: 'ChoiceBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, blocks: Array<(
+        { blockType: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardRowBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+      ) | (
+        { id: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { id: string | null, barType: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorBarChartBlock' }
+      ) | (
+        { id: string | null, helpText: string | null, showTotalLine: boolean | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorLineChartBlock' }
+      ) | (
+        { helpText: string | null, year: number | null, blockType: string, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorPieChartBlock' }
+      ) | (
+        { id: string | null, blockType: string, indicator: (
+          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { value: number, date: string | null }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null, unit: (
+            { name: string, shortName: string | null }
+            & { __typename: 'Unit' }
+          ) }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'DashboardIndicatorSummaryBlock' }
+      ) | (
+        { text: string | null, blockType: string }
+        & { __typename: 'DashboardParagraphBlock' }
+      )> }
+      & { __typename: 'DashboardRowBlock' }
+    ) | (
+      { layout: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
+        { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, large: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, small: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, social: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null, rendition: (
+          { id: string, width: number, height: number, src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null }
+        & { __typename: 'Image' }
+      ) | null }
+      & { __typename: 'FrontPageHeroBlock' }
+    ) | (
+      { style: string | null, id: string | null, blockType: string, field: string, indicator: (
+        { id: string }
+        & { __typename: 'Indicator' }
+      ) | null }
+      & { __typename: 'IndicatorBlock' }
+    ) | (
+      { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { style: string | null, indicator: (
+          { id: string, identifier: string | null, name: string, description: string | null, timeResolution: IndicatorTimeResolution, level: string | null, unit: (
+            { id: string, name: string }
+            & { __typename: 'Unit' }
+          ), latestValue: (
+            { id: string, date: string | null, value: number }
+            & { __typename: 'IndicatorValue' }
+          ) | null, goals: Array<(
+            { id: string, date: string | null, value: number }
+            & { __typename: 'IndicatorGoal' }
+          ) | null> | null }
+          & { __typename: 'Indicator' }
+        ) | null }
+        & { __typename: 'IndicatorBlock' }
+      ) | null> | null }
+      & { __typename: 'IndicatorGroupBlock' }
+    ) | (
+      { title: string | null, body: string | null, id: string | null, blockType: string, field: string, blocks: Array<(
+        { id: string | null }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' }
+      ) | (
+        { id: string | null }
+        & { __typename: 'URLBlock' | 'UpdatedAtColumnBlock' }
+      )>, indicator: (
+        { id: string, identifier: string | null, name: string, minValue: number | null, maxValue: number | null, unit: (
+          { id: string, shortName: string | null, name: string }
+          & { __typename: 'Unit' }
+        ), latestValue: (
+          { id: string, date: string | null, value: number }
+          & { __typename: 'IndicatorValue' }
+        ) | null, values: Array<(
+          { id: string, date: string | null, value: number, normalizedValues: Array<(
+            { normalizerId: string | null, value: number | null }
+            & { __typename: 'NormalizedValue' }
+          ) | null> | null, categories: Array<(
+            { id: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'IndicatorValue' }
+        ) | null> | null, goals: Array<(
+          { id: string, date: string | null, value: number, normalizedValues: Array<(
+            { normalizerId: string | null, value: number | null }
+            & { __typename: 'NormalizedValue' }
+          ) | null> | null }
+          & { __typename: 'IndicatorGoal' }
+        ) | null> | null, common: (
+          { id: string, normalizations: Array<(
+            { unit: (
+              { shortName: string | null, name: string }
+              & { __typename: 'Unit' }
+            ) | null, normalizer: (
+              { name: string, id: string, identifier: string | null }
+              & { __typename: 'CommonIndicator' }
+            ) | null }
+            & { __typename: 'CommonIndicatorNormalization' }
+          ) | null> | null }
+          & { __typename: 'CommonIndicator' }
+        ) | null }
+        & { __typename: 'Indicator' }
+      ) | null, linkButton: (
+        { blockType: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { blockType: string }
+        & { __typename: 'UpdatedAtColumnBlock' }
+      ) | (
+        { text: string | null, blockType: string, page: (
+          { url: string | null, urlPath: string, slug: string }
+          & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
+        ) | null }
+        & { __typename: 'PageLinkBlock' }
+      ) | null }
+      & { __typename: 'IndicatorShowcaseBlock' }
+    ) | (
+      { width: string | null, id: string | null, blockType: string, field: string, image: (
+        { title: string, altText: string, width: number, height: number, imageCredit: string, renditionUncropped: (
+          { src: string }
+          & { __typename: 'ImageRendition' }
+        ) | null }
+        & { __typename: 'Image' }
+      ) | null }
+      & { __typename: 'LargeImageBlock' }
+    ) | (
+      { heading: string | null, helpText: string | null, outcomeNodeId: string | null, id: string | null, blockType: string, field: string }
+      & { __typename: 'PathsOutcomeBlock' }
+    ) | (
+      { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { question: string | null, answer: string | null }
+        & { __typename: 'QuestionBlock' }
+      ) | null> | null }
+      & { __typename: 'QuestionAnswerBlock' }
+    ) | null> | null, siblings: Array<(
       { id: string | null, title: string, slug: string, live: boolean, urlPath: string }
       & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
     )>, parent: (
@@ -11853,7 +13569,52 @@ export type GetHomePageQuery = (
     & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PrivacyPolicyPage' | 'StaticPage' }
   ) | (
     { id: string | null, slug: string, lastPublishedAt: string | null, body: Array<(
-      { id: string | null, blockType: string, field: string, cards: Array<(
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' | 'ActionLinksBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorHighlightsBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'UpdatedAtColumnBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, blocks: Array<(
+        { id: string | null, field: string }
+        & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' }
+      ) | (
+        { id: string | null, field: string }
+        & { __typename: 'UpdatedAtColumnBlock' }
+      ) | (
+        { value: string, id: string | null, field: string }
+        & { __typename: 'CharBlock' }
+      )> }
+      & { __typename: 'AccessibilityStatementContactInformationBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
         { heading: string | null, lead: string | null, category: (
           { id: string, type: (
             { identifier: string }
@@ -11862,11 +13623,17 @@ export type GetHomePageQuery = (
           & { __typename: 'Category' }
         ) | null }
         & { __typename: 'ActionCategoryFilterCardBlock' }
-      )> | null }
+      ) | null> | null }
       & { __typename: 'ActionCategoryFilterCardsBlock' }
     ) | (
-      { id: string | null, blockType: string, field: string }
-      & { __typename: 'ActionHighlightsBlock' | 'ActionStatusGraphsBlock' | 'IndicatorHighlightsBlock' | 'RelatedPlanListBlock' }
+      { id: string | null, heading: string | null, helpText: string | null, blockType: string, field: string, categoryFilter: (
+        { id: string }
+        & { __typename: 'Category' }
+      ) | null, groupByCategoryLevel: (
+        { id: string }
+        & { __typename: 'CategoryLevel' }
+      ) | null }
+      & { __typename: 'ActionListBlock' }
     ) | (
       { fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
         { html: string | null }
@@ -11874,7 +13641,7 @@ export type GetHomePageQuery = (
       ) | null }
       & { __typename: 'AdaptiveEmbedBlock' }
     ) | (
-      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<(
+      { heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, cards: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
         { heading: string | null, content: string | null, link: string | null, image: (
           { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
             { id: string, width: number, height: number, src: string }
@@ -11895,8 +13662,14 @@ export type GetHomePageQuery = (
           & { __typename: 'Image' }
         ) | null }
         & { __typename: 'CardBlock' }
-      )> | null }
+      ) | null> | null }
       & { __typename: 'CardListBlock' }
+    ) | (
+      { styleOverrides: string | null, id: string | null, blockType: string, field: string, cartographyStyle: string | null, account: (
+        { provider: CartographyProviderCredentialsProvider, account: string, publicAccessToken: string }
+        & { __typename: 'CartographyProviderCredentials' }
+      ) }
+      & { __typename: 'CartographyVisualisationBlock' }
     ) | (
       { style: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, categoryType: (
         { id: string, hideCategoryIdentifiers: boolean, categories: Array<(
@@ -11925,7 +13698,7 @@ export type GetHomePageQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -11951,7 +13724,7 @@ export type GetHomePageQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )>, parent: (
+          )> | null, parent: (
             { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
               { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
                 { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
@@ -11979,7 +13752,7 @@ export type GetHomePageQuery = (
                   { id: string, values: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorValue' }
-                  )>, goals: Array<(
+                  ) | null> | null, goals: Array<(
                     { date: string | null, value: number }
                     & { __typename: 'IndicatorGoal' }
                   ) | null> | null, unit: (
@@ -12005,7 +13778,7 @@ export type GetHomePageQuery = (
                 ) | (
                   { value: string, id: string, key: string }
                   & { __typename: 'AttributeRichText' | 'AttributeText' }
-                )> }
+                )> | null }
                 & { __typename: 'Category' }
               ) | null, level: (
                 { id: string, name: string, namePlural: string | null }
@@ -12032,7 +13805,7 @@ export type GetHomePageQuery = (
                 { id: string, values: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorValue' }
-                )>, goals: Array<(
+                ) | null> | null, goals: Array<(
                   { date: string | null, value: number }
                   & { __typename: 'IndicatorGoal' }
                 ) | null> | null, unit: (
@@ -12058,7 +13831,7 @@ export type GetHomePageQuery = (
               ) | (
                 { value: string, id: string, key: string }
                 & { __typename: 'AttributeRichText' | 'AttributeText' }
-              )> }
+              )> | null }
               & { __typename: 'Category' }
             ) | null, level: (
               { id: string, name: string, namePlural: string | null }
@@ -12085,7 +13858,7 @@ export type GetHomePageQuery = (
               { id: string, values: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorValue' }
-              )>, goals: Array<(
+              ) | null> | null, goals: Array<(
                 { date: string | null, value: number }
                 & { __typename: 'IndicatorGoal' }
               ) | null> | null, unit: (
@@ -12111,7 +13884,7 @@ export type GetHomePageQuery = (
             ) | (
               { value: string, id: string, key: string }
               & { __typename: 'AttributeRichText' | 'AttributeText' }
-            )> }
+            )> | null }
             & { __typename: 'Category' }
           ) | null }
           & { __typename: 'Category' }
@@ -12144,7 +13917,7 @@ export type GetHomePageQuery = (
             { id: string, values: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorValue' }
-            )>, goals: Array<(
+            ) | null> | null, goals: Array<(
               { date: string | null, value: number }
               & { __typename: 'IndicatorGoal' }
             ) | null> | null, unit: (
@@ -12170,7 +13943,7 @@ export type GetHomePageQuery = (
           ) | (
             { value: string, id: string, key: string }
             & { __typename: 'AttributeRichText' | 'AttributeText' }
-          )> }
+          )> | null }
           & { __typename: 'Category' }
         )> }
         & { __typename: 'Category' }
@@ -12183,11 +13956,248 @@ export type GetHomePageQuery = (
           & { __typename: 'Unit' }
         ) | null }
         & { __typename: 'AttributeType' }
-      ), treeMapCategoryType: (
+      ) | null, treeMapCategoryType: (
         { identifier: string }
         & { __typename: 'CategoryType' }
-      ) }
+      ) | null }
       & { __typename: 'CategoryTreeMapBlock' }
+    ) | (
+      { heading: string | null, helpText: string | null, id: string | null, blockType: string, field: string, categoryLevel: (
+        { id: string, name: string, namePlural: string | null }
+        & { __typename: 'CategoryLevel' }
+      ), groupByCategoryLevel: (
+        { id: string }
+        & { __typename: 'CategoryLevel' }
+      ) | null, categoryBlockType: (
+        { id: string, identifier: string, hideCategoryIdentifiers: boolean, categories: Array<(
+          { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, indicators: Array<(
+            { id: string, name: string, values: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorValue' }
+            ) | null> | null, goals: Array<(
+              { date: string | null, value: number }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          )>, level: (
+            { id: string, name: string, namePlural: string | null }
+            & { __typename: 'CategoryLevel' }
+          ) | null, image: (
+            { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, large: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, small: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, social: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null, rendition: (
+              { id: string, width: number, height: number, src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, iconImage: (
+            { rendition: (
+              { src: string }
+              & { __typename: 'ImageRendition' }
+            ) | null }
+            & { __typename: 'Image' }
+          ) | null, categoryPage: (
+            { id: string | null, title: string, urlPath: string, live: boolean }
+            & { __typename: 'CategoryPage' }
+          ) | null, type: (
+            { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+            & { __typename: 'CategoryType' }
+          ), attributes: Array<(
+            { id: string, key: string }
+            & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+          ) | (
+            { value: string, id: string, key: string }
+            & { __typename: 'AttributeRichText' | 'AttributeText' }
+          )> | null, parent: (
+            { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+              { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, parent: (
+                { id: string, identifier: string, name: string, leadParagraph: string, order: number, kausalPathsNodeUuid: string, color: string, iconSvgUrl: string | null, helpText: string, level: (
+                  { id: string, name: string, namePlural: string | null }
+                  & { __typename: 'CategoryLevel' }
+                ) | null, image: (
+                  { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, large: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, small: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, social: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null, rendition: (
+                    { id: string, width: number, height: number, src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, indicators: Array<(
+                  { id: string, values: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorValue' }
+                  ) | null> | null, goals: Array<(
+                    { date: string | null, value: number }
+                    & { __typename: 'IndicatorGoal' }
+                  ) | null> | null, unit: (
+                    { name: string, shortName: string | null }
+                    & { __typename: 'Unit' }
+                  ) }
+                  & { __typename: 'Indicator' }
+                )>, iconImage: (
+                  { rendition: (
+                    { src: string }
+                    & { __typename: 'ImageRendition' }
+                  ) | null }
+                  & { __typename: 'Image' }
+                ) | null, categoryPage: (
+                  { id: string | null, title: string, urlPath: string, live: boolean }
+                  & { __typename: 'CategoryPage' }
+                ) | null, type: (
+                  { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                  & { __typename: 'CategoryType' }
+                ), attributes: Array<(
+                  { id: string, key: string }
+                  & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+                ) | (
+                  { value: string, id: string, key: string }
+                  & { __typename: 'AttributeRichText' | 'AttributeText' }
+                )> | null }
+                & { __typename: 'Category' }
+              ) | null, level: (
+                { id: string, name: string, namePlural: string | null }
+                & { __typename: 'CategoryLevel' }
+              ) | null, image: (
+                { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, large: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, small: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, social: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null, rendition: (
+                  { id: string, width: number, height: number, src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, indicators: Array<(
+                { id: string, values: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorValue' }
+                ) | null> | null, goals: Array<(
+                  { date: string | null, value: number }
+                  & { __typename: 'IndicatorGoal' }
+                ) | null> | null, unit: (
+                  { name: string, shortName: string | null }
+                  & { __typename: 'Unit' }
+                ) }
+                & { __typename: 'Indicator' }
+              )>, iconImage: (
+                { rendition: (
+                  { src: string }
+                  & { __typename: 'ImageRendition' }
+                ) | null }
+                & { __typename: 'Image' }
+              ) | null, categoryPage: (
+                { id: string | null, title: string, urlPath: string, live: boolean }
+                & { __typename: 'CategoryPage' }
+              ) | null, type: (
+                { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+                & { __typename: 'CategoryType' }
+              ), attributes: Array<(
+                { id: string, key: string }
+                & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+              ) | (
+                { value: string, id: string, key: string }
+                & { __typename: 'AttributeRichText' | 'AttributeText' }
+              )> | null }
+              & { __typename: 'Category' }
+            ) | null, level: (
+              { id: string, name: string, namePlural: string | null }
+              & { __typename: 'CategoryLevel' }
+            ) | null, image: (
+              { id: string, title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, large: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, small: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, social: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null, rendition: (
+                { id: string, width: number, height: number, src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, indicators: Array<(
+              { id: string, values: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorValue' }
+              ) | null> | null, goals: Array<(
+                { date: string | null, value: number }
+                & { __typename: 'IndicatorGoal' }
+              ) | null> | null, unit: (
+                { name: string, shortName: string | null }
+                & { __typename: 'Unit' }
+              ) }
+              & { __typename: 'Indicator' }
+            )>, iconImage: (
+              { rendition: (
+                { src: string }
+                & { __typename: 'ImageRendition' }
+              ) | null }
+              & { __typename: 'Image' }
+            ) | null, categoryPage: (
+              { id: string | null, title: string, urlPath: string, live: boolean }
+              & { __typename: 'CategoryPage' }
+            ) | null, type: (
+              { id: string, identifier: string, hideCategoryIdentifiers: boolean }
+              & { __typename: 'CategoryType' }
+            ), attributes: Array<(
+              { id: string, key: string }
+              & { __typename: 'AttributeCategoryChoice' | 'AttributeChoice' | 'AttributeNumericValue' }
+            ) | (
+              { value: string, id: string, key: string }
+              & { __typename: 'AttributeRichText' | 'AttributeText' }
+            )> | null }
+            & { __typename: 'Category' }
+          ) | null }
+          & { __typename: 'Category' }
+        )> }
+        & { __typename: 'CategoryType' }
+      ) }
+      & { __typename: 'CategoryTypeLevelListBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string }
+      & { __typename: 'CharBlock' | 'RichTextBlock' | 'TextBlock' }
+    ) | (
+      { value: string, id: string | null, blockType: string, field: string, choices: Array<(
+        { key: string, value: string }
+        & { __typename: 'ChoiceOption' }
+      )> }
+      & { __typename: 'ChoiceBlock' }
     ) | (
       { id: string | null, blockType: string, field: string, blocks: Array<(
         { blockType: string }
@@ -12348,7 +14358,7 @@ export type GetHomePageQuery = (
       )> }
       & { __typename: 'DashboardRowBlock' }
     ) | (
-      { layout: string, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
+      { layout: string | null, heading: string | null, lead: string | null, id: string | null, blockType: string, field: string, image: (
         { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, full: (
           { id: string, width: number, height: number, src: string }
           & { __typename: 'ImageRendition' }
@@ -12368,6 +14378,12 @@ export type GetHomePageQuery = (
         & { __typename: 'Image' }
       ) | null }
       & { __typename: 'FrontPageHeroBlock' }
+    ) | (
+      { style: string | null, id: string | null, blockType: string, field: string, indicator: (
+        { id: string }
+        & { __typename: 'Indicator' }
+      ) | null }
+      & { __typename: 'IndicatorBlock' }
     ) | (
       { title: string | null, id: string | null, blockType: string, field: string, indicators: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
         { style: string | null, indicator: (
@@ -12419,28 +14435,28 @@ export type GetHomePageQuery = (
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )>, categories: Array<(
+          ) | null> | null, categories: Array<(
             { id: string }
             & { __typename: 'DimensionCategory' }
           )> }
           & { __typename: 'IndicatorValue' }
-        )>, goals: Array<(
+        ) | null> | null, goals: Array<(
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )> }
+          ) | null> | null }
           & { __typename: 'IndicatorGoal' }
         ) | null> | null, common: (
           { id: string, normalizations: Array<(
             { unit: (
               { shortName: string | null, name: string }
               & { __typename: 'Unit' }
-            ), normalizer: (
+            ) | null, normalizer: (
               { name: string, id: string, identifier: string | null }
               & { __typename: 'CommonIndicator' }
-            ) }
+            ) | null }
             & { __typename: 'CommonIndicatorNormalization' }
-          )> }
+          ) | null> | null }
           & { __typename: 'CommonIndicator' }
         ) | null }
         & { __typename: 'Indicator' }
@@ -12486,9 +14502,12 @@ export type GetHomePageQuery = (
       { heading: string | null, helpText: string | null, outcomeNodeId: string | null, id: string | null, blockType: string, field: string }
       & { __typename: 'PathsOutcomeBlock' }
     ) | (
-      { value: string, id: string | null, blockType: string, field: string }
-      & { __typename: 'RichTextBlock' }
-    )> }
+      { heading: string | null, id: string | null, blockType: string, field: string, questions: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' } | { __typename: 'ActionLeadParagraphBlock' | 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' } | { __typename: 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' } | { __typename: 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' } | { __typename: 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
+        { question: string | null, answer: string | null }
+        & { __typename: 'QuestionBlock' }
+      ) | null> | null }
+      & { __typename: 'QuestionAnswerBlock' }
+    ) | null> | null }
     & { __typename: 'PlanRootPage' }
   ) | null, plan: (
     { id: string, primaryActionClassification: (
@@ -12606,7 +14625,7 @@ export type IndicatorDetailsQuery = (
     ) | null, values: Array<(
       { id: string, date: string | null, value: number }
       & { __typename: 'IndicatorValue' }
-    )>, goals: Array<(
+    ) | null> | null, goals: Array<(
       { id: string, date: string | null, value: number, scenario: (
         { id: string }
         & { __typename: 'Scenario' }
@@ -12636,7 +14655,7 @@ export type IndicatorDetailsQuery = (
         & { __typename: 'ActionImpact' }
       ) | null }
       & { __typename: 'Action' }
-    )>, relatedCauses: Array<(
+    ) | null> | null, relatedCauses: Array<(
       { id: string, effectType: RelatedIndicatorEffectType, confidenceLevel: RelatedIndicatorConfidenceLevel, causalIndicator: (
         { id: string, name: string, level: string | null, plans: Array<(
           { identifier: string, viewUrl: string | null, parent: (
@@ -12714,7 +14733,7 @@ export type OrganizationDetailsQuery = (
       ), primaryOrgs: Array<(
         { id: string, name: string }
         & { __typename: 'Organization' }
-      )>, actionImpacts: Array<(
+      ) | null>, actionImpacts: Array<(
         { id: string }
         & { __typename: 'ActionImpact' }
       )>, actionStatusSummaries: Array<(
@@ -12878,7 +14897,7 @@ export type OrganizationDetailsQuery = (
     ), primaryOrgs: Array<(
       { id: string, name: string }
       & { __typename: 'Organization' }
-    )>, actionImpacts: Array<(
+    ) | null>, actionImpacts: Array<(
       { id: string }
       & { __typename: 'ActionImpact' }
     )>, actionStatusSummaries: Array<(
@@ -13017,7 +15036,7 @@ export type OrgContentPlanFragment = (
   ), primaryOrgs: Array<(
     { id: string, name: string }
     & { __typename: 'Organization' }
-  )>, actionImpacts: Array<(
+  ) | null>, actionImpacts: Array<(
     { id: string }
     & { __typename: 'ActionImpact' }
   )>, actionStatusSummaries: Array<(
@@ -13156,7 +15175,7 @@ export type GetPlanContextQueryVariables = Exact<{
 
 export type GetPlanContextQuery = (
   { plan: (
-    { id: string, identifier: string, name: string, shortName: string | null, versionName: string, themeIdentifier: string | null, primaryLanguage: string, otherLanguages: Array<string>, hideActionIdentifiers: boolean, publishedAt: string | null, kausalPathsInstanceUuid: string, viewUrl: string | null, actionReportExportViewUrl: string | null, serveFileBaseUrl: string, adminUrl: string | null, accessibilityStatementUrl: string | null, externalFeedbackUrl: string | null, primaryActionClassification: (
+    { id: string, identifier: string, name: string, shortName: string | null, versionName: string, themeIdentifier: string | null, primaryLanguage: string, otherLanguages: Array<string>, hideActionIdentifiers: boolean | null, publishedAt: string | null, kausalPathsInstanceUuid: string, viewUrl: string | null, actionReportExportViewUrl: string | null, serveFileBaseUrl: string, adminUrl: string | null, accessibilityStatementUrl: string | null, externalFeedbackUrl: string | null, primaryActionClassification: (
       { id: string, identifier: string, hideCategoryIdentifiers: boolean, common: (
         { identifier: string }
         & { __typename: 'CommonCategoryType' }
@@ -13210,10 +15229,10 @@ export type GetPlanContextQuery = (
     )>, impactGroups: Array<(
       { id: string }
       & { __typename: 'ImpactGroup' }
-    )>, primaryOrgs: Array<(
+    ) | null>, primaryOrgs: Array<(
       { id: string }
       & { __typename: 'Organization' }
-    )>, generalContent: (
+    ) | null>, generalContent: (
       { id: string, siteTitle: string, siteDescription: string, officialNameDescription: string, copyrightText: string, creativeCommonsLicense: string, ownerUrl: string, ownerName: string, actionTerm: SiteGeneralContentActionTerm, actionTaskTerm: SiteGeneralContentActionTaskTerm, organizationTerm: SiteGeneralContentOrganizationTerm, sitewideAnnouncement: string | null }
       & { __typename: 'SiteGeneralContent' }
     ), mainMenu: (
@@ -13229,7 +15248,7 @@ export type GetPlanContextQuery = (
           & { __typename: 'PageMenuItem' }
         ) | null }
         & { __typename: 'PageMenuItem' }
-      )> }
+      ) | null> }
       & { __typename: 'MainMenu' }
     ) | null, footer: (
       { items: Array<{ __typename: 'ExternalLinkMenuItem' } | (
@@ -13245,9 +15264,9 @@ export type GetPlanContextQuery = (
             & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
           ) }
           & { __typename: 'PageMenuItem' }
-        )> | null }
+        ) | null> | null }
         & { __typename: 'PageMenuItem' }
-      )> }
+      ) | null> }
       & { __typename: 'Footer' }
     ) | null, features: (
       { allowPublicSiteLogin: boolean, hasActionContactPersonRoles: boolean, contactPersonsPublicData: PlanFeaturesContactPersonsPublicData, contactPersonsShowPicture: boolean, contactPersonsShowOrganizationAncestors: boolean, enableSearch: boolean, hasActionIdentifiers: boolean, hasActionOfficialName: boolean, hasActionLeadParagraph: boolean, hasActionPrimaryOrgs: boolean, showAdminLink: boolean, enableIndicatorComparison: boolean, minimalStatuses: boolean }
@@ -13264,7 +15283,7 @@ export type GetPlanContextQuery = (
         & { __typename: 'Organization' }
       ) }
       & { __typename: 'Plan' }
-    )>, supersededBy: (
+    ) | null>, supersededBy: (
       { name: string, shortName: string | null, versionName: string, identifier: string, viewUrl: string | null, publishedAt: string | null }
       & { __typename: 'Plan' }
     ) | null, supersededPlans: Array<(
@@ -13303,7 +15322,7 @@ export type GetPlanContextQuery = (
     ) | null, additionalLinks: (
       { items: Array<{ __typename: 'ExternalLinkMenuItem' } | (
         { id: string, crossPlanLink: boolean | null, viewUrl: string | null, page: (
-          { title: string, url: string | null, urlPath: string, slug: string, body: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'RichTextBlock' } | (
+          { title: string, url: string | null, urlPath: string, slug: string, body: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
             { blocks: Array<(
               { field: string }
               & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
@@ -13330,14 +15349,14 @@ export type GetPlanContextQuery = (
               & { __typename: 'CharBlock' }
             )> }
             & { __typename: 'AccessibilityStatementContactInformationBlock' }
-          )> | null }
+          ) | null> | null }
           & { __typename: 'AccessibilityStatementPage' }
         ) | (
           { title: string, url: string | null, urlPath: string, slug: string }
           & { __typename: 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
         ) }
         & { __typename: 'PageMenuItem' }
-      )> }
+      ) | null> }
       & { __typename: 'AdditionalLinks' }
     ) | null, actionListPage: (
       { includeRelatedPlans: boolean | null, actionDateFormat: string | null, taskDateFormat: string | null }
@@ -13345,14 +15364,14 @@ export type GetPlanContextQuery = (
     ) | null }
     & { __typename: 'Plan' }
   ) | null, workflowStates: Array<(
-    { id: string, description: string | null }
+    { id: string | null, description: string | null }
     & { __typename: 'WorkflowStateDescription' }
   ) | null> | null }
   & { __typename: 'Query' }
 );
 
 export type PlanContextFragment = (
-  { id: string, identifier: string, name: string, shortName: string | null, versionName: string, themeIdentifier: string | null, primaryLanguage: string, otherLanguages: Array<string>, hideActionIdentifiers: boolean, publishedAt: string | null, kausalPathsInstanceUuid: string, viewUrl: string | null, actionReportExportViewUrl: string | null, serveFileBaseUrl: string, adminUrl: string | null, accessibilityStatementUrl: string | null, externalFeedbackUrl: string | null, primaryActionClassification: (
+  { id: string, identifier: string, name: string, shortName: string | null, versionName: string, themeIdentifier: string | null, primaryLanguage: string, otherLanguages: Array<string>, hideActionIdentifiers: boolean | null, publishedAt: string | null, kausalPathsInstanceUuid: string, viewUrl: string | null, actionReportExportViewUrl: string | null, serveFileBaseUrl: string, adminUrl: string | null, accessibilityStatementUrl: string | null, externalFeedbackUrl: string | null, primaryActionClassification: (
     { id: string, identifier: string, hideCategoryIdentifiers: boolean, common: (
       { identifier: string }
       & { __typename: 'CommonCategoryType' }
@@ -13406,10 +15425,10 @@ export type PlanContextFragment = (
   )>, impactGroups: Array<(
     { id: string }
     & { __typename: 'ImpactGroup' }
-  )>, primaryOrgs: Array<(
+  ) | null>, primaryOrgs: Array<(
     { id: string }
     & { __typename: 'Organization' }
-  )>, generalContent: (
+  ) | null>, generalContent: (
     { id: string, siteTitle: string, siteDescription: string, officialNameDescription: string, copyrightText: string, creativeCommonsLicense: string, ownerUrl: string, ownerName: string, actionTerm: SiteGeneralContentActionTerm, actionTaskTerm: SiteGeneralContentActionTaskTerm, organizationTerm: SiteGeneralContentOrganizationTerm, sitewideAnnouncement: string | null }
     & { __typename: 'SiteGeneralContent' }
   ), mainMenu: (
@@ -13425,7 +15444,7 @@ export type PlanContextFragment = (
         & { __typename: 'PageMenuItem' }
       ) | null }
       & { __typename: 'PageMenuItem' }
-    )> }
+    ) | null> }
     & { __typename: 'MainMenu' }
   ) | null, footer: (
     { items: Array<{ __typename: 'ExternalLinkMenuItem' } | (
@@ -13441,9 +15460,9 @@ export type PlanContextFragment = (
           & { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
         ) }
         & { __typename: 'PageMenuItem' }
-      )> | null }
+      ) | null> | null }
       & { __typename: 'PageMenuItem' }
-    )> }
+    ) | null> }
     & { __typename: 'Footer' }
   ) | null, features: (
     { allowPublicSiteLogin: boolean, hasActionContactPersonRoles: boolean, contactPersonsPublicData: PlanFeaturesContactPersonsPublicData, contactPersonsShowPicture: boolean, contactPersonsShowOrganizationAncestors: boolean, enableSearch: boolean, hasActionIdentifiers: boolean, hasActionOfficialName: boolean, hasActionLeadParagraph: boolean, hasActionPrimaryOrgs: boolean, showAdminLink: boolean, enableIndicatorComparison: boolean, minimalStatuses: boolean }
@@ -13460,7 +15479,7 @@ export type PlanContextFragment = (
       & { __typename: 'Organization' }
     ) }
     & { __typename: 'Plan' }
-  )>, supersededBy: (
+  ) | null>, supersededBy: (
     { name: string, shortName: string | null, versionName: string, identifier: string, viewUrl: string | null, publishedAt: string | null }
     & { __typename: 'Plan' }
   ) | null, supersededPlans: Array<(
@@ -13499,7 +15518,7 @@ export type PlanContextFragment = (
   ) | null, additionalLinks: (
     { items: Array<{ __typename: 'ExternalLinkMenuItem' } | (
       { id: string, crossPlanLink: boolean | null, viewUrl: string | null, page: (
-        { title: string, url: string | null, urlPath: string, slug: string, body: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'RichTextBlock' } | (
+        { title: string, url: string | null, urlPath: string, slug: string, body: Array<{ __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' | 'ActionLeadParagraphBlock' } | { __typename: 'ActionLinksBlock' | 'ActionListBlock' | 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' } | { __typename: 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' | 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' } | { __typename: 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' } | { __typename: 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' | 'IndicatorCausalChainBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorShowcaseBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' } | { __typename: 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' } | { __typename: 'UpdatedAtColumnBlock' } | (
           { blocks: Array<(
             { field: string }
             & { __typename: 'AccessibilityStatementComplianceStatusBlock' | 'AccessibilityStatementContactFormBlock' | 'AccessibilityStatementContactInformationBlock' | 'AccessibilityStatementPreparationInformationBlock' | 'ActionAttributeTypeFilterBlock' | 'ActionAttributeTypeReportFieldBlock' | 'ActionCategoryFilterCardBlock' | 'ActionCategoryFilterCardsBlock' | 'ActionCategoryReportFieldBlock' | 'ActionContactFormBlock' | 'ActionContactPersonsBlock' | 'ActionContentAttributeTypeBlock' | 'ActionContentCategoryTypeBlock' | 'ActionContentSectionBlock' | 'ActionDependenciesBlock' | 'ActionDescriptionBlock' | 'ActionEndDateBlock' | 'ActionHighlightsBlock' | 'ActionImplementationPhaseFilterBlock' | 'ActionImplementationPhaseReportFieldBlock' }
@@ -13526,14 +15545,14 @@ export type PlanContextFragment = (
             & { __typename: 'CharBlock' }
           )> }
           & { __typename: 'AccessibilityStatementContactInformationBlock' }
-        )> | null }
+        ) | null> | null }
         & { __typename: 'AccessibilityStatementPage' }
       ) | (
         { title: string, url: string | null, urlPath: string, slug: string }
         & { __typename: 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' }
       ) }
       & { __typename: 'PageMenuItem' }
-    )> }
+    ) | null> }
     & { __typename: 'AdditionalLinks' }
   ) | null, actionListPage: (
     { includeRelatedPlans: boolean | null, actionDateFormat: string | null, taskDateFormat: string | null }
@@ -13594,12 +15613,12 @@ export type IndicatorSparklineGraphDataQuery = (
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )>, categories: Array<(
+      ) | null> | null, categories: Array<(
         { id: string }
         & { __typename: 'DimensionCategory' }
       )> }
       & { __typename: 'IndicatorValue' }
-    )>, dimensions: Array<(
+    ) | null> | null, dimensions: Array<(
       { dimension: (
         { id: string, name: string, categories: Array<(
           { id: string, name: string }
@@ -13612,7 +15631,7 @@ export type IndicatorSparklineGraphDataQuery = (
       { id: string, date: string | null, value: number, normalizedValues: Array<(
         { normalizerId: string | null, value: number | null }
         & { __typename: 'NormalizedValue' }
-      )>, scenario: (
+      ) | null> | null, scenario: (
         { id: string }
         & { __typename: 'Scenario' }
       ) | null }
@@ -13625,12 +15644,12 @@ export type IndicatorSparklineGraphDataQuery = (
         { unit: (
           { shortName: string | null }
           & { __typename: 'Unit' }
-        ), normalizer: (
+        ) | null, normalizer: (
           { name: string, id: string, identifier: string | null }
           & { __typename: 'CommonIndicator' }
-        ) }
+        ) | null }
         & { __typename: 'CommonIndicatorNormalization' }
-      )>, indicators: Array<(
+      ) | null> | null, indicators: Array<(
         { id: string, timeResolution: IndicatorTimeResolution, minValue: number | null, maxValue: number | null, organization: (
           { id: string, name: string, abbreviation: string | null }
           & { __typename: 'Organization' }
@@ -13641,12 +15660,12 @@ export type IndicatorSparklineGraphDataQuery = (
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )>, categories: Array<(
+          ) | null> | null, categories: Array<(
             { id: string }
             & { __typename: 'DimensionCategory' }
           )> }
           & { __typename: 'IndicatorValue' }
-        )>, dimensions: Array<(
+        ) | null> | null, dimensions: Array<(
           { dimension: (
             { id: string, name: string, categories: Array<(
               { id: string, name: string }
@@ -13659,7 +15678,7 @@ export type IndicatorSparklineGraphDataQuery = (
           { id: string, date: string | null, value: number, normalizedValues: Array<(
             { normalizerId: string | null, value: number | null }
             & { __typename: 'NormalizedValue' }
-          )>, scenario: (
+          ) | null> | null, scenario: (
             { id: string }
             & { __typename: 'Scenario' }
           ) | null }

--- a/src/common/__generated__/possible_types.json
+++ b/src/common/__generated__/possible_types.json
@@ -1,12 +1,5 @@
 {
   "possibleTypes": {
-    "AccessibilityStatementPageBodyUnion": [
-      "AccessibilityStatementComplianceStatusBlock",
-      "AccessibilityStatementContactFormBlock",
-      "AccessibilityStatementContactInformationBlock",
-      "AccessibilityStatementPreparationInformationBlock",
-      "RichTextBlock"
-    ],
     "ActionAsideContentBlock": [
       "ActionContactPersonsBlock",
       "ActionContentAttributeTypeBlock",
@@ -71,15 +64,6 @@
     ],
     "CategoryPageAsideBlock": [
       "CategoryPageAttributeTypeBlock"
-    ],
-    "CategoryPageBodyUnion": [
-      "ActionListBlock",
-      "AdaptiveEmbedBlock",
-      "CategoryListBlock",
-      "IndicatorGroupBlock",
-      "QuestionAnswerBlock",
-      "RelatedIndicatorsBlock",
-      "RichTextBlock"
     ],
     "CategoryPageMainBottomBlock": [
       "CategoryPageAttributeTypeBlock",
@@ -176,24 +160,6 @@
       "Plan",
       "RestrictedPlanNode"
     ],
-    "PlanRootPageBodyUnion": [
-      "ActionCategoryFilterCardsBlock",
-      "ActionHighlightsBlock",
-      "ActionStatusGraphsBlock",
-      "AdaptiveEmbedBlock",
-      "CardListBlock",
-      "CategoryListBlock",
-      "CategoryTreeMapBlock",
-      "DashboardRowBlock",
-      "FrontPageHeroBlock",
-      "IndicatorGroupBlock",
-      "IndicatorHighlightsBlock",
-      "IndicatorShowcaseBlock",
-      "LargeImageBlock",
-      "PathsOutcomeBlock",
-      "RelatedPlanListBlock",
-      "RichTextBlock"
-    ],
     "ReportFieldBlock": [
       "ActionAttributeTypeReportFieldBlock",
       "ActionCategoryReportFieldBlock",
@@ -224,19 +190,6 @@
       "Indicator"
     ],
     "SnippetInterface": [],
-    "StaticPageBodyUnion": [
-      "AdaptiveEmbedBlock",
-      "CartographyVisualisationBlock",
-      "CategoryListBlock",
-      "CategoryTreeMapBlock",
-      "CategoryTypeLevelListBlock",
-      "DashboardRowBlock",
-      "IndicatorGroupBlock",
-      "LargeImageBlock",
-      "PathsOutcomeBlock",
-      "QuestionAnswerBlock",
-      "RichTextBlock"
-    ],
     "StreamFieldInterface": [
       "AccessibilityStatementComplianceStatusBlock",
       "AccessibilityStatementContactFormBlock",

--- a/src/components/actions/ActionCardList.tsx
+++ b/src/components/actions/ActionCardList.tsx
@@ -12,8 +12,8 @@ import type { TFunction } from '@/common/i18n';
 import type { ActionListAction, ActionListCategory } from '../dashboard/dashboard.types';
 import ActionCard from './ActionCard';
 
-const ActionsList = styled.ul`
-  margin-top: ${(props) => props.theme.spaces.s400};
+const ActionsList = styled.ul<{ $compactTop?: boolean }>`
+  margin-top: ${({ theme, $compactTop }) => ($compactTop ? 0 : theme.spaces.s400)};
   padding: 0;
 `;
 
@@ -135,6 +135,7 @@ type ActionCardListProps<ActionT extends ActionListAction | ActionCardFragment> 
   headingHierarchyDepth: number;
   includeRelatedPlans: boolean;
   showOtherCategory?: boolean;
+  compactTopMargin?: boolean;
 };
 
 function ActionCardList<ActionT extends ActionListAction | ActionCardFragment>({
@@ -143,6 +144,7 @@ function ActionCardList<ActionT extends ActionListAction | ActionCardFragment>({
   headingHierarchyDepth,
   includeRelatedPlans,
   showOtherCategory = true,
+  compactTopMargin = false,
 }: ActionCardListProps<ActionT>) {
   const theme = useTheme();
   const t = useTranslations();
@@ -151,7 +153,7 @@ function ActionCardList<ActionT extends ActionListAction | ActionCardFragment>({
   const getFullAction = (id: string) => actionsById.get(id);
 
   return (
-    <ActionsList>
+    <ActionsList $compactTop={compactTopMargin}>
       {groups.map((group) => (
         <ActionGroup key={group.id} tag="li">
           {(groups.length > 1 || (group.id === OTHER_GROUP_ID && showOtherCategory)) && (

--- a/src/components/common/StreamField.tsx
+++ b/src/components/common/StreamField.tsx
@@ -273,6 +273,7 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
           categoryId={categoryFilter?.id || page.category.id}
           heading={block.heading}
           lead={block.helpText}
+          groupByLevel={block.groupByCategoryLevel}
         />
       );
     }

--- a/src/components/contentblocks/ActionListBlock.tsx
+++ b/src/components/contentblocks/ActionListBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { gql, useQuery } from '@apollo/client';
 import { useTranslations } from 'next-intl';
@@ -6,9 +6,11 @@ import { Container } from 'reactstrap';
 import styled from 'styled-components';
 
 import type {
+  ActionCardFragment,
   GetActionListForBlockQuery,
   GetActionListForBlockQueryVariables,
 } from '@/common/__generated__/graphql';
+import { getDeepParents } from '@/common/categories';
 import { getActionTermContext } from '@/common/i18n';
 import ActionCard from '@/components/actions/ActionCard';
 import ActionCardList from '@/components/actions/ActionCardList';
@@ -51,15 +53,147 @@ export const SectionHeader = styled.h2`
   }
 `;
 
+const ParentGroupHeading = styled.h3`
+  margin: ${({ theme }) => `${theme.spaces.s200} 0 ${theme.spaces.s050}`};
+  font-size: ${({ theme }) => theme.fontSizeLg};
+  color: ${({ theme }) => theme.headingsColor};
+`;
+
+const GroupHeading = styled.h4`
+  margin: ${({ theme }) => `${theme.spaces.s050} 0 ${theme.spaces.s100}`};
+  font-size: ${({ theme }) => theme.fontSizeBase};
+  color: ${({ theme }) => theme.textColor.primary};
+`;
+
+type CategoryNode = Pick<Category, 'id' | 'name' | 'order'> & {
+  level?: { id?: string | null } | null;
+  parent?: CategoryNode | null;
+};
+
+const getParents = (cat?: CategoryNode | null): CategoryNode[] =>
+  (cat ? getDeepParents(cat as unknown as Category) : []) as unknown as CategoryNode[];
+
+const getNodeAtLevel = (cat?: CategoryNode | null, levelId?: string | null) => {
+  if (!cat || !levelId) return undefined;
+  if (cat.level?.id === levelId) return cat;
+  return getParents(cat).find((p) => p?.level?.id === levelId);
+};
+
+const compareOrderName = (a?: CategoryNode, b?: CategoryNode) => {
+  const ao = a?.order ?? 0;
+  const bo = b?.order ?? 0;
+  if (ao !== bo) return ao - bo;
+  const an = (a?.name ?? '').toLocaleLowerCase();
+  const bn = (b?.name ?? '').toLocaleLowerCase();
+  return an.localeCompare(bn);
+};
+
+function buildGroupsForPageCategory(
+  actions: ActionCardFragment[],
+  groupLevelId: string,
+  pageCategoryId: string
+): {
+  mode: 'oneLevel' | 'twoLevels';
+  oneLevel?: Array<{ group: CategoryNode; actions: ActionCardFragment[] }>;
+  twoLevels?: Array<{
+    parentGroup: CategoryNode;
+    children: Array<{ group: CategoryNode; actions: ActionCardFragment[] }>;
+  }>;
+} {
+  let sample: { parentId?: string; grandParentId?: string } | null = null;
+  outer: for (const a of actions) {
+    for (const c of a.categories as unknown as CategoryNode[]) {
+      const node = getNodeAtLevel(c, groupLevelId);
+      if (node) {
+        sample = {
+          parentId: node.parent?.id,
+          grandParentId: node.parent?.parent?.id,
+        };
+        break outer;
+      }
+    }
+  }
+
+  // oneLevel-level (group is a child of page category)
+  if (sample?.parentId === pageCategoryId) {
+    const map = new Map<string, { group: CategoryNode; actions: ActionCardFragment[] }>();
+    for (const a of actions) {
+      for (const c of a.categories as unknown as CategoryNode[]) {
+        const node = getNodeAtLevel(c, groupLevelId);
+        if (!node) continue;
+        if (!map.has(node.id)) map.set(node.id, { group: node, actions: [] });
+        map.get(node.id)!.actions.push(a);
+      }
+    }
+    const oneLevel = Array.from(map.values()).sort((x, y) => compareOrderName(x.group, y.group));
+    return { mode: 'oneLevel', oneLevel };
+  }
+
+  // twoLevels-level (group is a grandchild under page category)
+  if (sample?.grandParentId === pageCategoryId) {
+    const parentMap = new Map<
+      string,
+      {
+        parentGroup: CategoryNode;
+        children: Map<string, { group: CategoryNode; actions: ActionCardFragment[] }>;
+      }
+    >();
+
+    for (const a of actions) {
+      for (const c of a.categories as unknown as CategoryNode[]) {
+        const node = getNodeAtLevel(c, groupLevelId);
+        if (!node) continue;
+        const parent = node.parent;
+        if (!parent) continue;
+
+        let parentBucket = parentMap.get(parent.id);
+        if (!parentBucket) {
+          parentBucket = { parentGroup: parent, children: new Map() };
+          parentMap.set(parent.id, parentBucket);
+        }
+
+        let child = parentBucket.children.get(node.id);
+        if (!child) {
+          child = { group: node, actions: [] };
+          parentBucket.children.set(node.id, child);
+        }
+        child.actions.push(a);
+      }
+    }
+
+    const twoLevels = Array.from(parentMap.values())
+      .sort((a, b) => compareOrderName(a.parentGroup, b.parentGroup))
+      .map(({ parentGroup, children }) => ({
+        parentGroup,
+        children: Array.from(children.values()).sort((a, b) => compareOrderName(a.group, b.group)),
+      }));
+
+    return { mode: 'twoLevels', twoLevels };
+  }
+
+  const fallback = new Map<string, { group: CategoryNode; actions: ActionCardFragment[] }>();
+  for (const a of actions) {
+    for (const c of a.categories as unknown as CategoryNode[]) {
+      const node = getNodeAtLevel(c, groupLevelId);
+      if (!node) continue;
+      if (!fallback.has(node.id)) fallback.set(node.id, { group: node, actions: [] });
+      fallback.get(node.id)!.actions.push(a);
+    }
+  }
+  const oneLevel = Array.from(fallback.values()).sort((x, y) => compareOrderName(x.group, y.group));
+  return { mode: 'oneLevel', oneLevel };
+}
+
 type ActionListBlockProps = {
   id?: string;
   categoryId: string;
   heading?: string | null;
   lead?: string | null;
+  groupByLevel?: CategoryLevel | null;
 };
 
 const ActionListBlock = (props: ActionListBlockProps) => {
-  const { id = '', categoryId, heading, lead } = props;
+  const { id = '', categoryId, heading, lead, groupByLevel } = props;
   const t = useTranslations();
 
   const plan = usePlan();
@@ -77,17 +211,23 @@ const ActionListBlock = (props: ActionListBlockProps) => {
   });
   useEffect(() => {
     if (!loading) setLoading(false);
-  }, [loading]);
-  if (error) return <ErrorMessage message={error.message} />;
-  if (loading || !data) return <ContentLoader />;
+  }, [loading, setLoading]);
 
-  const { planActions } = data;
-  if (!planActions) {
-    return <ErrorMessage statusCode={404} message={t('page-not-found')} />;
-  }
-  const groupBy = plan.primaryOrgs.length > 0 ? 'primaryOrg' : 'none';
+  const planActions: ActionCardFragment[] = data?.planActions ?? [];
+  const groupLevelId = groupByLevel?.id ?? null;
+
+  const groups = useMemo(
+    () => (groupLevelId ? buildGroupsForPageCategory(planActions, groupLevelId, categoryId) : null),
+    [planActions, groupLevelId, categoryId]
+  );
+
+  const innerGroupBy = plan.primaryOrgs.length > 0 ? 'primaryOrg' : 'none';
 
   const displayHeader = heading ? heading : t('actions-plural', getActionTermContext(plan));
+
+  if (error) return <ErrorMessage message={error.message} />;
+  if (loading && !data) return <ContentLoader />;
+
   return (
     <ActionListSection id={id}>
       <Container>
@@ -95,7 +235,46 @@ const ActionListBlock = (props: ActionListBlockProps) => {
         {displayHeader && displayHeader !== '-' ? (
           <SectionHeader>{displayHeader}</SectionHeader>
         ) : null}
-        <ActionCardList actions={planActions} groupBy={groupBy} showOtherCategory={false} />
+        {!groups ? (
+          <ActionCardList
+            actions={planActions}
+            groupBy={innerGroupBy}
+            headingHierarchyDepth={2}
+            includeRelatedPlans={false}
+            showOtherCategory={false}
+          />
+        ) : groups.mode === 'oneLevel' ? (
+          groups.oneLevel!.map(({ group, actions }) => (
+            <section key={group.id} aria-labelledby={`group-${group.id}`}>
+              <GroupHeading id={`group-${group.id}`}>{group.name ?? '—'}</GroupHeading>
+              <ActionCardList
+                actions={actions}
+                groupBy={innerGroupBy}
+                headingHierarchyDepth={2}
+                includeRelatedPlans={false}
+                showOtherCategory={false}
+              />
+            </section>
+          ))
+        ) : (
+          groups.twoLevels!.map(({ parentGroup, children }) => (
+            <div key={parentGroup.id}>
+              <ParentGroupHeading>{parentGroup.name ?? '—'}</ParentGroupHeading>
+              {children.map(({ group, actions }) => (
+                <section key={group.id} aria-labelledby={`group-${group.id}`}>
+                  <GroupHeading id={`group-${group.id}`}>{group.name ?? '—'}</GroupHeading>
+                  <ActionCardList
+                    actions={actions}
+                    groupBy={innerGroupBy}
+                    headingHierarchyDepth={2}
+                    includeRelatedPlans={false}
+                    showOtherCategory={false}
+                  />
+                </section>
+              ))}
+            </div>
+          ))
+        )}
       </Container>
     </ActionListSection>
   );

--- a/src/components/contentblocks/ActionListBlock.tsx
+++ b/src/components/contentblocks/ActionListBlock.tsx
@@ -54,13 +54,13 @@ export const SectionHeader = styled.h2`
 `;
 
 const ParentGroupHeading = styled.h3`
-  margin: ${({ theme }) => `${theme.spaces.s200} 0 ${theme.spaces.s050}`};
+  margin: ${({ theme }) => `${theme.spaces.s400} 0 ${theme.spaces.s400}`};
   font-size: ${({ theme }) => theme.fontSizeLg};
   color: ${({ theme }) => theme.headingsColor};
 `;
 
 const GroupHeading = styled.h4`
-  margin: ${({ theme }) => `${theme.spaces.s050} 0 ${theme.spaces.s100}`};
+  margin: ${({ theme }) => `${theme.spaces.s150} 0 ${theme.spaces.s150}`};
   font-size: ${({ theme }) => theme.fontSizeBase};
   color: ${({ theme }) => theme.textColor.primary};
 `;
@@ -242,6 +242,7 @@ const ActionListBlock = (props: ActionListBlockProps) => {
             headingHierarchyDepth={2}
             includeRelatedPlans={false}
             showOtherCategory={false}
+            compactTopMargin={false}
           />
         ) : groups.mode === 'oneLevel' ? (
           groups.oneLevel!.map(({ group, actions }) => (
@@ -253,6 +254,7 @@ const ActionListBlock = (props: ActionListBlockProps) => {
                 headingHierarchyDepth={2}
                 includeRelatedPlans={false}
                 showOtherCategory={false}
+                compactTopMargin={true}
               />
             </section>
           ))
@@ -269,6 +271,7 @@ const ActionListBlock = (props: ActionListBlockProps) => {
                     headingHierarchyDepth={2}
                     includeRelatedPlans={false}
                     showOtherCategory={false}
+                    compactTopMargin={true}
                   />
                 </section>
               ))}

--- a/src/fragments/stream-field.fragment.ts
+++ b/src/fragments/stream-field.fragment.ts
@@ -72,22 +72,12 @@ export const STREAM_FIELD_FRAGMENT = gql`
       }
     }
     ... on ActionListBlock {
+      id
       heading
       helpText
       categoryFilter {
         id
-        type {
-          id
-        }
       }
-      groupByCategoryLevel {
-        id
-        type {
-          id
-        }
-      }
-      heading
-      helpText
       groupByCategoryLevel {
         id
       }


### PR DESCRIPTION
## Description
Add category-level grouping to `ActionListBlock` on `Category` pages.

Plymouth request: Actions should be grouped by the selected in Admin `CategoryLevel` (child or grandchild of the page category) and rendered as list sections with two headings: intermediate parent + selected level. Now all actions are displayed as a flat list even when they have that setting in Admin.

<img width="1468" height="827" alt="Screenshot 2025-09-30 at 12 27 09" src="https://github.com/user-attachments/assets/0862f138-0c1c-425b-a326-9e3d5a1cb5af" />


## Type of Change
Implement grouping modes: `oneLevel` (child) and `twoLevels` (grandchild under page).
Kept inner grouping by `org` (primaryOrg → none fallback).

## Related issue
Asana: https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1211392323171602?focus=true

## Requirements, dependencies and related PRs
Depends on `Group by level` setting in Admin for the relevant Category page

## ✅ Pre-Merge Checklist

### Testing
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
    ##### Manual testing instructions
   Test case Priority-Plymouth that has 2 levels of headings for Category page - http://priority-plymouth.localhost:3000/key-focus-areas/buildings-energy-and-infrastructure.


## Screenshots/Videos (if applicable)
<img width="1370" height="766" alt="Screenshot 2025-09-30 at 12 09 31" src="https://github.com/user-attachments/assets/b4c398be-8dad-4bd0-8f81-0900403d5ded" />



