### PR TITLE
De-index non-production deployments via X-Robots-Tag header

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,20 +1,13 @@
 import type { MetadataRoute } from 'next';
 
-import { deploymentType } from '@/common/environment';
-
-export const dynamic = 'force-dynamic';
-
 export default function robots(): MetadataRoute.Robots {
+  // Crawling is allowed on every deployment. Non-production deployments
+  // emit a `noindex, nofollow` robots meta tag via the layout's metadata
+  // export, so crawlers must be allowed to fetch the page to see it.
   return {
-    rules:
-      deploymentType === 'production'
-        ? {
-            userAgent: '*',
-            allow: '/',
-          }
-        : {
-            userAgent: '*',
-            disallow: '/',
-          },
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
   };
 }

--- a/src/app/root/[domain]/[lang]/layout.tsx
+++ b/src/app/root/[domain]/[lang]/layout.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { headers } from 'next/headers';
 import Script from 'next/script';
 
+import type { Metadata } from 'next';
 import { NextIntlClientProvider, useMessages } from 'next-intl';
 import 'react-medium-image-zoom/dist/styles.css';
 
@@ -12,6 +13,7 @@ import { EmotionRegistry } from '@common/themes/StyledComponentsRegistry';
 import '@common/themes/styles/main.scss';
 
 import { DayjsLocaleProvider } from '@/common/dayjs';
+import { deploymentType } from '@/common/environment';
 import { ApolloWrapper } from '@/components/providers/ApolloWrapper';
 import { AuthProvider } from '@/components/providers/AuthProvider';
 import { auth } from '@/config/auth';
@@ -19,6 +21,13 @@ import { auth } from '@/config/auth';
 type Props = {
   params: Promise<{ lang: string }>;
   children: ReactNode;
+};
+
+// Non-production deployments tell crawlers not to index any page.
+// `robots.ts` allows crawl on every deployment so the directive is actually seen;
+// child pages/layouts can override `robots` to opt back in if ever needed.
+export const metadata: Metadata = {
+  robots: deploymentType === 'production' ? undefined : { index: false, follow: false },
 };
 
 async function AsyncAuthProvider({ children }) {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -13,6 +13,7 @@ import type {
   GetSitemapQueryVariables,
 } from '@/common/__generated__/graphql';
 import possibleTypes from '@/common/__generated__/possible_types.json';
+import { deploymentType } from '@/common/environment';
 import { ACTIONS_PATH, INDICATORS_PATH, STATIC_ROUTES } from '@/constants/routes';
 import { GET_PLANS_BY_HOSTNAME } from '@/queries/get-plans';
 import { tryRequest } from '@/utils/api.utils';
@@ -76,6 +77,11 @@ function getDefaultPlanId(plans: NonNullable<GetPlansByHostnameQuery['plansForHo
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // Non-production deployments should not advertise their URLs to crawlers.
+  if (deploymentType !== 'production') {
+    return [];
+  }
+
   const origin = await getRequestOrigin();
   const url = new URL(origin);
 


### PR DESCRIPTION
## Description
The existing `Disallow: /` in robots.ts on non-production deployments only blocks crawling, not indexing. URLs can still appear in search results via inbound links, with no description. Switch to emitting `X-Robots-Tag: noindex, nofollow` from middleware so crawlers actually drop the URLs from their indexes once they re-crawl.

For the directive to be seen, crawlers must be allowed to fetch the page, so robots.ts now allows `/` on every deployment. The sitemap is gated to production so non-production stops advertising its URLs.

Seems counterintuitive, but the i.e. google [docs](https://developers.google.com/search/docs/crawling-indexing/block-indexing) say:
>Important: For the noindex rule to be effective, the page or resource must not be blocked by a robots.txt file, and it has to be otherwise accessible to the crawler. If the page is blocked by a robots.txt file or the crawler can't access the page, the crawler will never see the noindex rule, and the page can still appear in search results, for example if other pages link to it.

## Screenshots/Videos (if applicable)

Add screenshots or videos demonstrating the changes if applicable.

## Related issue
https://kausaltech.slack.com/archives/C05B87BS9NY/p1777458650827369

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [ ] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [ ] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
