### PR TITLE
Replace reactstrap Badge with styled span

### DIFF
--- a/src/components/actions/blocks/ActionMergedActionsBlock.tsx
+++ b/src/components/actions/blocks/ActionMergedActionsBlock.tsx
@@ -1,24 +1,26 @@
 import styled from '@emotion/styled';
 import { useTranslations } from 'next-intl';
 import { readableColor } from 'polished';
-import { Badge, Col, Row } from 'reactstrap';
+import { Col, Row } from 'reactstrap';
 
 import { getActionTermContext } from '@/common/i18n';
 import type { ActionContentAction } from '@/components/actions/ActionContent';
 import { ActionSection, SectionHeader } from '@/components/actions/ActionContent';
 import { usePlan } from '@/context/plan';
 
-const ActionNumberBadge = styled(Badge)`
+const ActionNumberBadge = styled.span`
+  display: inline-block;
   font-size: ${(props) => props.theme.fontSizeBase};
   padding: ${(props) => props.theme.spaces.s025};
   border-radius: ${(props) => props.theme.btnBorderRadius};
-  background-color: ${(props) => props.theme.brandDark} !important;
+  background-color: ${(props) => props.theme.brandDark};
   color: ${(props) =>
     readableColor(
       props.theme.brandDark,
       props.theme.themeColors.black,
       props.theme.themeColors.white
     )};
+  line-height: 1;
 `;
 
 const MergedActionSection = styled.div`


### PR DESCRIPTION
## Description

`ActionNumberBadge` inherited the default `Bootstrap` secondary badge styling, which caused color-contast issue in some cases. 

* Replace the `Badge` with a styled `span` so the component uses only theme-controlled colors and readableColor contrast logic.

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes if applicable.

Before:

<img width="713" height="102" alt="Screenshot 2026-04-09 at 16 02 15" src="https://github.com/user-attachments/assets/4e9c10c7-a1d9-439b-aa75-b2bae7609dc3" />




After:



<img width="744" height="121" alt="Screenshot 2026-04-09 at 16 01 47" src="https://github.com/user-attachments/assets/f306d6f4-8d85-4af8-9322-a5bb33e1ffe7" />


## Related issue

E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [fix] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.
  
  Check color contrast for ActionNumberBadge on http://tampere-lumo.localhost:3000/actions/3

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
