### PR TITLE
Verify that all assets load correctly in e2e tests

### DIFF
--- a/e2e-tests/__generated__/graphql.ts
+++ b/e2e-tests/__generated__/graphql.ts
@@ -1149,7 +1149,7 @@ export type PlaywrightGetPlanInfoQuery = (
       { id: string, siteTitle: string, siteDescription: string }
       & { __typename: 'SiteGeneralContent' }
     ), actionListPage: (
-      { urlPath: string }
+      { urlPath: string, includeRelatedPlans: boolean | null }
       & { __typename: 'ActionListPage' }
     ) | null, actions: Array<(
       { identifier: string, viewUrl: string }
@@ -1180,6 +1180,9 @@ export type PlaywrightGetPlanInfoQuery = (
   ) | null, planIndicators: Array<(
     { id: string, name: string }
     & { __typename: 'Indicator' }
+  )> | null, relatedPlanActions: Array<(
+    { identifier: string, viewUrl: string }
+    & { __typename: 'Action' }
   )> | null }
   & { __typename: 'Query' }
 );

--- a/e2e-tests/common/context.ts
+++ b/e2e-tests/common/context.ts
@@ -157,6 +157,7 @@ export class PlanContext {
   planOrganizations: PlanOrganizations;
   planIndicators: PlanIndicators;
   baseURL: string;
+  failedAssetRequests: string[] = [];
 
   constructor(data: PlaywrightGetPlanInfoQuery, baseURL: string, planIndicators: PlanIndicators) {
     this.plan = data.plan!;
@@ -166,6 +167,44 @@ export class PlanContext {
   }
 
   beforeEach(page: Page) {
+    this.failedAssetRequests = [];
+
+    // Network-level failures (CORS, DNS, connection errors)
+    page.on('requestfailed', (request) => {
+      const resourceType = request.resourceType();
+      const errorText = request.failure()?.errorText ?? '';
+      // ERR_ABORTED and friends are fired when navigation cancels in-flight requests;
+      // HTTP-level errors (404, 500) are already caught by the response handler.
+      if (
+        errorText === 'net::ERR_ABORTED' || // chrome
+        errorText === 'NS_BINDING_ABORTED' || // firefox
+        errorText === 'Load request cancelled' // webkit
+      ) {
+        return;
+      }
+      this.failedAssetRequests.push(
+        `${resourceType} failed to load: ${request.url()} (${errorText})`
+      );
+    });
+
+    // HTTP-level failures (404, 500, etc.)
+    page.on('response', (response) => {
+      const request = response.request();
+      const resourceType = request.resourceType();
+      const status = response.status();
+      if (status >= 200 && status < 400) {
+        return;
+      }
+      this.failedAssetRequests.push(
+        `${resourceType} returned HTTP ${response.status()}: ${request.url()}`
+      );
+    });
+
+    // Unhandled exceptions
+    page.on('pageerror', (exception) => {
+      throw new Error(exception);
+    });
+
     page.on('console', (msg) => {
       const IGNORE_STARTSWITH = [
         'Public environment',
@@ -325,6 +364,7 @@ export class PlanContext {
   async waitForLoadingFinished(page: Page) {
     await expect(page.locator('*[aria-busy=true]')).toHaveCount(0, { timeout: 30000 });
     await page.waitForLoadState('networkidle');
+    expect(this.failedAssetRequests, 'Some assets failed to load').toEqual([]);
   }
 
   async checkAccessibility(page: Page) {

--- a/e2e-tests/common/context.ts
+++ b/e2e-tests/common/context.ts
@@ -58,6 +58,7 @@ const GET_PLAN_INFO = gql`
       }
       actionListPage {
         urlPath
+        includeRelatedPlans
       }
       actions(first: 5) {
         identifier
@@ -102,12 +103,17 @@ const GET_PLAN_INFO = gql`
       id
       name
     }
+    relatedPlanActions(plan: $plan, first: 5) {
+      identifier
+      viewUrl(clientUrl: $clientURL)
+    }
   }
 `;
 
 type PlanInfo = NonNullable<PlaywrightGetPlanInfoQuery['plan']>;
 type PlanIndicators = NonNullable<PlaywrightGetPlanInfoQuery['planIndicators']>;
 type PlanOrganizations = NonNullable<PlaywrightGetPlanInfoQuery['planOrganizations']>;
+type RelatedPlanActions = NonNullable<PlaywrightGetPlanInfoQuery['relatedPlanActions']>;
 type ActionInfo = PlanInfo['actions'][0];
 
 export type MainMenuItem = NonNullable<PlanInfo['mainMenu']>['items'][0] & {
@@ -156,14 +162,21 @@ export class PlanContext {
   plan: PlanInfo;
   planOrganizations: PlanOrganizations;
   planIndicators: PlanIndicators;
+  relatedPlanActions: RelatedPlanActions;
   baseURL: string;
   failedAssetRequests: string[] = [];
 
-  constructor(data: PlaywrightGetPlanInfoQuery, baseURL: string, planIndicators: PlanIndicators) {
+  constructor(
+    data: PlaywrightGetPlanInfoQuery,
+    baseURL: string,
+    planIndicators: PlanIndicators,
+    relatedPlanActions: RelatedPlanActions
+  ) {
     this.plan = data.plan!;
     this.planOrganizations = data.planOrganizations ?? [];
     this.baseURL = baseURL;
     this.planIndicators = planIndicators;
+    this.relatedPlanActions = relatedPlanActions;
   }
 
   beforeEach(page: Page) {
@@ -358,7 +371,8 @@ export class PlanContext {
     });
     const data = res.data;
     const planIndicators = res.data.planIndicators!;
-    return new PlanContext(data, baseURL, planIndicators);
+    const relatedPlanActions = res.data.relatedPlanActions!;
+    return new PlanContext(data, baseURL, planIndicators, relatedPlanActions);
   }
 
   async waitForLoadingFinished(page: Page) {

--- a/e2e-tests/common/context.ts
+++ b/e2e-tests/common/context.ts
@@ -202,7 +202,7 @@ export class PlanContext {
 
     // Unhandled exceptions
     page.on('pageerror', (exception) => {
-      throw new Error(exception);
+      throw new Error(exception.toString());
     });
 
     page.on('console', (msg) => {

--- a/e2e-tests/tests/basic.spec.ts
+++ b/e2e-tests/tests/basic.spec.ts
@@ -62,6 +62,20 @@ const testPlan = (planId: string) => {
       test.skip(!listItem, 'No action list page for plan');
 
       const nav = page.locator('nav#global-navigation-bar');
+      const parentPage = listItem.parent?.page;
+      if (
+        parentPage != null &&
+        parentPage.showInMenus === true &&
+        parentPage.__typename !== 'PlanRootPage'
+      ) {
+        // The action list page link is inside a collapsiple submenu,
+        // click to open the submenu first.
+        const parentLink = nav.getByRole('button', {
+          name: parentPage.title,
+          exact: true,
+        });
+        await parentLink.click();
+      }
       const link = nav.getByRole('link', {
         name: listItem.page.title,
         exact: true,

--- a/e2e-tests/tests/basic.spec.ts
+++ b/e2e-tests/tests/basic.spec.ts
@@ -96,7 +96,15 @@ const testPlan = (planId: string) => {
 
     test('action details page', async ({ page, ctx }) => {
       const listItem = ctx.getActionListMenuItem();
-      test.skip(!listItem, 'No actions defined in plan');
+      test.skip(!listItem, 'No action list page for plan');
+      if (ctx.plan.actionListPage?.includeRelatedPlans) {
+        test.skip(ctx.relatedPlanActions.length === 0, 'No actions defined for plan');
+      } else {
+        test.skip(ctx.plan.actions.length === 0, 'No actions defined for plan');
+      }
+      if (listItem == null) {
+        return;
+      }
       await page.goto(`${ctx.baseURL}${listItem.page.urlPath}`, { waitUntil: 'domcontentloaded' });
       await ctx.waitForLoadingFinished(page);
 

--- a/src/components/orgs/OrgContent.tsx
+++ b/src/components/orgs/OrgContent.tsx
@@ -105,7 +105,7 @@ const OrgLogo = styled.img`
   }
 `;
 
-const OrgDescription = styled.p`
+const OrgDescription = styled.div`
   font-size: ${(props) => props.theme.fontSizeSm};
 `;
 


### PR DESCRIPTION
## Description

The e2e check need to fail fast if run in production (or elsewhere too) and the assets fail to load -- for example the main js chunks.

This PR also contains various fixes to make the e2e tests more usable for  monitoring purposes for heterogeneous plans:
- skip action details page if plan does not have actions
- support action list page even when its menu item is hidden inside a submenu
- fix small invalid html issue

---

## ✅ Pre-Merge Checklist

### Type of Change

- [X] Set the PR's label to match the nature of this change

### Testing

- [X] **Built E2E tests** (if applicable. E2E tests added/updated)
- [X] **Mobile screen widths** tested for responsiveness
- [X] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
