### PR TITLE
Fix secondary nav clipping when there is no body content

### DIFF
--- a/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/ContentPage.tsx
+++ b/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/ContentPage.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+
 import { Col, Container, Row } from 'reactstrap';
 
 import { ActionListPage } from '@/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/actions/ActionListPage';
@@ -154,6 +155,7 @@ export default function ContentPage({ page, testId }: { page: GeneralPlanPage; t
 
   const categoryColor = isCategoryPage && (page.category?.color || page.category?.parent?.color);
   const pageSectionColor = categoryColor || theme.themeColors.light;
+  const pageBodyHasBlocks = isPageWithBody && (page.body?.length ?? 0) > 0;
 
   /* Content pages can have a secondary side nav */
   const secondaryNavParent =
@@ -206,10 +208,11 @@ export default function ContentPage({ page, testId }: { page: GeneralPlanPage; t
               links={siblings}
               activeLink={page.id}
               title={secondaryNavParent.title || ''}
+              pageHasContent={pageBodyHasBlocks}
             />
           ) : null}
 
-          {isPageWithBody && page.body && (
+          {isPageWithBody && page.body && pageBodyHasBlocks && (
             <StreamField page={page} blocks={page.body} hasSidebar={siblings.length > 1} />
           )}
         </div>

--- a/src/components/common/SecondaryNavigation.tsx
+++ b/src/components/common/SecondaryNavigation.tsx
@@ -1,12 +1,17 @@
 import styled from '@emotion/styled';
+
 import { Col, Container, Row } from 'reactstrap';
+
+import { transientOptions } from '@common/themes/styles/styled';
 
 import { type StaticPage } from '@/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/ContentPage';
 import { Link } from '@/common/links';
 
-const NavigationContainer = styled(Container)`
+const NavigationContainer = styled(Container, transientOptions)<{ $pageHasContent: boolean }>`
   @media (min-width: ${(props) => props.theme.breakpointLg}) {
-    position: absolute;
+    // When there is no body content, render the navigation as
+    // relative to ensure it's not clipped by the footer
+    position: ${(props) => (props.$pageHasContent ? 'absolute' : 'relative')};
     margin-left: auto;
     margin-right: auto;
     left: 0;
@@ -55,13 +60,14 @@ interface SecondaryNavigationProps {
   links: StaticPageParentsChildren;
   activeLink?: string | null;
   title?: string;
+  pageHasContent?: boolean;
 }
 
 const SecondaryNavigation = (props: SecondaryNavigationProps) => {
-  const { links, activeLink, title } = props;
+  const { links, activeLink, title, pageHasContent = true } = props;
 
   return (
-    <NavigationContainer>
+    <NavigationContainer $pageHasContent={pageHasContent}>
       <Row>
         <Col md={{ size: 10, offset: 1 }} lg={{ size: 4, offset: 0 }} xl={3}>
           <NavigationCard>


### PR DESCRIPTION
## Description

When there's no body content, the `absolute` secondary navigation takes no vertical space on the page and gets cut off by the footer. In these cases, render the secondary nav as relative instead.

## Screenshots/Videos (if applicable)

### Before
<img width="1011" height="794" alt="image" src="https://github.com/user-attachments/assets/8ad7e9ca-cf22-4d01-ba25-961fbdb65e24" />

### After 
<img width="1013" height="782" alt="image" src="https://github.com/user-attachments/assets/9a59c6e4-c60a-4c08-a301-cf0b79d6dcbb" />

## Related issue

https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1213990915317190?focus=true
