### PR TITLE
Fix zero goal display

### DIFF
--- a/src/components/indicators/IndicatorProgressBar.tsx
+++ b/src/components/indicators/IndicatorProgressBar.tsx
@@ -351,10 +351,10 @@ function IndicatorProgressBar(props: IndicatorProgressBarProps) {
   };
   const goalBar = {
     name: 'goal',
-    x: bars.w - Math.max(MIN_BAR_WIDTH, +(roundedValues.goal || 0) * scale),
+    x: bars.w - Math.max(MIN_BAR_WIDTH, +(roundedValues.goal ?? 0) * scale),
     y: topMargin + 2 * barHeight,
     w:
-      roundedValues.goal && +roundedValues.goal > 0
+      roundedValues.goal != null && +roundedValues.goal > 0
         ? Math.max(MIN_BAR_WIDTH, +roundedValues.goal * scale)
         : 0,
   };
@@ -478,9 +478,10 @@ function IndicatorProgressBar(props: IndicatorProgressBarProps) {
     latestValue: `${roundedValues.latest} ${displayUnit ?? ''}`,
     goalValue: `${roundedValues.goal} ${displayUnit ?? ''}`,
     reduced: `${reductionCounterTo.toFixed(1)} ${displayUnit ?? ''}`,
-    toBeReduced: roundedValues.goal
-      ? `${roundedValues.latest - Number(roundedValues.goal)} ${displayUnit ?? ''}`
-      : '',
+    toBeReduced:
+      roundedValues.goal != null
+        ? `${roundedValues.latest - Number(roundedValues.goal)} ${displayUnit ?? ''}`
+        : '',
   };
   /*
     On the year {{startYear}} {{name}} was {{startValue}}.
@@ -723,7 +724,7 @@ function IndicatorProgressBar(props: IndicatorProgressBarProps) {
             textAnchor={goalBar.w > 120 ? 'start' : 'end'}
             transform={`translate(${goalBar.w > 120 ? goalBar.x + 4 : goalBar.x - 8} ${goalBar.y})`}
             date={graphValues.goalYear}
-            value={roundedValues.goal ? formatNumber(roundedValues.goal) : ''}
+            value={roundedValues.goal != null ? formatNumber(roundedValues.goal) : ''}
             unit={displayUnit ?? ''}
             locale={locale}
             textColor={


### PR DESCRIPTION
## Description

A valid goal value of `0` was treated as missing in the showcase indicator progress bar.
The UI was using a truthy check for the goal value.

* Updated the logic with explicit null checks, so `0` is handled as a valid goal value

## Screenshots/Videos (if applicable)

Before:

<img width="886" height="204" alt="Screenshot 2026-05-05 at 12 36 49" src="https://github.com/user-attachments/assets/5575e94e-3d55-493b-9760-a0067cbd3b4d" />


After:

<img width="878" height="185" alt="Screenshot 2026-05-05 at 12 36 30" src="https://github.com/user-attachments/assets/090c7def-27a7-41e7-b906-0fdbfbbc2c23" />


## Related issue

[slack thread](https://kausaltech.slack.com/archives/C091K1SK10F/p1777966761054999)

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

We decided to not display minimal bar for 0 goal.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
