### PR TITLE
Fix/custom status donut slice

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -2010,7 +2010,10 @@ export type GetActionListForGraphsQueryVariables = Exact<{
 
 export type GetActionListForGraphsQuery = (
   { planActions: Array<(
-    { color: string | null, scheduleContinuous: boolean, statusSummary: (
+    { color: string | null, scheduleContinuous: boolean, status: (
+      { identifier: string, name: string, color: string }
+      & { __typename: 'ActionStatus' }
+    ) | null, statusSummary: (
       { identifier: ActionStatusSummaryIdentifier }
       & { __typename: 'ActionStatusSummary' }
     ), timeliness: (

--- a/src/common/preprocess.ts
+++ b/src/common/preprocess.ts
@@ -33,9 +33,26 @@ type ActionWithPhaseAndStatus = {
     viewUrl: string;
   };
 };
+
 type ActionStatus = ActionWithPhaseAndStatus['status'] & {
   isCompleted?: boolean;
 };
+
+type ActionForStatusGraph = {
+  color: string | null;
+  statusSummary: {
+    identifier: ActionStatusSummaryIdentifier;
+  };
+  status?: {
+    identifier: string;
+    name: string;
+    color: string | null;
+  } | null;
+};
+
+const CUSTOM_STATUS_PREFIX = '__custom__';
+
+const CUSTOM_STATUS_COLOR_KEYS = ['grey060', 'grey040', 'grey070', 'grey030'] as const;
 
 // Clean up actionStatus so UI can handle edge cases
 const cleanActionStatus = (
@@ -105,11 +122,41 @@ class DonutSector {
   }
 }
 
+const getThemeGraphColor = (
+  theme: Theme,
+  colorKey: string | null | undefined
+): string | undefined => {
+  if (colorKey == null) {
+    return undefined;
+  }
+
+  return theme.graphColors[colorKey as keyof typeof theme.graphColors];
+};
+
+const getCustomStatusColor = (
+  theme: Theme,
+  colorKey: string | null,
+  assignedColors: Set<string>
+): string => {
+  const rawStatusColor = getThemeGraphColor(theme, colorKey);
+
+  if (rawStatusColor != null && !assignedColors.has(rawStatusColor)) {
+    return rawStatusColor;
+  }
+
+  const fallbackColorKey = CUSTOM_STATUS_COLOR_KEYS.find((key) => {
+    const color = theme.graphColors[key];
+    return color != null && !assignedColors.has(color);
+  });
+
+  return fallbackColorKey ? theme.graphColors[fallbackColorKey] : theme.graphColors.grey060;
+};
+
 /*
  Process a list of actions and return an ordered list of statuses for statistics
  */
 const getStatusData = (
-  actions: NonNullable<GetActionListForGraphsQuery['planActions']>,
+  actions: ActionForStatusGraph[],
   actionStatusSummaries: ActionStatusSummary[],
   theme: Theme,
   unknownLabelText: string = ''
@@ -125,15 +172,36 @@ const getStatusData = (
 
   const counts: Map<string, number> = new Map();
   const colors: Map<string, string | null> = new Map();
+  const customStatusMeta: Map<string, { name: string; color: string | null }> = new Map();
+
   for (const action of actions) {
     const {
       statusSummary: { identifier },
+      status,
       color,
     } = action;
-    const val = 1 + (counts.get(identifier) ?? 0);
-    counts.set(identifier, val);
-    colors.set(identifier, color ?? null);
+
+    // If the backend maps an action to UNDEFINED but the action has a raw status,
+    // show that raw status as a separate neutral slice instead of "no status".
+    const isCustomStatus = identifier === ActionStatusSummaryIdentifier.Undefined && status != null;
+
+    const bucketKey = isCustomStatus ? `${CUSTOM_STATUS_PREFIX}${status.identifier}` : identifier;
+
+    counts.set(bucketKey, 1 + (counts.get(bucketKey) ?? 0));
+
+    if (isCustomStatus) {
+      const customColor = status.color ?? color ?? null;
+
+      colors.set(bucketKey, customColor);
+      customStatusMeta.set(bucketKey, {
+        name: status.name,
+        color: customColor,
+      });
+    } else {
+      colors.set(bucketKey, color ?? null);
+    }
   }
+
   actionStatusSummaries.forEach(({ identifier, label, color, sentiment }) => {
     const statusCount = counts.get(identifier) ?? 0;
     if (statusCount > 0) {
@@ -153,7 +221,34 @@ const getStatusData = (
     }
     totalCount += statusCount;
   });
-  progress.total = `${Math.round((progress.good / totalCount) * 100)}%`;
+
+  const assignedColors = new Set(progress.colors.filter(Boolean));
+
+  for (const [bucketKey, statusCount] of counts.entries()) {
+    if (!bucketKey.startsWith(CUSTOM_STATUS_PREFIX) || statusCount === 0) {
+      continue;
+    }
+
+    const meta = customStatusMeta.get(bucketKey);
+
+    if (meta == null) {
+      continue;
+    }
+
+    const customColor = getCustomStatusColor(theme, meta.color, assignedColors);
+
+    assignedColors.add(customColor);
+
+    progress.values.push(statusCount);
+    progress.labels.push(meta.name);
+    progress.colors.push(customColor);
+
+    // Custom statuses are neutral: included in total, but not counted as good.
+    totalCount += statusCount;
+  }
+
+  progress.total = totalCount > 0 ? `${Math.round((progress.good / totalCount) * 100)}%` : '0%';
+
   return progress;
 };
 
@@ -267,7 +362,5 @@ const getPhaseData = (
     ongoingAndCompleted,
   } as Progress;
 };
-
-type StatusSummary = Plan['actionStatusSummaries'][0];
 
 export { cleanActionStatus, getPhaseData, getStatusData };

--- a/src/components/contentblocks/ActionStatusGraphsBlock.tsx
+++ b/src/components/contentblocks/ActionStatusGraphsBlock.tsx
@@ -24,6 +24,11 @@ const GET_ACTION_LIST_FOR_GRAPHS = gql`
     planActions(plan: $plan, category: $categoryId) {
       color
       scheduleContinuous
+      status {
+        identifier
+        name
+        color
+      }
       statusSummary {
         identifier
       }


### PR DESCRIPTION
## Description

Fix custom action status being shown as “no status” in the action status donut graph.

The graph uses the backend’s statusSummary field, not the raw status field. Because the backend didn’t have a CHANGED summary, actions with the changed status were treated as UNDEFINED.

* Show custom raw status as a separate neutral donut slice;
* Custom status is included in the total count, but it's neutral (not counted as good/bad);
* Custom status uses neutral gray colors and avoids reusing the same color as other slices, so they do not visually merge with “no status”.

## Screenshots/Videos (if applicable)

Before (custom status Changed merged with No status):

<img width="409" height="427" alt="Screenshot 2026-05-08 at 15 10 26" src="https://github.com/user-attachments/assets/4186e44e-7242-4417-8c43-4fff2f74ec1a" />


After ( the custom status is shown as a separate slice):

<img width="378" height="383" alt="Screenshot 2026-05-08 at 15 10 59" src="https://github.com/user-attachments/assets/acd3885f-ada4-43b8-8855-eca5c380ec09" />

## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1214519221455608?focus=true)

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
