### PR TITLE
Fixes for indicator page data table

### DIFF
--- a/src/components/graphs/GraphAsTable.tsx
+++ b/src/components/graphs/GraphAsTable.tsx
@@ -19,7 +19,7 @@ type Trace = {
   y: Array<number | null>;
 };
 
-type Spec = { unit?: string | null };
+type Spec = { unit?: string | null; valueRounding?: number | null };
 
 type ExtraColumn = {
   header: string;
@@ -33,7 +33,7 @@ type GraphAsTableProps = {
   timeResolution: IndicatorTimeResolution;
   specification: Spec;
   title?: string;
-  language: string;
+  openByDefault?: boolean;
   extraColumns?: ExtraColumn[];
 };
 
@@ -100,13 +100,15 @@ function GraphAsTable({
   timeResolution,
   specification,
   title,
-  language,
   extraColumns = [],
+  openByDefault = false,
 }: GraphAsTableProps) {
   const t = useTranslations();
   const [isOpen, setIsOpen] = useState(false);
   const toggle = () => setIsOpen(!isOpen);
-  const formatNumber = useNumberFormatter();
+  const formatNumber = useNumberFormatter({
+    maximumSignificantDigits: specification.valueRounding ?? undefined,
+  });
   const isTime = data?.[0]?.xType === 'time';
 
   const { tableData, tableCategoryHeaders } = useMemo(() => {
@@ -169,6 +171,59 @@ function GraphAsTable({
     return { tableData, tableCategoryHeaders };
   }, [data, goalTraces, extraColumns, isTime, timeResolution]);
 
+  const dataTable = (
+    <TableContainer>
+      <Table responsive bordered size="sm">
+        {title && <caption>{title}</caption>}
+        <thead>
+          {tableCategoryHeaders.length > 0 && (
+            <tr>
+              <th></th>
+              {tableCategoryHeaders.map((header, i) => (
+                <th key={i} colSpan={header.count} scope="colgroup">
+                  {header.name}
+                </th>
+              ))}
+            </tr>
+          )}
+          <tr>
+            <td></td>
+            {data.map((trace, i) => (
+              <th key={i} scope="col">
+                {trace.name.replace(`${trace._parentName ?? ''}, `, '')}
+                {specification.unit ? ` (${specification.unit})` : ''}
+              </th>
+            ))}
+            {goalTraces.map((trace, i) => (
+              <th key={i} scope="col">
+                {trace.name}
+                {specification.unit ? ` (${specification.unit})` : ''}
+              </th>
+            ))}
+            {extraColumns.map((col, i) => (
+              <th key={`extra-${i}`} scope="col">
+                {col.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {tableData.map((row, i) => (
+            <tr key={i}>
+              <th scope="row">{row.label}</th>
+              {row.values.map((value, j) => (
+                <td key={j}>{value != null ? formatNumber(value) : null}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </TableContainer>
+  );
+
+  if (openByDefault) {
+    return dataTable;
+  }
   return (
     <CollapsibleTable>
       <TriggerButton color="link" size="sm" onClick={toggle}>
@@ -176,55 +231,7 @@ function GraphAsTable({
         <Icon name={isOpen ? 'angle-down' : 'angle-right'} />
       </TriggerButton>
 
-      <Collapse isOpen={isOpen}>
-        <TableContainer>
-          <Table responsive bordered size="sm">
-            {title && <caption>{title}</caption>}
-            <thead>
-              {tableCategoryHeaders.length > 0 && (
-                <tr>
-                  <th></th>
-                  {tableCategoryHeaders.map((header, i) => (
-                    <th key={i} colSpan={header.count} scope="colgroup">
-                      {header.name}
-                    </th>
-                  ))}
-                </tr>
-              )}
-              <tr>
-                <td></td>
-                {data.map((trace, i) => (
-                  <th key={i} scope="col">
-                    {trace.name.replace(`${trace._parentName ?? ''}, `, '')}
-                    {specification.unit ? ` (${specification.unit})` : ''}
-                  </th>
-                ))}
-                {goalTraces.map((trace, i) => (
-                  <th key={i} scope="col">
-                    {trace.name}
-                    {specification.unit ? ` (${specification.unit})` : ''}
-                  </th>
-                ))}
-                {extraColumns.map((col, i) => (
-                  <th key={`extra-${i}`} scope="col">
-                    {col.header}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {tableData.map((row, i) => (
-                <tr key={i}>
-                  <th scope="row">{row.label}</th>
-                  {row.values.map((value, j) => (
-                    <td key={j}>{value != null ? formatNumber(value) : null}</td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </Table>
-        </TableContainer>
-      </Collapse>
+      <Collapse isOpen={isOpen}>{dataTable}</Collapse>
     </CollapsibleTable>
   );
 }

--- a/src/components/indicators/IndicatorContent.tsx
+++ b/src/components/indicators/IndicatorContent.tsx
@@ -197,6 +197,7 @@ function IndicatorContent({ indicator, layout, testId }: Props) {
                     <Col className="mb-4">
                       <GraphContainer>
                         {showGraphHeader && <h2>{indicator.name}</h2>}
+                        {/* In legacy layouts we show reference always with the visualisation */}
                         <IndicatorVisualisation
                           indicatorId={indicator.id}
                           showReference={true}

--- a/src/components/indicators/IndicatorModalContentBlock.tsx
+++ b/src/components/indicators/IndicatorModalContentBlock.tsx
@@ -118,6 +118,7 @@ const IndicatorContentBlock = (props: IndicatorContentBlockProps) => {
             useLegacyGraph={false}
             showGraph={showIndicatorGraph}
             showTable={showIndicatorTable}
+            showReference={false}
           />
         </ContentBlockWrapper>
       );
@@ -414,9 +415,11 @@ const IndicatorModalContentBlock = ({
         <IndicatorVisualisation
           indicatorId={indicator.id}
           useLegacyGraph={false}
-          showReference={true}
+          showReference={false}
           {...componentProps?.['IndicatorVisualisation']}
           showFactorValues={block.showFactorValues ?? false}
+          showGraph={!(indicator.hideIndicatorGraph ?? false)}
+          showTable={!(indicator.hideIndicatorTable ?? false)}
         />
       );
 

--- a/src/components/indicators/IndicatorModalContentBlock.tsx
+++ b/src/components/indicators/IndicatorModalContentBlock.tsx
@@ -411,6 +411,11 @@ const IndicatorModalContentBlock = ({
     case 'IndicatorFactorValueSummaryContentBlock':
       return <IndicatorFactorValueSummaryBlock block={block} indicator={indicator} />;
     case 'IndicatorVisualizationContentBlock': {
+      // Check if it makes sense to show the visualisation
+      const showGraph = !(indicator.hideIndicatorGraph ?? false);
+      const showTable = !(indicator.hideIndicatorTable ?? false);
+      const indicatorHasData = indicator.values.length > 0;
+      if (!indicatorHasData || (!showGraph && !showTable)) return null;
       const visualisation = (
         <IndicatorVisualisation
           indicatorId={indicator.id}

--- a/src/components/indicators/IndicatorVisualisation.tsx
+++ b/src/components/indicators/IndicatorVisualisation.tsx
@@ -520,8 +520,8 @@ function FactorCharts({
                   data={[factorTrace]}
                   goalTraces={[]}
                   title={metric.label}
-                  language={language}
                   extraColumns={[factorExtraColumn]}
+                  openByDefault={!showGraph}
                 />
               )}
             </div>
@@ -844,7 +844,7 @@ function IndicatorVisualisation({
           data={traces}
           goalTraces={goalTraces}
           title={plotTitle}
-          language={i18n.language}
+          openByDefault={!showGraph}
         />
       )}
       {showFactorValues && indicator.datasets && (


### PR DESCRIPTION
## Description

[1] On indicator page display data table without collapse if the indicator graph is hidden and table is set as visible
Apply this setting also in custom layouts (previously only legacy)

<img width="1545" height="664" alt="Screenshot 2026-04-14 at 11 19 16" src="https://github.com/user-attachments/assets/11f316c7-e6a6-49a0-a033-8cfb871903ac" />

[2] Apply indicator number formatting settings in table values. Hide duplicate reference display on custom indicator layouts.

<img width="1541" height="403" alt="Screenshot 2026-04-14 at 11 20 47" src="https://github.com/user-attachments/assets/0dffaec5-b8c9-45f4-8a24-e571bdf84c4b" />

## Related issue

[[1] Slack](https://app.asana.com/1/1201243246741462/project/1205307984231852/task/1214016143087731?focus=true)
[[2] Asana](https://kausaltech.slack.com/archives/C031Z5WMGJ0/p1776148222289529)


---

## ✅ Pre-Merge Checklist

### Type of Change

- [X] Set the PR's label to match the nature of this change
