### PR TITLE
Add a11y title and description support for embed

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -5020,7 +5020,7 @@ type StreamFieldFragment_ActionListBlock_Fragment = (
 );
 
 type StreamFieldFragment_AdaptiveEmbedBlock_Fragment = (
-  { fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
+  { title: string | null, description: string | null, fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
     { html: string | null }
     & { __typename: 'EmbedHTMLValue' }
   ) | null }
@@ -12700,7 +12700,7 @@ export type GetContentPageQuery = (
       ) | null }
       & { __typename: 'ActionListBlock' }
     ) | (
-      { fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
+      { title: string | null, description: string | null, fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
         { html: string | null }
         & { __typename: 'EmbedHTMLValue' }
       ) | null }
@@ -13354,7 +13354,7 @@ export type GetContentPageQuery = (
       ) | null }
       & { __typename: 'Image' }
     ) | null, body: Array<(
-      { fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
+      { title: string | null, description: string | null, fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
         { html: string | null }
         & { __typename: 'EmbedHTMLValue' }
       ) | null }
@@ -14245,7 +14245,7 @@ export type GetHomePageQuery = (
       { id: string | null, blockType: string, field: string }
       & { __typename: 'ActionHighlightsBlock' | 'ActionStatusGraphsBlock' | 'ChangeLogMessageBlock' | 'IndicatorHighlightsBlock' | 'RelatedPlanListBlock' }
     ) | (
-      { fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
+      { title: string | null, description: string | null, fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
         { html: string | null }
         & { __typename: 'EmbedHTMLValue' }
       ) | null }

--- a/src/components/common/StreamField.tsx
+++ b/src/components/common/StreamField.tsx
@@ -195,7 +195,7 @@ const RichTextContainer = styled.div`
   }
 `;
 
-type AccessibleEmbedProps = {
+type InjectHTMLAccessiblyProps = {
   html: string;
   title?: string | null;
   description?: string | null;
@@ -213,7 +213,18 @@ const VisuallyHidden = styled.p`
   border: 0;
 `;
 
-function AccessibleEmbed({ html, title, description }: AccessibleEmbedProps) {
+function setA11yAttributes(elements: NodeListOf<Element>, title?: string, descriptionId?: string) {
+  elements.forEach((el) => {
+    if (title) {
+      el.setAttribute('title', title);
+    }
+    if (descriptionId) {
+      el.setAttribute('aria-describedby', descriptionId);
+    }
+  });
+}
+
+function InjectHTMLAccessibly({ html, title, description }: InjectHTMLAccessiblyProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const descriptionId = useId();
 
@@ -223,24 +234,10 @@ function AccessibleEmbed({ html, title, description }: AccessibleEmbedProps) {
 
     const trimmedTitle = title?.trim();
     const trimmedDescription = description?.trim();
+    const resolvedDescriptionId = trimmedDescription ? descriptionId : undefined;
 
-    root.querySelectorAll('iframe').forEach((iframe) => {
-      if (trimmedTitle) {
-        iframe.setAttribute('title', trimmedTitle);
-      }
-      if (trimmedDescription) {
-        iframe.setAttribute('aria-describedby', descriptionId);
-      }
-    });
-
-    root.querySelectorAll('object, embed').forEach((el) => {
-      if (trimmedTitle) {
-        el.setAttribute('title', trimmedTitle);
-      }
-      if (trimmedDescription) {
-        el.setAttribute('aria-describedby', descriptionId);
-      }
-    });
+    setA11yAttributes(root.querySelectorAll('iframe'), trimmedTitle, resolvedDescriptionId);
+    setA11yAttributes(root.querySelectorAll('object, embed'), trimmedTitle, resolvedDescriptionId);
   }, [html, title, description, descriptionId]);
 
   return (
@@ -570,7 +567,7 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
               {...columnProps}
             >
               {!!html && (
-                <AccessibleEmbed
+                <InjectHTMLAccessibly
                   html={html}
                   title={accessibleTitle}
                   description={accessibleDescription}

--- a/src/components/common/StreamField.tsx
+++ b/src/components/common/StreamField.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import React, { Suspense, useEffect } from 'react';
+import React, { Suspense, useEffect, useId, useRef } from 'react';
 
 import dynamic from 'next/dynamic';
 
@@ -194,6 +194,66 @@ const RichTextContainer = styled.div`
     flex: 0 1 800px;
   }
 `;
+
+type AccessibleEmbedProps = {
+  html: string;
+  title?: string | null;
+  description?: string | null;
+};
+
+const VisuallyHidden = styled.p`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+`;
+
+function AccessibleEmbed({ html, title, description }: AccessibleEmbedProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const descriptionId = useId();
+
+  useEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+
+    const trimmedTitle = title?.trim();
+    const trimmedDescription = description?.trim();
+
+    root.querySelectorAll('iframe').forEach((iframe) => {
+      if (trimmedTitle) {
+        iframe.setAttribute('title', trimmedTitle);
+      }
+      if (trimmedDescription) {
+        iframe.setAttribute('aria-describedby', descriptionId);
+      }
+    });
+
+    root.querySelectorAll('object, embed').forEach((el) => {
+      if (trimmedTitle) {
+        el.setAttribute('title', trimmedTitle);
+      }
+      if (trimmedDescription) {
+        el.setAttribute('aria-describedby', descriptionId);
+      }
+    });
+  }, [html, title, description, descriptionId]);
+
+  return (
+    <>
+      {description?.trim() && <VisuallyHidden id={descriptionId}>{description}</VisuallyHidden>}
+      <ResponsiveStyles
+        ref={containerRef}
+        aria-label={title?.trim() || undefined}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </>
+  );
+}
 
 type StreamFieldBlockPage = {
   __typename:
@@ -486,12 +546,13 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
     case 'AdaptiveEmbedBlock': {
       const fullWidth = block.fullWidth || false;
       const html = block.embed?.html;
+      const accessibleTitle = block.title;
+      const accessibleDescription = block.description;
 
       function getColSize(defaultSize: ColumnProps): ColumnProps {
         if (fullWidth) {
           return hasSidebar ? { size: 11, offset: 1 } : { size: 12, offset: 0 };
         }
-
         return defaultSize;
       }
 
@@ -508,7 +569,13 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
               className="my-4"
               {...columnProps}
             >
-              {!!html && <ResponsiveStyles dangerouslySetInnerHTML={{ __html: html }} />}
+              {!!html && (
+                <AccessibleEmbed
+                  html={html}
+                  title={accessibleTitle}
+                  description={accessibleDescription}
+                />
+              )}
             </Col>
           </Row>
         </Container>

--- a/src/fragments/stream-field.fragment.ts
+++ b/src/fragments/stream-field.fragment.ts
@@ -86,6 +86,8 @@ export const STREAM_FIELD_FRAGMENT = gql`
       }
     }
     ... on AdaptiveEmbedBlock {
+      title
+      description
       fullWidth
       embed {
         html


### PR DESCRIPTION
## Description

Improves accessibility support for embeds (`AdaptiveEmbedBlock`) and fixes the axe DevTools issue: "Frames must have an accessible name."
The embeds added in admin were rendered as raw HTML on the frontend, so embedded iframe content did not have an accessible name.
To support this, new optional admin fields were added for embed blocks: `title` and `description` — backend PR https://github.com/kausaltech/kausal-watch/pull/569.
Frontend now uses the new fields, applies them to embeds, and provides accessible names for screen readers.

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes if applicable.

## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1214030248927486?focus=true)

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
This change improves accessibility on the host page only. It does not fix potential a11y issues inside third-party content.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [x] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
