### PR TITLE
Add goal achieved marker to indicator list

### DIFF
--- a/e2e-tests/__generated__/graphql.ts
+++ b/e2e-tests/__generated__/graphql.ts
@@ -1083,24 +1083,6 @@ export enum SiteGeneralContentOrganizationTerm {
   Organization = 'ORGANIZATION'
 }
 
-export type TestUserInput = {
-  defaultAdminPlanId: InputMaybe<Scalars['ID']['input']>;
-  email: Scalars['String']['input'];
-  isSuperuser: Scalars['Boolean']['input'];
-  password: Scalars['String']['input'];
-  roles: Array<TestUserRoleInput>;
-};
-
-export type TestUserRoleInput = {
-  kind: TestUserRoleKind;
-  targetId: Scalars['ID']['input'];
-};
-
-export enum TestUserRoleKind {
-  ActionContact = 'ACTION_CONTACT',
-  PlanAdmin = 'PLAN_ADMIN'
-}
-
 export type UserFeedbackMutationInput = {
   action: InputMaybe<Scalars['ID']['input']>;
   additionalFields: InputMaybe<Scalars['String']['input']>;

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -1084,24 +1084,6 @@ export enum SiteGeneralContentOrganizationTerm {
   Organization = 'ORGANIZATION'
 }
 
-export type TestUserInput = {
-  defaultAdminPlanId: InputMaybe<Scalars['ID']['input']>;
-  email: Scalars['String']['input'];
-  isSuperuser: Scalars['Boolean']['input'];
-  password: Scalars['String']['input'];
-  roles: Array<TestUserRoleInput>;
-};
-
-export type TestUserRoleInput = {
-  kind: TestUserRoleKind;
-  targetId: Scalars['ID']['input'];
-};
-
-export enum TestUserRoleKind {
-  ActionContact = 'ACTION_CONTACT',
-  PlanAdmin = 'PLAN_ADMIN'
-}
-
 export type UserFeedbackMutationInput = {
   action: InputMaybe<Scalars['ID']['input']>;
   additionalFields: InputMaybe<Scalars['String']['input']>;
@@ -4664,7 +4646,7 @@ export type DashboardIndicatorBlockFragmentFragment = (
 );
 
 export type IndicatorListIndicatorFragment = (
-  { id: string, name: string, timeResolution: IndicatorTimeResolution, valueRounding: number | null, sortKey: string | null, nonQuantifiedGoal: IndicatorNonQuantifiedGoal | null, nonQuantifiedGoalDate: string | null, organization: (
+  { id: string, name: string, timeResolution: IndicatorTimeResolution, desiredTrend: IndicatorDesiredTrend | null, valueRounding: number | null, sortKey: string | null, nonQuantifiedGoal: IndicatorNonQuantifiedGoal | null, nonQuantifiedGoalDate: string | null, organization: (
     { id: string, name: string }
     & { __typename: 'Organization' }
   ), common: (
@@ -15118,7 +15100,7 @@ export type IndicatorListQuery = (
     )> }
     & { __typename: 'Plan' }
   ) | null, planIndicators?: Array<(
-    { level: string | null, id: string, name: string, timeResolution: IndicatorTimeResolution, valueRounding: number | null, sortKey: string | null, nonQuantifiedGoal: IndicatorNonQuantifiedGoal | null, nonQuantifiedGoalDate: string | null, organization: (
+    { level: string | null, id: string, name: string, timeResolution: IndicatorTimeResolution, desiredTrend: IndicatorDesiredTrend | null, valueRounding: number | null, sortKey: string | null, nonQuantifiedGoal: IndicatorNonQuantifiedGoal | null, nonQuantifiedGoalDate: string | null, organization: (
       { id: string, name: string }
       & { __typename: 'Organization' }
     ), common: (
@@ -15214,7 +15196,7 @@ export type IndicatorListQuery = (
     )> }
     & { __typename: 'Indicator' }
   )> | null, relatedPlanIndicators?: Array<(
-    { level: string | null, id: string, name: string, timeResolution: IndicatorTimeResolution, valueRounding: number | null, sortKey: string | null, nonQuantifiedGoal: IndicatorNonQuantifiedGoal | null, nonQuantifiedGoalDate: string | null, organization: (
+    { level: string | null, id: string, name: string, timeResolution: IndicatorTimeResolution, desiredTrend: IndicatorDesiredTrend | null, valueRounding: number | null, sortKey: string | null, nonQuantifiedGoal: IndicatorNonQuantifiedGoal | null, nonQuantifiedGoalDate: string | null, organization: (
       { id: string, name: string }
       & { __typename: 'Organization' }
     ), common: (

--- a/src/common/__generated__/paths/graphql.ts
+++ b/src/common/__generated__/paths/graphql.ts
@@ -95,7 +95,6 @@ export type CreateNodeInput = {
   description: InputMaybe<Scalars['String']['input']>;
   i18n: InputMaybe<Scalars['JSON']['input']>;
   identifier: Scalars['ID']['input'];
-  inputDatasets: InputMaybe<Scalars['JSON']['input']>;
   inputDimensions: InputMaybe<Array<Scalars['String']['input']>>;
   inputPorts: InputMaybe<Array<InputPortInput>>;
   isOutcome: Scalars['Boolean']['input'];
@@ -168,6 +167,12 @@ export type FrameworkConfigInput = {
   /** UUID for the new framework config. If not set, will be generated automatically. */
   uuid: InputMaybe<Scalars['UUID']['input']>;
 };
+
+/** An enumeration. */
+export enum FrameworksMeasureTemplateDefaultValueScalingChoices {
+  /** Population */
+  Population = 'POPULATION'
+}
 
 /** An enumeration. */
 export enum FrameworksMeasureTemplatePriorityChoices {
@@ -350,10 +355,26 @@ export type UpdateDimensionInput = {
 };
 
 export type UpdateNodeInput = {
+  allowNulls: InputMaybe<Scalars['Boolean']['input']>;
   color: InputMaybe<Scalars['String']['input']>;
+  config: InputMaybe<NodeConfigInput>;
+  description: InputMaybe<Scalars['String']['input']>;
+  i18n: InputMaybe<Scalars['JSON']['input']>;
+  inputDimensions: InputMaybe<Array<Scalars['String']['input']>>;
+  inputPorts: InputMaybe<Array<InputPortInput>>;
   isOutcome: InputMaybe<Scalars['Boolean']['input']>;
   isVisible: InputMaybe<Scalars['Boolean']['input']>;
+  kind: InputMaybe<NodeKind>;
+  minimumYear: InputMaybe<Scalars['Int']['input']>;
   name: InputMaybe<Scalars['String']['input']>;
+  nodeGroup: InputMaybe<Scalars['ID']['input']>;
+  order: InputMaybe<Scalars['Int']['input']>;
+  outputDimensions: InputMaybe<Array<Scalars['String']['input']>>;
+  outputMetrics: InputMaybe<Array<OutputMetricInput>>;
+  outputPorts: InputMaybe<Array<OutputPortInput>>;
+  params: InputMaybe<Scalars['JSON']['input']>;
+  shortName: InputMaybe<Scalars['String']['input']>;
+  tags: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 export type UpdateScenarioInput = {

--- a/src/common/__generated__/paths/possible_types.json
+++ b/src/common/__generated__/paths/possible_types.json
@@ -80,6 +80,10 @@
       "OperationInfo",
       "RegisterUserResult"
     ],
+    "SetInstanceLockedPayload": [
+      "OperationInfo",
+      "SetInstanceLockedResult"
+    ],
     "SnippetInterface": [
       "InstanceSiteContent"
     ],

--- a/src/common/__generated__/possible_types.json
+++ b/src/common/__generated__/possible_types.json
@@ -280,10 +280,6 @@
       "OperationInfo",
       "Plan"
     ],
-    "CreateTestUserPayload": [
-      "OperationInfo",
-      "User"
-    ],
     "DashboardColumnInterface": [
       "FieldColumnBlock",
       "IndicatorCategoryColumn",

--- a/src/components/indicators/IndicatorTableCell.tsx
+++ b/src/components/indicators/IndicatorTableCell.tsx
@@ -315,7 +315,7 @@ const IndicatorValueCell = (props: IndicatorValueCellProps) => {
       values: indicator.values,
       goals: indicator.goals,
       desiredTrend: indicator.desiredTrend,
-      defaultGoalYear: defaultYear ?? year,
+      defaultGoalYear: defaultYear,
       isNormalized,
     });
 

--- a/src/components/indicators/IndicatorTableCell.tsx
+++ b/src/components/indicators/IndicatorTableCell.tsx
@@ -18,6 +18,7 @@ import BadgeTooltip from '../common/BadgeTooltip';
 import Icon from '../common/Icon';
 import { getIndicatorTranslation } from './IndicatorCard';
 import type { IndicatorListIndicator } from './IndicatorList';
+import { isGoalAlreadyExceeded } from './indicatorUtils';
 
 const DEFAULT_ROUNDING = 2;
 
@@ -52,6 +53,14 @@ const TrendIcon = styled(Icon)`
   width: 1.25em;
   margin-bottom: -0.1em;
   color: ${(props) => props.theme.graphColors.grey040};
+`;
+
+const GoalAchievedIcon = styled.span`
+  display: inline-block;
+  margin-right: ${(props) => props.theme.spaces.s025};
+  color: ${(props) => props.theme.actionColor};
+  font-weight: 400;
+  line-height: 1;
 `;
 
 const IndicatorLevelBadge = styled.span<{ $level: string }>`
@@ -254,6 +263,7 @@ const IndicatorValueCell = (props: IndicatorValueCellProps) => {
     maximumSignificantDigits: indicator.valueRounding ?? undefined,
   });
   const t = useTranslations();
+  const goalAchievedLabel = t('indicator-goal-exceeded');
 
   const { value, year } = getValue(indicator, valueType, isNormalized, defaultYear);
 
@@ -296,9 +306,30 @@ const IndicatorValueCell = (props: IndicatorValueCellProps) => {
 
   const unitName = unit.shortName || unit.name;
 
+  // Show the tick only for the Latest/current-status column.
+  // This uses the same goal-exceeded logic as the indicator summary utility.
+  const showGoalAchievedIcon =
+    valueType === IndicatorColumnValueType.Latest &&
+    isGoalAlreadyExceeded({
+      currentValue: value,
+      values: indicator.values,
+      goals: indicator.goals,
+      desiredTrend: indicator.desiredTrend,
+      defaultGoalYear: defaultYear ?? year,
+      isNormalized,
+    });
+
   return (
     <CellContent $numeric={true}>
-      <Value>{formatNumber(value)}</Value>
+      <Value title={showGoalAchievedIcon ? goalAchievedLabel : undefined}>
+        {showGoalAchievedIcon && (
+          <>
+            <GoalAchievedIcon aria-hidden="true">✓</GoalAchievedIcon>
+            <span className="visually-hidden">{goalAchievedLabel} </span>
+          </>
+        )}
+        {formatNumber(value)}
+      </Value>
       {!hideUnit && <Unit>{unitName}</Unit>}
       {defaultYear && year && year !== defaultYear && (
         <>

--- a/src/components/indicators/indicatorUtils.tsx
+++ b/src/components/indicators/indicatorUtils.tsx
@@ -1,3 +1,6 @@
+import { IndicatorDesiredTrend } from '@/common/__generated__/graphql';
+import dayjs from '@/common/dayjs';
+
 import type { CategoryType, IndicatorListIndicator } from './IndicatorList';
 import type { Hierarchy } from './process-indicators';
 
@@ -189,4 +192,162 @@ export const groupIndicatorsByCommonCategory = (
     grouped.set(commonId ?? '', [...group, indicator]);
   });
   return grouped;
+};
+
+type IndicatorGoalValue = IndicatorListIndicator['goals'][number];
+
+type IndicatorDataValue =
+  | IndicatorListIndicator['latestValue']
+  | IndicatorListIndicator['referenceValue']
+  | IndicatorListIndicator['values'][number]
+  | IndicatorGoalValue
+  | null
+  | undefined;
+
+export const getGoalValue = (
+  goals: IndicatorListIndicator['goals'],
+  defaultGoalYear: number | null
+): IndicatorGoalValue | null => {
+  if (!goals || goals.length === 0) {
+    return null;
+  }
+
+  const now = dayjs();
+
+  const validGoals = goals.filter(
+    (goal): goal is NonNullable<IndicatorGoalValue> & { date: string } =>
+      goal !== null && goal !== undefined && goal.date !== null && goal.date !== undefined
+  );
+
+  if (validGoals.length === 0) {
+    return null;
+  }
+
+  if (defaultGoalYear === null || defaultGoalYear === undefined) {
+    const nextGoal = validGoals.find((goal) => dayjs(goal.date).isSameOrAfter(now));
+    return nextGoal || null;
+  }
+
+  const defaultGoalYearStart = dayjs(`${defaultGoalYear}-01-01`);
+  const defaultGoalYearEnd = dayjs(`${defaultGoalYear}-12-31`).endOf('day');
+
+  const goalOnYear = validGoals.find((goal) => {
+    const goalDate = dayjs(goal.date);
+
+    return (
+      goalDate.isSameOrAfter(defaultGoalYearStart) &&
+      (goalDate.isBefore(defaultGoalYearEnd) || goalDate.isSame(defaultGoalYearEnd))
+    );
+  });
+
+  if (goalOnYear) {
+    return goalOnYear;
+  }
+
+  const goalsBeforeYear = validGoals
+    .filter((goal) => dayjs(goal.date).isBefore(defaultGoalYearStart))
+    .sort((a, b) => dayjs(b.date).valueOf() - dayjs(a.date).valueOf());
+
+  if (goalsBeforeYear.length > 0) {
+    return goalsBeforeYear[0];
+  }
+
+  const goalsBetweenNowAndYear = validGoals.filter((goal) => {
+    const goalDate = dayjs(goal.date);
+
+    return (
+      goalDate.isSameOrAfter(now) &&
+      (goalDate.isBefore(defaultGoalYearEnd) || goalDate.isSame(defaultGoalYearEnd))
+    );
+  });
+
+  if (goalsBetweenNowAndYear.length === 0) {
+    const goalsAfterYear = validGoals
+      .filter((goal) => dayjs(goal.date).isAfter(defaultGoalYearEnd))
+      .sort((a, b) => dayjs(a.date).valueOf() - dayjs(b.date).valueOf());
+
+    if (goalsAfterYear.length > 0) {
+      return goalsAfterYear[0];
+    }
+  }
+
+  return validGoals[validGoals.length - 1];
+};
+
+const getNumberValue = (value: IndicatorDataValue, isNormalized: boolean): number | null => {
+  if (!value) {
+    return null;
+  }
+
+  if (isNormalized) {
+    return value.normalizedValues?.[0]?.value ?? null;
+  }
+
+  return value.value ?? null;
+};
+
+export const determineDesirableDirection = (
+  desiredTrend: IndicatorListIndicator['desiredTrend'] | null | undefined,
+  values: IndicatorListIndicator['values'],
+  goals: IndicatorListIndicator['goals']
+): '+' | '-' | null => {
+  if (desiredTrend === IndicatorDesiredTrend.Increasing) {
+    return '+';
+  }
+
+  if (desiredTrend === IndicatorDesiredTrend.Decreasing) {
+    return '-';
+  }
+
+  if (!values.length || !goals?.length) {
+    return null;
+  }
+
+  const latestValue = values[values.length - 1];
+  const latestGoal = goals[goals.length - 1];
+
+  if (
+    latestGoal?.value !== null &&
+    latestGoal?.value !== undefined &&
+    latestValue?.value !== null &&
+    latestValue?.value !== undefined &&
+    latestGoal.value - latestValue.value >= 0
+  ) {
+    return '+';
+  }
+
+  return '-';
+};
+
+export const isGoalAlreadyExceeded = (params: {
+  currentValue: number;
+  values: IndicatorListIndicator['values'];
+  goals: IndicatorListIndicator['goals'];
+  desiredTrend: IndicatorListIndicator['desiredTrend'] | null | undefined;
+  defaultGoalYear: number | null;
+  isNormalized: boolean;
+}): boolean => {
+  const { currentValue, values, goals, desiredTrend, defaultGoalYear, isNormalized } = params;
+
+  const displayGoal = getGoalValue(goals, defaultGoalYear);
+
+  if (!displayGoal) {
+    return false;
+  }
+
+  const goalValue = getNumberValue(displayGoal, isNormalized);
+
+  if (goalValue === null || !Number.isFinite(goalValue)) {
+    return false;
+  }
+
+  const desirableDirection = determineDesirableDirection(desiredTrend, values, goals);
+
+  if (!desirableDirection) {
+    return false;
+  }
+
+  const difference = goalValue - currentValue;
+
+  return desirableDirection === '+' ? difference <= 0 : difference >= 0;
 };

--- a/src/fragments/indicator-list-indicator.fragment.ts
+++ b/src/fragments/indicator-list-indicator.fragment.ts
@@ -5,6 +5,7 @@ export const INDICATOR_LIST_INDICATOR_FRAGMENT = gql`
     id
     name
     timeResolution
+    desiredTrend
     valueRounding
     sortKey
     organization {


### PR DESCRIPTION
## Description

Add a nordic minimalistic marker (tick) for indicator list values that have already exceeded their goal.
Achieved latest/current-status values now display a small colored tick before the value.
The goal-exceeded check uses indicator utility logic and `desiredTrend`.
The hover uses the existing `indicator-goal-exceeded` translation key.


## Screenshots/Videos (if applicable)

<img width="1379" height="277" alt="Screenshot 2026-05-04 at 17 35 40" src="https://github.com/user-attachments/assets/64f0209c-e9b4-4646-9bae-e121ced945b3" />


## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1214374645081797?focus=true)

## Requirements, dependencies and related PRs

- Adds `desiredTrend` to the indicator list GraphQL fragment.
- Updates generated GraphQL types.

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
