### PR TITLE
Encode actions variable in action report API call

### DIFF
--- a/src/components/dashboard/ActionStatusExport.js
+++ b/src/components/dashboard/ActionStatusExport.js
@@ -8,8 +8,8 @@ export default function ActionStatusExport({ actions }) {
   const plan = usePlan();
   const url = plan.actionReportExportViewUrl;
   const actionIds = actions.map(({ id }) => id).join(',');
-  const csvExportUrl = `${url}?actions=${actionIds}&format=csv`;
-  const excelExportUrl = `${url}?actions=${actionIds}&format=xlsx`;
+  const csvExportUrl = `${url}?actions=${encodeURIComponent(actionIds)}&format=csv`;
+  const excelExportUrl = `${url}?actions=${encodeURIComponent(actionIds)}&format=xlsx`;
   return (
     <UncontrolledDropdown>
       <DropdownToggle caret>{t('export')}</DropdownToggle>


### PR DESCRIPTION
## Description
This is an attempt to fix a bug where sometimes the actions variable has a single quote character (') appended to it, making the call crash in the backend.

[Here is an example of the issue in Sentry](https://sentry.kausal.tech/organizations/kausal/issues/10732/?project=3&query=assigned%3Ame&referrer=issue-stream), where the API call has ended up in backend and the last action id has the single quote character appended, and it crashes when the id is processed as integer.

This was a Claude-generated answer. It thought for a long time (~10 minutes) and got no other ideas. I'm guessing if it's not this, then somehow backend might return the ids wrong, but I couldn't figure out how that could happen.

I couldn't reproduce the bug, so this is a somewhat blind guess. If you think it doesn't make sense, please tell, I'm willing to believe that! :smile: 

## Screenshots/Videos (if applicable)
\-

## Related issue
[Sentry](https://sentry.kausal.tech/organizations/kausal/issues/10732/?project=3&query=assigned%3Ame&referrer=issue-stream)

## Requirements, dependencies and related PRs
\-

## Additional Notes
\-

---

## ✅ Pre-Merge Checklist

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [ ] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  \-

### Internationalization & Accessibility

- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [x] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
