### PR TITLE
Fixes on Paths outcome block rendering

### DIFF
--- a/src/components/paths/contentblocks/PathsOutcomeBlock.tsx
+++ b/src/components/paths/contentblocks/PathsOutcomeBlock.tsx
@@ -226,7 +226,6 @@ export default function PathsOutcomeBlock(props: PathsOutcomeBlockProps) {
                       activeNodeId={
                         index < nodes.visible.length - 1 ? nodes.visible[index + 1].id : undefined
                       }
-                      lastActiveNodeId={lastActiveNodeId}
                       setLastActiveNodeId={setLastActiveNodeId}
                       refetching={refetching}
                     />

--- a/src/components/paths/outcome/OutcomeCard.tsx
+++ b/src/components/paths/outcome/OutcomeCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 
 import styled from '@emotion/styled';
 import chroma from 'chroma-js';
@@ -167,13 +167,17 @@ const OutcomeCard = (props: OutcomeCardProps) => {
 
   const cardRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (active && cardRef.current)
+    // Only scroll into view on initial mount (e.g. when landing with ?node=foo).
+    // Don't re-scroll on subsequent active toggles from clicks.
+    if (active && cardRef.current) {
       cardRef.current.scrollIntoView({
         inline: 'center',
         behavior: 'smooth',
-        block: 'nearest',
+        block: 'start',
       });
-  }, [active]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const displayColor = chroma(color)
     .brighten(colorAdjust || 0)
@@ -269,4 +273,4 @@ const OutcomeCard = (props: OutcomeCardProps) => {
   );
 };
 
-export default OutcomeCard;
+export default memo(OutcomeCard);

--- a/src/components/paths/outcome/OutcomeCardSet.tsx
+++ b/src/components/paths/outcome/OutcomeCardSet.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 
 import { activeGoalVar } from '@common/apollo/paths-cache';
 import { setUniqueColors } from '@common/utils/paths/colors';
-import { getMetricValue, getOutcomeTotal } from '@common/utils/paths/metric';
+import { getMetricValue } from '@common/utils/paths/metric';
 
 import OutcomeCard from '@/components/paths/outcome/OutcomeCard';
 import OutcomeNodeContent from '@/components/paths/outcome/OutcomeNodeContent';
@@ -153,7 +153,6 @@ type OutcomeCardSetProps = {
   endYear: number;
   activeScenario: string;
   activeNodeId: string | undefined;
-  lastActiveNodeId: string | undefined;
   setLastActiveNodeId: (s: string) => void;
   subNodesTitle: string;
   refetching: boolean;
@@ -167,13 +166,13 @@ const OutcomeCardSet = ({
   endYear,
   activeScenario,
   activeNodeId,
-  lastActiveNodeId,
   setLastActiveNodeId,
   subNodesTitle,
   refetching,
 }: OutcomeCardSetProps) => {
   const [hoveredNodeId, setHoveredNodeId] = useState(undefined);
-  const { cardNodes, subNodeMap } = useMemo(() => {
+
+  const cardNodes = useMemo(() => {
     const inputNodeIds = rootNode.inputNodes.map((node) => node.id);
     const cardNodes = [...nodeMap.values()]
       .filter((node) => inputNodeIds.indexOf(node.id) >= 0)
@@ -186,16 +185,7 @@ const OutcomeCardSet = ({
         node.color = color;
       }
     );
-    const subNodeMap = new Map(
-      cardNodes.map((cn) => [
-        cn.id,
-        cn.inputNodes.map((child) => nodeMap.get(child.id)!).filter((child) => !!child),
-      ])
-    );
-    return {
-      cardNodes,
-      subNodeMap,
-    };
+    return cardNodes;
   }, [nodeMap, rootNode.inputNodes]);
 
   const activeGoal = useReactiveVar(activeGoalVar);
@@ -204,7 +194,6 @@ const OutcomeCardSet = ({
   const chartType = activeGoal?.defaultOutcomeGraphType || 'bar';
   const hideForecast = separateYears && separateYears.length > 1;
   const colorAdjust = activeGoal?.colorAdjust;
-  const inputNodes = rootNode.inputNodes.filter((node) => !nodeMap.has(node.id));
 
   const handleHover = useCallback((evt) => {
     setHoveredNodeId(evt);
@@ -219,65 +208,65 @@ const OutcomeCardSet = ({
     [activeNodeId, rootNode.id, setLastActiveNodeId]
   );
 
-  const negativeNodesTotal = getOutcomeTotal(
-    cardNodes.filter((node) => getMetricValue(node, endYear) < 0),
-    endYear
-  );
-  const positiveNodesTotal = getOutcomeTotal(
-    cardNodes.filter((node) => getMetricValue(node, endYear) >= 0),
-    endYear
-  );
+  const { negativeNodesTotal, positiveNodesTotal } = useMemo(() => {
+    let negative = 0;
+    let positive = 0;
+    for (const node of cardNodes) {
+      const value = getMetricValue(node, endYear) ?? 0;
+      if (value < 0) negative += value;
+      else positive += value;
+    }
+    return { negativeNodesTotal: negative, positiveNodesTotal: positive };
+  }, [cardNodes, endYear]);
 
   return (
-    <>
-      <CardSet id={rootNode.id} $color={rootNode.color!} $haschildren={cardNodes.length > 0}>
-        <ContentArea>
-          <OutcomeNodeContent
-            node={rootNode}
-            subNodes={cardNodes}
-            color={rootNode.color || parentColor}
-            colorAdjust={colorAdjust}
-            startYear={startYear}
-            endYear={endYear}
-            activeScenario={activeScenario}
-            refetching={refetching}
-            separateYears={separateYears}
-            chartType={chartType}
-          />
-        </ContentArea>
-        {cardNodes.length > 0 && (
-          <SubNodes>
-            <BarHeader>{subNodesTitle}</BarHeader>
-            <CardDeck role="tablist">
-              {cardNodes.map((node, indx) => (
-                <OutcomeCard
-                  key={node.id}
-                  startYear={separateYears ? separateYears[0] : startYear}
-                  endYear={separateYears ? separateYears[separateYears.length - 1] : endYear}
-                  node={node}
-                  state={activeNodeId === undefined ? 'closed' : 'open'}
-                  hovered={hoveredNodeId === node.id}
-                  active={activeNodeId === node.id}
-                  onHover={handleHover}
-                  handleClick={handleClick}
-                  color={node.color || parentColor}
-                  colorAdjust={colorAdjust}
-                  total={positiveNodesTotal - negativeNodesTotal}
-                  positiveTotal={positiveNodesTotal}
-                  negativeTotal={negativeNodesTotal}
-                  refetching={refetching}
-                  hideForecast={hideForecast}
-                  disabled={
-                    node.metric?.forecastValues?.length === 0 &&
-                    node.metric?.historicalValues?.length === 0
-                  }
-                />
-              ))}
-            </CardDeck>
-          </SubNodes>
-        )}
-      </CardSet>
-    </>
+    <CardSet id={rootNode.id} $color={rootNode.color!} $haschildren={cardNodes.length > 0}>
+      <ContentArea>
+        <OutcomeNodeContent
+          node={rootNode}
+          subNodes={cardNodes}
+          color={rootNode.color || parentColor}
+          colorAdjust={colorAdjust}
+          startYear={startYear}
+          endYear={endYear}
+          activeScenario={activeScenario}
+          refetching={refetching}
+          separateYears={separateYears}
+          chartType={chartType}
+        />
+      </ContentArea>
+      {cardNodes.length > 0 && (
+        <SubNodes>
+          <BarHeader>{subNodesTitle}</BarHeader>
+          <CardDeck role="tablist">
+            {cardNodes.map((node) => (
+              <OutcomeCard
+                key={node.id}
+                startYear={separateYears ? separateYears[0] : startYear}
+                endYear={separateYears ? separateYears[separateYears.length - 1] : endYear}
+                node={node}
+                state={activeNodeId === undefined ? 'closed' : 'open'}
+                hovered={hoveredNodeId === node.id}
+                active={activeNodeId === node.id}
+                onHover={handleHover}
+                handleClick={handleClick}
+                color={node.color || parentColor}
+                colorAdjust={colorAdjust}
+                total={positiveNodesTotal - negativeNodesTotal}
+                positiveTotal={positiveNodesTotal}
+                negativeTotal={negativeNodesTotal}
+                refetching={refetching}
+                hideForecast={hideForecast}
+                disabled={
+                  node.metric?.forecastValues?.length === 0 &&
+                  node.metric?.historicalValues?.length === 0
+                }
+              />
+            ))}
+          </CardDeck>
+        </SubNodes>
+      )}
+    </CardSet>
   );
 };
 

--- a/src/components/paths/toolbar/SettingsPanelFull.tsx
+++ b/src/components/paths/toolbar/SettingsPanelFull.tsx
@@ -33,7 +33,7 @@ const Spacer = styled.div`
 
 const FixedPanel = styled.aside`
   position: fixed;
-  z-index: 255;
+  z-index: 500;
   left: 0;
   bottom: 0;
   width: 100%;


### PR DESCRIPTION
## Description

- Stop page occasionally scrolling to top in prod on clicking outcome card
- Reduce re-rendering when navigating outcome graph
- Make sure settingsPanel overlaps global nav on custom global nav

## Related issue

https://app.asana.com/1/1201243246741462/project/1202855459841144/task/1214073793886828?focus=true
https://app.asana.com/1/1201243246741462/project/1202855459841144/task/1214073790841989?focus=true
