### PR TITLE
Clamp pledge card description correctly

### DIFF
--- a/src/components/pledge/PledgeCard.tsx
+++ b/src/components/pledge/PledgeCard.tsx
@@ -182,15 +182,22 @@ const StyledCategory = styled(StyledMetaItem)`
 `;
 
 const StyledCardDescription = styled.p`
-  flex: 1 0 auto; // Fill the remaining vertical space to ensure action buttons align in a card list
   font-size: ${({ theme }) => theme.fontSizeSm};
   color: ${({ theme }) => theme.textColor.secondary};
   margin: ${({ theme }) => theme.spaces.s100} 0 ${({ theme }) => theme.spaces.s150};
   line-height: ${({ theme }) => theme.lineHeightBase};
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
+  min-width: 0;
   overflow: hidden;
+
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
+
+  line-clamp: 4;
+`;
+
+const StyledCardFooterSpacer = styled.div`
+  flex: 1 1 auto;
 `;
 
 const StyledCommitButton = styled(Button, {
@@ -306,8 +313,14 @@ function InteractivePledgeCard({
 
           <StyledCardTitle $layout={layout}>{title}</StyledCardTitle>
 
-          {/* Render the container even when there's no description to fill vertical space for even layouts across cards */}
-          {layout === 'default' && <StyledCardDescription>{description}</StyledCardDescription>}
+          {/* Keep a spacer in default layout so buttons stay aligned across cards,
+              even when there is no description */}
+          {layout === 'default' && (
+            <>
+              {description ? <StyledCardDescription>{description}</StyledCardDescription> : null}
+              <StyledCardFooterSpacer />
+            </>
+          )}
 
           <StyledCommitButton
             color="primary"


### PR DESCRIPTION
## Description

Bug: Incorrect truncation in pledge card descriptions.

Previously the description was used for text clamping and layout spacing, which caused the ellipsis to appear incorrectly in some cards. Now we separate that responsibilities: the description clamps to 4 lines and buttons stay aligned across cards (StyledCardFooterSpacer).

## Screenshots/Videos (if applicable)

Before:

<img width="1362" height="489" alt="Screenshot 2026-04-07 at 16 41 17" src="https://github.com/user-attachments/assets/67a2c9fd-bfd8-44fe-b901-87664337348b" />


After:

<img width="1350" height="500" alt="Screenshot 2026-04-07 at 16 42 53" src="https://github.com/user-attachments/assets/b705b16f-077b-4028-ac3f-f6f45365f105" />


## Related issue

asana https://app.asana.com/1/1201243246741462/project/1210142367022685/task/1213829330705064?focus=true

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [fix] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
