### PR TITLE
Fix pledges page title and lead content not translating

### DIFF
--- a/e2e-tests/__generated__/graphql.ts
+++ b/e2e-tests/__generated__/graphql.ts
@@ -1083,6 +1083,24 @@ export enum SiteGeneralContentOrganizationTerm {
   Organization = 'ORGANIZATION'
 }
 
+export type TestUserInput = {
+  defaultAdminPlanId: InputMaybe<Scalars['ID']['input']>;
+  email: Scalars['String']['input'];
+  isSuperuser: Scalars['Boolean']['input'];
+  password: Scalars['String']['input'];
+  roles: Array<TestUserRoleInput>;
+};
+
+export type TestUserRoleInput = {
+  kind: TestUserRoleKind;
+  targetId: Scalars['ID']['input'];
+};
+
+export enum TestUserRoleKind {
+  ActionContact = 'ACTION_CONTACT',
+  PlanAdmin = 'PLAN_ADMIN'
+}
+
 export type UserFeedbackMutationInput = {
   action: InputMaybe<Scalars['ID']['input']>;
   additionalFields: InputMaybe<Scalars['String']['input']>;

--- a/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/pledges/page.tsx
+++ b/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/pledges/page.tsx
@@ -14,7 +14,8 @@ export default async function PledgeListPage({ params }: Props) {
 
   const { data } = await getPledges(planId);
   const plan = data?.plan;
-  const pledgeListPageConfig = plan?.pages?.find((page) => page.__typename === 'PledgeListPage');
+  const pledgeListPageConfig =
+    data?.planPage?.__typename === 'PledgeListPage' ? data.planPage : null;
 
   if (!plan || !pledgeListPageConfig) {
     notFound();

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -1084,6 +1084,24 @@ export enum SiteGeneralContentOrganizationTerm {
   Organization = 'ORGANIZATION'
 }
 
+export type TestUserInput = {
+  defaultAdminPlanId: InputMaybe<Scalars['ID']['input']>;
+  email: Scalars['String']['input'];
+  isSuperuser: Scalars['Boolean']['input'];
+  password: Scalars['String']['input'];
+  roles: Array<TestUserRoleInput>;
+};
+
+export type TestUserRoleInput = {
+  kind: TestUserRoleKind;
+  targetId: Scalars['ID']['input'];
+};
+
+export enum TestUserRoleKind {
+  ActionContact = 'ACTION_CONTACT',
+  PlanAdmin = 'PLAN_ADMIN'
+}
+
 export type UserFeedbackMutationInput = {
   action: InputMaybe<Scalars['ID']['input']>;
   additionalFields: InputMaybe<Scalars['String']['input']>;
@@ -16868,29 +16886,29 @@ export type GetPledgesQueryVariables = Exact<{
 
 
 export type GetPledgesQuery = (
-  { plan: (
-    { id: string, pages: Array<{ __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' } | (
-      { id: string | null, title: string, leadContent: string | null, backgroundImage: (
-        { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, focalPointWidth: number | null, focalPointHeight: number | null, full: (
-          { id: string, width: number, height: number, src: string }
-          & { __typename: 'ImageRendition' }
-        ) | null, large: (
-          { id: string, width: number, height: number, src: string }
-          & { __typename: 'ImageRendition' }
-        ) | null, small: (
-          { id: string, width: number, height: number, src: string }
-          & { __typename: 'ImageRendition' }
-        ) | null, social: (
-          { id: string, width: number, height: number, src: string }
-          & { __typename: 'ImageRendition' }
-        ) | null, rendition: (
-          { id: string, width: number, height: number, src: string }
-          & { __typename: 'ImageRendition' }
-        ) | null }
-        & { __typename: 'Image' }
+  { planPage: { __typename: 'AccessibilityStatementPage' | 'ActionListPage' | 'CategoryPage' | 'CategoryTypePage' | 'EmptyPage' | 'ImpactGroupPage' | 'IndicatorListPage' | 'Page' | 'PlanRootPage' | 'PrivacyPolicyPage' | 'StaticPage' } | (
+    { id: string | null, title: string, leadContent: string | null, backgroundImage: (
+      { title: string, altText: string, imageCredit: string, width: number, height: number, focalPointX: number | null, focalPointY: number | null, focalPointWidth: number | null, focalPointHeight: number | null, full: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null, large: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null, small: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null, social: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
+      ) | null, rendition: (
+        { id: string, width: number, height: number, src: string }
+        & { __typename: 'ImageRendition' }
       ) | null }
-      & { __typename: 'PledgeListPage' }
-    )> | null, pledges: Array<(
+      & { __typename: 'Image' }
+    ) | null }
+    & { __typename: 'PledgeListPage' }
+  ) | null, plan: (
+    { id: string, pledges: Array<(
       { id: string, name: string, description: string, uuid: string, slug: string, commitmentCount: number, residentCount: number | null, impactStatement: string, localEquivalency: string, actions: Array<(
         { id: string, identifier: string, name: string, viewUrl: string }
         & { __typename: 'Action' }

--- a/src/common/__generated__/possible_types.json
+++ b/src/common/__generated__/possible_types.json
@@ -280,6 +280,10 @@
       "OperationInfo",
       "Plan"
     ],
+    "CreateTestUserPayload": [
+      "OperationInfo",
+      "User"
+    ],
     "DashboardColumnInterface": [
       "FieldColumnBlock",
       "IndicatorCategoryColumn",

--- a/src/queries/get-pledges.ts
+++ b/src/queries/get-pledges.ts
@@ -71,18 +71,18 @@ const PLEDGE_FRAGMENT = gql`
 
 const GET_PLEDGES = gql`
   query GetPledges($plan: ID!) {
-    plan(id: $plan) {
-      id
-      pages {
-        ... on PledgeListPage {
-          id
-          title
-          leadContent
-          backgroundImage {
-            ...MultiUseImageFragment
-          }
+    planPage(plan: $plan, path: "/pledges") {
+      ... on PledgeListPage {
+        id
+        title
+        leadContent
+        backgroundImage {
+          ...MultiUseImageFragment
         }
       }
+    }
+    plan(id: $plan) {
+      id
       pledges {
         ...PledgeFragment
         actions {


### PR DESCRIPTION
## Description
Use planPage(path: "/pledges") instead of plan.pages to fetch PledgeListPage config, so the locale middleware is honoured and hero title/lead render in the active language.

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://kausaltech.slack.com/archives/C089YT69DUH/p1776848404175369

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
