### PR TITLE
Restore category grouping after resetting filter

### DIFF
--- a/src/components/dashboard/ActionList.tsx
+++ b/src/components/dashboard/ActionList.tsx
@@ -503,11 +503,14 @@ const ActionList = (props: ActionListProps) => {
   });
 
   let groupBy: 'category' | 'primaryOrg' | 'plan' = 'category';
-  if (
-    plan.features.hasActionPrimaryOrgs &&
-    primaryCatType?.identifier &&
-    `${getCategoryString(primaryCatType.identifier)}` in activeFilters
-  ) {
+  const hasPrimaryCategoryFilter = primaryCatType?.identifier
+    ? (() => {
+        const value = activeFilters[getCategoryString(primaryCatType.identifier)];
+        return Array.isArray(value) ? value.length > 0 : Boolean(value);
+      })()
+    : false;
+
+  if (plan.features.hasActionPrimaryOrgs && hasPrimaryCategoryFilter) {
     groupBy = 'primaryOrg';
   }
   // for umbrella plans group by plan if no common category exists

--- a/src/components/dashboard/ActionList.tsx
+++ b/src/components/dashboard/ActionList.tsx
@@ -413,6 +413,16 @@ type ActionListProps = {
   primaryOrgs: ActionListPrimaryOrg[];
 };
 
+function hasActivePrimaryCategoryFilter(
+  activeFilters: Filters,
+  primaryCatType?: ActionListCategoryType
+) {
+  if (!primaryCatType?.identifier) return false;
+
+  const value = activeFilters[getCategoryString(primaryCatType.identifier)];
+  return Array.isArray(value) ? value.length > 0 : Boolean(value);
+}
+
 const ActionList = (props: ActionListProps) => {
   const {
     actions,
@@ -503,17 +513,19 @@ const ActionList = (props: ActionListProps) => {
   });
 
   let groupBy: 'category' | 'primaryOrg' | 'plan' = 'category';
-  const hasPrimaryCategoryFilter = primaryCatType?.identifier
-    ? (() => {
-        const value = activeFilters[getCategoryString(primaryCatType.identifier)];
-        return Array.isArray(value) ? value.length > 0 : Boolean(value);
-      })()
-    : false;
 
-  if (plan.features.hasActionPrimaryOrgs && hasPrimaryCategoryFilter) {
+  if (
+    plan.features.hasActionPrimaryOrgs &&
+    hasActivePrimaryCategoryFilter(activeFilters, primaryCatType)
+  ) {
     groupBy = 'primaryOrg';
   }
+
   // for umbrella plans group by plan if no common category exists
+  if (includeRelatedPlans && !plan.primaryActionClassification?.common) {
+    groupBy = 'plan';
+  }
+
   if (includeRelatedPlans && !plan.primaryActionClassification?.common) groupBy = 'plan';
 
   // add plan.feature.showActionUpdateStatus to backend


### PR DESCRIPTION
## Description

Action list grouping remains by organization after clearing theme/category filter.

* Update the grouping condition to check if the primary category filter has an actual active value, instead of only checking the key.

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes if applicable.

## Related issue

asana https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1213784801354375?focus=true

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [ ] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
