### PR TITLE
Use indicator.valueRounding as max significant digits for IndicatorFactorValueSummaryBlock

### DIFF
--- a/src/components/indicators/IndicatorFactorValueSummaryBlock.tsx
+++ b/src/components/indicators/IndicatorFactorValueSummaryBlock.tsx
@@ -93,7 +93,9 @@ export default function IndicatorFactorValueSummaryBlock({ block, indicator }: P
                 <ValueDate>{dayjs(reference.date).format(timeFormat)}</ValueDate>
                 <ValueDisplay>
                   <div>
-                    {format.number(reference.value)}
+                    {format.number(reference.value, {
+                      maximumSignificantDigits: indicator.valueRounding ?? undefined,
+                    })}
                     {metric.unit && <ValueUnit>{metric.unit}</ValueUnit>}
                   </div>
                 </ValueDisplay>
@@ -104,7 +106,9 @@ export default function IndicatorFactorValueSummaryBlock({ block, indicator }: P
                 <ValueDate>{dayjs(latest.date).format(timeFormat)}</ValueDate>
                 <ValueDisplay>
                   <div>
-                    {format.number(latest.value)}
+                    {format.number(latest.value, {
+                      maximumSignificantDigits: indicator.valueRounding ?? undefined,
+                    })}
                     {metric.unit && <ValueUnit>{metric.unit}</ValueUnit>}
                   </div>
                 </ValueDisplay>


### PR DESCRIPTION
## Description
Fixes number formatting in IndicatorFactorValueSummaryBlock to use maximumSignificantDigits (via indicator.valueRounding) instead of the Intl.NumberFormat default of 3 decimal places, which would lose all precision for small numbers.

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes if applicable.

## Related issue

E.g. Link to asana, sentry, slack thread etc.

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
