### PR TITLE
Fix pledge search bar height when there are no other filters

### DIFF
--- a/src/components/pledge/PledgeList.tsx
+++ b/src/components/pledge/PledgeList.tsx
@@ -87,12 +87,13 @@ const StyledRadioButton = styled(Button)`
   }
 `;
 
-const StyledTabsContainer = styled.div`
+const StyledToolbarContainer = styled.div`
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.spaces.s100};
   flex-wrap: wrap;
   margin-bottom: ${({ theme }) => theme.spaces.s200};
+  align-items: stretch;
 `;
 
 const StyledToolbarLeft = styled.div`
@@ -345,7 +346,7 @@ function PledgeList({ pledges }: Props) {
   return (
     <StyledPageWrapper>
       <StyledContainer>
-        <StyledTabsContainer>
+        <StyledToolbarContainer>
           <StyledToolbarLeft>
             <ButtonGroup
               size="small"
@@ -411,7 +412,7 @@ function PledgeList({ pledges }: Props) {
               />
             )}
           </StyledToolbarRight>
-        </StyledTabsContainer>
+        </StyledToolbarContainer>
 
         <Collapse in={!!searchQuery || activeFilterChips.length > 0} mountOnEnter unmountOnExit>
           <StyledActiveFiltersRow>


### PR DESCRIPTION
## Description

When there are no additional filters, the search bar didn't stretch to the full height of the container.

| Before | After |
|-|-|
| <img width="724" height="116" alt="image" src="https://github.com/user-attachments/assets/4f21f880-52a0-4ace-af66-a5644ed112e3" /> | <img width="715" height="117" alt="image" src="https://github.com/user-attachments/assets/2ae33591-f986-43eb-bccc-a1aadd400fc4" /> |