### PR TITLE
Compare trend extrapolation against data year

### DIFF
--- a/src/components/indicators/IndicatorVisualisation.tsx
+++ b/src/components/indicators/IndicatorVisualisation.tsx
@@ -152,6 +152,9 @@ const generateTrendTrace = (indicator, traces, goals, i18n) => {
     const regData = mainValues
       .slice(mainValues.length - numberOfYears, mainValues.length)
       .map((item) => [parseInt(item.date, 10), item.value]);
+    if (regData.length < 5) {
+      return [undefined, undefined];
+    }
     const model = linearRegression(regData);
     const predictedTrace = {
       x: regData.map((item) => item[0]),

--- a/src/components/indicators/IndicatorVisualisation.tsx
+++ b/src/components/indicators/IndicatorVisualisation.tsx
@@ -158,7 +158,7 @@ const generateTrendTrace = (indicator, traces, goals, i18n) => {
       name: i18n.t('current-trend'),
     };
 
-    const highestDataYear = traces[0].y[traces[0].y.length - 1];
+    const highestDataYear = regData[regData.length - 1][0];
     const highestGoalYear = Math.max(
       ...goals.map((goal) => {
         const goalDate = goal.x[goal.x.length - 1];
@@ -166,7 +166,7 @@ const generateTrendTrace = (indicator, traces, goals, i18n) => {
       })
     );
 
-    if (highestGoalYear && highestGoalYear > highestDataYear) {
+    if (!Number.isNaN(highestGoalYear) && highestGoalYear > highestDataYear) {
       predictedTrace.x.push(highestGoalYear);
     }
 


### PR DESCRIPTION
## Description

Fix inconsistent indicator trend line extrapolation in Indicator graph.

The trend line extension logic was comparing the highest goal year against the latest indicator **value** instead of the latest data **year**. The indicators with large latest values could fail the extrapolation check and stop at the latest data point instead of extending to the goal year.
Expected behavior: indicators with future goals should consistently extend the trend line to the latest goal year.

## Screenshots/Videos (if applicable)

Before:

<img width="950" height="561" alt="Screenshot 2026-04-29 at 14 06 10" src="https://github.com/user-attachments/assets/a479e1d3-b396-4309-b96c-862f70f0ea8b" />




After:

<img width="946" height="364" alt="Screenshot 2026-04-29 at 14 06 34" src="https://github.com/user-attachments/assets/37a28040-7446-4721-b9a6-9cdc3eb39970" />


## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1213780833805070?focus=true)

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
