### PR TITLE
Fix/resp parties hover caboom

### DIFF
--- a/src/components/dashboard/ActionTableTooltips.tsx
+++ b/src/components/dashboard/ActionTableTooltips.tsx
@@ -174,6 +174,9 @@ export const ResponsiblePartiesTooltipContent = ({ action, plan }: TooltipWithPl
 
   const parties = action.responsibleParties ?? [];
 
+  const getResponsiblePartyLabel = (party: (typeof parties)[number]) =>
+    party.organization?.abbreviation || party.organization?.name;
+
   if (parties.length < 1)
     return (
       <div>
@@ -189,8 +192,10 @@ export const ResponsiblePartiesTooltipContent = ({ action, plan }: TooltipWithPl
         <strong>{t('with-contact-persons')}:</strong>
       )}
       <ResponsibleTooltipList>
-        {parties.map((party) =>
-          party.hasContactPerson ? (
+        {parties.map((party) => {
+          const label = getResponsiblePartyLabel(party);
+
+          return party.hasContactPerson && label ? (
             <ResponsibleTooltipListItem key={party.id}>
               <Icon
                 name={party.hasContactPerson ? 'dot-circle' : 'circle-outline'}
@@ -198,17 +203,19 @@ export const ResponsiblePartiesTooltipContent = ({ action, plan }: TooltipWithPl
                 width="1em"
                 height="1em"
               />{' '}
-              {party.organization?.abbreviation || party.organization?.name}
+              {label}
             </ResponsibleTooltipListItem>
-          ) : null
-        )}
+          ) : null;
+        })}
       </ResponsibleTooltipList>
       {parties.find((party) => !party.hasContactPerson) && (
         <strong>{t('without-contact-person')}:</strong>
       )}
       <ResponsibleTooltipList>
-        {parties.map((party) =>
-          !party.hasContactPerson ? (
+        {parties.map((party) => {
+          const label = getResponsiblePartyLabel(party);
+
+          return !party.hasContactPerson && label ? (
             <ResponsibleTooltipListItem key={party.id}>
               <Icon
                 name={party.hasContactPerson ? 'dot-circle' : 'circle-outline'}
@@ -216,10 +223,10 @@ export const ResponsiblePartiesTooltipContent = ({ action, plan }: TooltipWithPl
                 width="1em"
                 height="1em"
               />{' '}
-              {party.organization?.abbreviation || party.organization?.name}
+              {label}
             </ResponsibleTooltipListItem>
-          ) : null
-        )}
+          ) : null;
+        })}
       </ResponsibleTooltipList>
     </div>
   );

--- a/src/components/dashboard/ActionTableTooltips.tsx
+++ b/src/components/dashboard/ActionTableTooltips.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+
 import { useTranslations } from 'next-intl';
 
 import { ActionStatusSummaryIdentifier } from '@/common/__generated__/graphql';
@@ -171,7 +172,7 @@ export const ResponsiblePartiesTooltipContent = ({ action, plan }: TooltipWithPl
   const theme = useTheme();
   const organizationTerm = plan?.generalContent?.organizationTerm;
 
-  const parties = action.responsibleParties;
+  const parties = action.responsibleParties ?? [];
 
   if (parties.length < 1)
     return (
@@ -197,7 +198,7 @@ export const ResponsiblePartiesTooltipContent = ({ action, plan }: TooltipWithPl
                 width="1em"
                 height="1em"
               />{' '}
-              {party.organization.abbreviation || party.organization.name}
+              {party.organization?.abbreviation || party.organization?.name}
             </ResponsibleTooltipListItem>
           ) : null
         )}
@@ -215,7 +216,7 @@ export const ResponsiblePartiesTooltipContent = ({ action, plan }: TooltipWithPl
                 width="1em"
                 height="1em"
               />{' '}
-              {party.organization.abbreviation || party.organization.name}
+              {party.organization?.abbreviation || party.organization?.name}
             </ResponsibleTooltipListItem>
           ) : null
         )}

--- a/src/components/orgs/OrgContent.tsx
+++ b/src/components/orgs/OrgContent.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+
 import { useTranslations } from 'next-intl';
 import { readableColor } from 'polished';
 import { Col, Container, Nav, NavItem, Row } from 'reactstrap';
@@ -205,7 +206,11 @@ function OrgContent({ org, planFromOrgQuery, testId }: Props) {
                       planShortName={`${p.shortName || p.name}${
                         p.versionName ? ` (${p.versionName})` : ''
                       }`}
-                      organization={p.shortName ? p.name : p.organization.abbreviation}
+                      organization={
+                        p.shortName
+                          ? p.name
+                          : p.organization?.abbreviation || p.organization?.name || ''
+                      }
                       size="md"
                       negative={i !== selectedPlanIndex}
                     />


### PR DESCRIPTION
## Description

Fix a crash that happens during hovering over the responsible organisations cell in the action list.
The caboom happened when a responsible party did not have organization data. 

* Make responsible party organization labels null-safe so the tooltip can open without crashing.
* Add the same safe check in `OrgContent` for organization labels:
* Hide missing organization label in the tooltip (don't show empty row).

## Screenshots/Videos (if applicable)

Before (organization cell hovering):
<img width="1470" height="571" alt="Screenshot 2026-05-07 at 12 10 16" src="https://github.com/user-attachments/assets/d7bc4b81-b17e-42ba-9998-58a8ca4fe52c" />

After: 

<img width="1362" height="452" alt="Screenshot 2026-05-07 at 14 35 28" src="https://github.com/user-attachments/assets/e7388f75-dbaa-4488-8dca-3fb45f4c1ee1" />





## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1214579750772824?focus=true)

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
 Hover over organization cell of action 1.4.1 here: https://pirkkala-ilmasto.watch.fi.kausal.tech/actions?view=dashboard

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
