### PR TITLE
Default Visualisations in Indicator Details Page and Action Details Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "@eslint/core": "^1.2.1",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^9.39.2",
+    "@graphql-codegen/add": "^7.0.0",
     "@graphql-codegen/cli": "^5.0.7",
     "@graphql-codegen/fragment-matcher": "^5.1.0",
     "@graphql-codegen/introspection": "^4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,6 +309,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.4
+      '@graphql-codegen/add':
+        specifier: ^7.0.0
+        version: 7.0.0(graphql@16.13.2)
       '@graphql-codegen/cli':
         specifier: ^5.0.7
         version: 5.0.7(@parcel/watcher@2.5.6)(@types/node@17.0.45)(encoding@0.1.13)(graphql@16.13.2)(typescript@5.9.3)
@@ -1746,6 +1749,12 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
+  '@graphql-codegen/add@7.0.0':
+    resolution: {integrity: sha512-fQGlUQd0BpoevCTOKi3b7M+kuXCI13udXmJrIh1QMtTCLXUTYGgsubNVcPLr0cVjVwyBK/ZRgwtxdCmkVXqTwQ==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
   '@graphql-codegen/cli@5.0.7':
     resolution: {integrity: sha512-h/sxYvSaWtxZxo8GtaA8SvcHTyViaaPd7dweF/hmRDpaQU1o3iU3EZxlcJ+oLTunU0tSMFsnrIXm/mhXxI11Cw==}
     engines: {node: '>=16'}
@@ -1797,6 +1806,12 @@ packages:
 
   '@graphql-codegen/plugin-helpers@6.3.0':
     resolution: {integrity: sha512-Auc+/B7okDx9+pVgLVliZtZLYh6iltWXlnzzM+bRE+zh1T4r3hKbnr8xAmtT937ArfSgk5GHcQHr8LfPYnrRBg==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+
+  '@graphql-codegen/plugin-helpers@7.0.1':
+    resolution: {integrity: sha512-S2X0YT3XQbP2haqhIeku8GOXo2j8QuBu7BrLsOEHz4UeMu78y3rja1Q4ri3oJ0jq4dMgaQlazoVHI/A+FAKMGw==}
     engines: {node: '>=16'}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -4389,7 +4404,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   array-flatten@1.1.1:
-    resolution: {integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=}
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
   array-includes@3.1.9:
     resolution: {integrity: sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==}
@@ -4760,8 +4775,14 @@ packages:
   change-case-all@1.0.15:
     resolution: {integrity: sha512-3+GIFhk3sNuvFAJKU46o26OdzudQlPNBCu1ZQi3cMeMHhty1bhDxu2WrEilVNYaGvqUtR1VSigFcJOiS13dRhQ==}
 
+  change-case-all@2.1.0:
+    resolution: {integrity: sha512-v6b0WWWkZUMHVuYk82l+WROgkUm4qEN2w5hKRNWtEOYwWqUGoi8C6xH0l1RLF1EoWqDFK6MFclmN3od6ws3/uw==}
+
   change-case@4.1.2:
     resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
+
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -4990,7 +5011,7 @@ packages:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-signature@1.0.6:
-    resolution: {integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=}
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
@@ -5520,7 +5541,7 @@ packages:
     engines: {node: '>=14'}
 
   encodeurl@1.0.2:
-    resolution: {integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=}
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
 
   encodeurl@2.0.0:
@@ -5627,7 +5648,7 @@ packages:
     engines: {node: '>=6'}
 
   escape-html@1.0.3:
-    resolution: {integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=}
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
   escape-string-regexp@1.0.5:
     resolution: {integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=}
@@ -5813,7 +5834,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   etag@1.8.1:
-    resolution: {integrity: sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=}
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
   event-emitter@0.3.5:
@@ -6049,7 +6070,7 @@ packages:
         optional: true
 
   fresh@0.5.2:
-    resolution: {integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=}
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
   from2@2.3.0:
@@ -7405,7 +7426,7 @@ packages:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
   media-typer@0.3.0:
-    resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
   memoize-one@4.0.3:
@@ -7434,7 +7455,7 @@ packages:
         optional: true
 
   methods@1.1.2:
-    resolution: {integrity: sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=}
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
 
   micromatch@4.0.8:
@@ -9042,6 +9063,9 @@ packages:
   sponge-case@1.0.1:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
 
+  sponge-case@2.0.3:
+    resolution: {integrity: sha512-i4h9ZGRfxV6Xw3mpZSFOfbXjf0cQcYmssGWutgNIfFZ2VM+YIWfD71N/kjjwK6X/AAHzBr+rciEcn/L34S8TGw==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=}
 
@@ -9281,6 +9305,9 @@ packages:
 
   swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
+
+  swap-case@3.0.3:
+    resolution: {integrity: sha512-6p4op8wE9CQv7uDFzulI6YXUw4lD9n4oQierdbFThEKVWVQcbQcUjdP27W8XE7V4QnWmnq9jueSHceyyQnqQVA==}
 
   swc-plugin-coverage-instrument@0.0.28:
     resolution: {integrity: sha512-ps70ske/LiIubyKOakw5rSOjHOIv6ecyyGQY0BctkVS2t776qtIVS2nqpAUaw3g5VMgAGoq/TShV12D3D7n3ag==}
@@ -9642,7 +9669,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   unpipe@1.0.0:
-    resolution: {integrity: sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=}
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
   unplugin@2.3.11:
@@ -9715,7 +9742,7 @@ packages:
     resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
 
   utils-merge@1.0.1:
-    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
   uuid@8.3.2:
@@ -9736,7 +9763,7 @@ packages:
     resolution: {integrity: sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==}
 
   vary@1.1.2:
-    resolution: {integrity: sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=}
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
   vite-plugin-storybook-nextjs@3.2.4:
@@ -11330,6 +11357,12 @@ snapshots:
       graphql: 16.13.2
       tslib: 2.6.3
 
+  '@graphql-codegen/add@7.0.0(graphql@16.13.2)':
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 7.0.1(graphql@16.13.2)
+      graphql: 16.13.2
+      tslib: 2.8.1
+
   '@graphql-codegen/cli@5.0.7(@parcel/watcher@2.5.6)(@types/node@17.0.45)(encoding@0.1.13)(graphql@16.13.2)(typescript@5.9.3)':
     dependencies:
       '@babel/generator': 7.29.1
@@ -11447,6 +11480,15 @@ snapshots:
     dependencies:
       '@graphql-tools/utils': 11.1.0(graphql@16.13.2)
       change-case-all: 1.0.15
+      common-tags: 1.8.2
+      graphql: 16.13.2
+      import-from: 4.0.0
+      tslib: 2.8.1
+
+  '@graphql-codegen/plugin-helpers@7.0.1(graphql@16.13.2)':
+    dependencies:
+      '@graphql-tools/utils': 11.1.0(graphql@16.13.2)
+      change-case-all: 2.1.0
       common-tags: 1.8.2
       graphql: 16.13.2
       import-from: 4.0.0
@@ -14989,6 +15031,13 @@ snapshots:
       upper-case: 2.0.2
       upper-case-first: 2.0.2
 
+  change-case-all@2.1.0:
+    dependencies:
+      change-case: 5.4.4
+      sponge-case: 2.0.3
+      swap-case: 3.0.3
+      title-case: 3.0.3
+
   change-case@4.1.2:
     dependencies:
       camel-case: 4.1.2
@@ -15003,6 +15052,8 @@ snapshots:
       sentence-case: 3.0.4
       snake-case: 3.0.4
       tslib: 2.8.1
+
+  change-case@5.4.4: {}
 
   char-regex@1.0.2: {}
 
@@ -20201,6 +20252,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  sponge-case@2.0.3: {}
+
   sprintf-js@1.0.3: {}
 
   ssri@12.0.0:
@@ -20471,6 +20524,8 @@ snapshots:
   swap-case@2.0.2:
     dependencies:
       tslib: 2.8.1
+
+  swap-case@3.0.3: {}
 
   swc-plugin-coverage-instrument@0.0.28: {}
 

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -4467,20 +4467,6 @@ export type CategoryTagRecursiveFragmentFragment = (
   & { __typename: 'Category' }
 );
 
-export type DashboardIndicatorFragmentFragment = (
-  { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
-    { value: number, date: string | null }
-    & { __typename: 'IndicatorValue' }
-  ) | null, goals: Array<(
-    { value: number, date: string | null }
-    & { __typename: 'IndicatorGoal' }
-  ) | null> | null, unit: (
-    { name: string, shortName: string | null }
-    & { __typename: 'Unit' }
-  ) }
-  & { __typename: 'Indicator' }
-);
-
 export type DashboardIndicatorBlockFragmentFragment = (
   { blockType: string, blocks: Array<(
     { blockType: string }
@@ -4504,22 +4490,7 @@ export type DashboardIndicatorBlockFragmentFragment = (
     { blockType: string }
     & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
   ) | (
-    { id: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
-      { dimensionCategory: (
-        { id: string, name: string, defaultColor: string }
-        & { __typename: 'DimensionCategory' }
-      ) | null, values: Array<(
-        { id: string, value: number, date: string | null }
-        & { __typename: 'IndicatorValue' }
-      ) | null> }
-      & { __typename: 'DashboardIndicatorChartSeries' }
-    ) | null> | null, dimension: (
-      { id: string, name: string, categories: Array<(
-        { id: string, name: string }
-        & { __typename: 'DimensionCategory' }
-      )> }
-      & { __typename: 'Dimension' }
-    ) | null, indicator: (
+    { id: string | null, helpText: string | null, blockType: string, showTotalLine: boolean | null, indicator: (
       { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
         { value: number, date: string | null }
         & { __typename: 'IndicatorValue' }
@@ -4531,25 +4502,25 @@ export type DashboardIndicatorBlockFragmentFragment = (
         & { __typename: 'Unit' }
       ) }
       & { __typename: 'Indicator' }
-    ) | null }
-    & { __typename: 'DashboardIndicatorAreaChartBlock' }
+    ) | null, dimension: (
+      { id: string, name: string, categories: Array<(
+        { id: string, name: string }
+        & { __typename: 'DimensionCategory' }
+      )> }
+      & { __typename: 'Dimension' }
+    ) | null, chartSeries: Array<(
+      { dimensionCategory: (
+        { id: string, name: string, defaultColor: string }
+        & { __typename: 'DimensionCategory' }
+      ) | null, values: Array<(
+        { id: string, value: number, date: string | null }
+        & { __typename: 'IndicatorValue' }
+      ) | null> }
+      & { __typename: 'DashboardIndicatorChartSeries' }
+    ) | null> | null }
+    & { __typename: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorLineChartBlock' }
   ) | (
-    { id: string | null, barType: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
-      { dimensionCategory: (
-        { id: string, name: string, defaultColor: string }
-        & { __typename: 'DimensionCategory' }
-      ) | null, values: Array<(
-        { id: string, value: number, date: string | null }
-        & { __typename: 'IndicatorValue' }
-      ) | null> }
-      & { __typename: 'DashboardIndicatorChartSeries' }
-    ) | null> | null, dimension: (
-      { id: string, name: string, categories: Array<(
-        { id: string, name: string }
-        & { __typename: 'DimensionCategory' }
-      )> }
-      & { __typename: 'Dimension' }
-    ) | null, indicator: (
+    { id: string | null, helpText: string | null, blockType: string, barType: string | null, indicator: (
       { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
         { value: number, date: string | null }
         & { __typename: 'IndicatorValue' }
@@ -4561,25 +4532,25 @@ export type DashboardIndicatorBlockFragmentFragment = (
         & { __typename: 'Unit' }
       ) }
       & { __typename: 'Indicator' }
-    ) | null }
+    ) | null, dimension: (
+      { id: string, name: string, categories: Array<(
+        { id: string, name: string }
+        & { __typename: 'DimensionCategory' }
+      )> }
+      & { __typename: 'Dimension' }
+    ) | null, chartSeries: Array<(
+      { dimensionCategory: (
+        { id: string, name: string, defaultColor: string }
+        & { __typename: 'DimensionCategory' }
+      ) | null, values: Array<(
+        { id: string, value: number, date: string | null }
+        & { __typename: 'IndicatorValue' }
+      ) | null> }
+      & { __typename: 'DashboardIndicatorChartSeries' }
+    ) | null> | null }
     & { __typename: 'DashboardIndicatorBarChartBlock' }
   ) | (
-    { id: string | null, helpText: string | null, showTotalLine: boolean | null, blockType: string, chartSeries: Array<(
-      { dimensionCategory: (
-        { id: string, name: string, defaultColor: string }
-        & { __typename: 'DimensionCategory' }
-      ) | null, values: Array<(
-        { id: string, value: number, date: string | null }
-        & { __typename: 'IndicatorValue' }
-      ) | null> }
-      & { __typename: 'DashboardIndicatorChartSeries' }
-    ) | null> | null, dimension: (
-      { id: string, name: string, categories: Array<(
-        { id: string, name: string }
-        & { __typename: 'DimensionCategory' }
-      )> }
-      & { __typename: 'Dimension' }
-    ) | null, indicator: (
+    { helpText: string | null, blockType: string, year: number | null, indicator: (
       { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
         { value: number, date: string | null }
         & { __typename: 'IndicatorValue' }
@@ -4591,10 +4562,13 @@ export type DashboardIndicatorBlockFragmentFragment = (
         & { __typename: 'Unit' }
       ) }
       & { __typename: 'Indicator' }
-    ) | null }
-    & { __typename: 'DashboardIndicatorLineChartBlock' }
-  ) | (
-    { helpText: string | null, year: number | null, blockType: string, chartSeries: Array<(
+    ) | null, dimension: (
+      { id: string, name: string, categories: Array<(
+        { id: string, name: string }
+        & { __typename: 'DimensionCategory' }
+      )> }
+      & { __typename: 'Dimension' }
+    ) | null, chartSeries: Array<(
       { dimensionCategory: (
         { id: string, name: string, defaultColor: string }
         & { __typename: 'DimensionCategory' }
@@ -4603,25 +4577,7 @@ export type DashboardIndicatorBlockFragmentFragment = (
         & { __typename: 'IndicatorValue' }
       ) | null> }
       & { __typename: 'DashboardIndicatorChartSeries' }
-    ) | null> | null, dimension: (
-      { id: string, name: string, categories: Array<(
-        { id: string, name: string }
-        & { __typename: 'DimensionCategory' }
-      )> }
-      & { __typename: 'Dimension' }
-    ) | null, indicator: (
-      { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
-        { value: number, date: string | null }
-        & { __typename: 'IndicatorValue' }
-      ) | null, goals: Array<(
-        { value: number, date: string | null }
-        & { __typename: 'IndicatorGoal' }
-      ) | null> | null, unit: (
-        { name: string, shortName: string | null }
-        & { __typename: 'Unit' }
-      ) }
-      & { __typename: 'Indicator' }
-    ) | null }
+    ) | null> | null }
     & { __typename: 'DashboardIndicatorPieChartBlock' }
   ) | (
     { id: string | null, blockType: string, indicator: (
@@ -4644,6 +4600,320 @@ export type DashboardIndicatorBlockFragmentFragment = (
   )> }
   & { __typename: 'DashboardRowBlock' }
 );
+
+export type DashboardIndicatorFragmentFragment = (
+  { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+    { value: number, date: string | null }
+    & { __typename: 'IndicatorValue' }
+  ) | null, goals: Array<(
+    { value: number, date: string | null }
+    & { __typename: 'IndicatorGoal' }
+  ) | null> | null, unit: (
+    { name: string, shortName: string | null }
+    & { __typename: 'Unit' }
+  ) }
+  & { __typename: 'Indicator' }
+);
+
+type BarChartVisualization_DashboardIndicatorBarChartBlock_Fragment = (
+  { barType: string | null, indicator: (
+    { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null, goals: Array<(
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorGoal' }
+    ) | null> | null, unit: (
+      { name: string, shortName: string | null }
+      & { __typename: 'Unit' }
+    ) }
+    & { __typename: 'Indicator' }
+  ) | null, dimension: (
+    { id: string, name: string, categories: Array<(
+      { id: string, name: string }
+      & { __typename: 'DimensionCategory' }
+    )> }
+    & { __typename: 'Dimension' }
+  ) | null, chartSeries: Array<(
+    { dimensionCategory: (
+      { id: string, name: string, defaultColor: string }
+      & { __typename: 'DimensionCategory' }
+    ) | null, values: Array<(
+      { id: string, value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null> }
+    & { __typename: 'DashboardIndicatorChartSeries' }
+  ) | null> | null }
+  & { __typename: 'DashboardIndicatorBarChartBlock' }
+);
+
+type BarChartVisualization_IndicatorDefaultBarChart_Fragment = (
+  { barType: string | null, indicator: (
+    { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null, goals: Array<(
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorGoal' }
+    ) | null> | null, unit: (
+      { name: string, shortName: string | null }
+      & { __typename: 'Unit' }
+    ) }
+    & { __typename: 'Indicator' }
+  ), dimension: (
+    { id: string, name: string, categories: Array<(
+      { id: string, name: string }
+      & { __typename: 'DimensionCategory' }
+    )> }
+    & { __typename: 'Dimension' }
+  ) | null, chartSeries: Array<(
+    { dimensionCategory: (
+      { id: string, name: string, defaultColor: string }
+      & { __typename: 'DimensionCategory' }
+    ) | null, values: Array<(
+      { id: string, value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null> }
+    & { __typename: 'DashboardIndicatorChartSeries' }
+  )> }
+  & { __typename: 'IndicatorDefaultBarChart' }
+);
+
+export type BarChartVisualizationFragment = BarChartVisualization_DashboardIndicatorBarChartBlock_Fragment | BarChartVisualization_IndicatorDefaultBarChart_Fragment;
+
+type LineChartVisualization_DashboardIndicatorLineChartBlock_Fragment = (
+  { showTotalLine: boolean | null, indicator: (
+    { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null, goals: Array<(
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorGoal' }
+    ) | null> | null, unit: (
+      { name: string, shortName: string | null }
+      & { __typename: 'Unit' }
+    ) }
+    & { __typename: 'Indicator' }
+  ) | null, dimension: (
+    { id: string, name: string, categories: Array<(
+      { id: string, name: string }
+      & { __typename: 'DimensionCategory' }
+    )> }
+    & { __typename: 'Dimension' }
+  ) | null, chartSeries: Array<(
+    { dimensionCategory: (
+      { id: string, name: string, defaultColor: string }
+      & { __typename: 'DimensionCategory' }
+    ) | null, values: Array<(
+      { id: string, value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null> }
+    & { __typename: 'DashboardIndicatorChartSeries' }
+  ) | null> | null }
+  & { __typename: 'DashboardIndicatorLineChartBlock' }
+);
+
+type LineChartVisualization_IndicatorDefaultLineChart_Fragment = (
+  { showTotalLine: boolean | null, indicator: (
+    { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null, goals: Array<(
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorGoal' }
+    ) | null> | null, unit: (
+      { name: string, shortName: string | null }
+      & { __typename: 'Unit' }
+    ) }
+    & { __typename: 'Indicator' }
+  ), dimension: (
+    { id: string, name: string, categories: Array<(
+      { id: string, name: string }
+      & { __typename: 'DimensionCategory' }
+    )> }
+    & { __typename: 'Dimension' }
+  ) | null, chartSeries: Array<(
+    { dimensionCategory: (
+      { id: string, name: string, defaultColor: string }
+      & { __typename: 'DimensionCategory' }
+    ) | null, values: Array<(
+      { id: string, value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null> }
+    & { __typename: 'DashboardIndicatorChartSeries' }
+  )> }
+  & { __typename: 'IndicatorDefaultLineChart' }
+);
+
+export type LineChartVisualizationFragment = LineChartVisualization_DashboardIndicatorLineChartBlock_Fragment | LineChartVisualization_IndicatorDefaultLineChart_Fragment;
+
+type AreaChartVisualization_DashboardIndicatorAreaChartBlock_Fragment = (
+  { showTotalLine: boolean | null, indicator: (
+    { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null, goals: Array<(
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorGoal' }
+    ) | null> | null, unit: (
+      { name: string, shortName: string | null }
+      & { __typename: 'Unit' }
+    ) }
+    & { __typename: 'Indicator' }
+  ) | null, dimension: (
+    { id: string, name: string, categories: Array<(
+      { id: string, name: string }
+      & { __typename: 'DimensionCategory' }
+    )> }
+    & { __typename: 'Dimension' }
+  ) | null, chartSeries: Array<(
+    { dimensionCategory: (
+      { id: string, name: string, defaultColor: string }
+      & { __typename: 'DimensionCategory' }
+    ) | null, values: Array<(
+      { id: string, value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null> }
+    & { __typename: 'DashboardIndicatorChartSeries' }
+  ) | null> | null }
+  & { __typename: 'DashboardIndicatorAreaChartBlock' }
+);
+
+type AreaChartVisualization_IndicatorDefaultAreaChart_Fragment = (
+  { showTotalLine: boolean | null, indicator: (
+    { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null, goals: Array<(
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorGoal' }
+    ) | null> | null, unit: (
+      { name: string, shortName: string | null }
+      & { __typename: 'Unit' }
+    ) }
+    & { __typename: 'Indicator' }
+  ), dimension: (
+    { id: string, name: string, categories: Array<(
+      { id: string, name: string }
+      & { __typename: 'DimensionCategory' }
+    )> }
+    & { __typename: 'Dimension' }
+  ) | null, chartSeries: Array<(
+    { dimensionCategory: (
+      { id: string, name: string, defaultColor: string }
+      & { __typename: 'DimensionCategory' }
+    ) | null, values: Array<(
+      { id: string, value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null> }
+    & { __typename: 'DashboardIndicatorChartSeries' }
+  )> }
+  & { __typename: 'IndicatorDefaultAreaChart' }
+);
+
+export type AreaChartVisualizationFragment = AreaChartVisualization_DashboardIndicatorAreaChartBlock_Fragment | AreaChartVisualization_IndicatorDefaultAreaChart_Fragment;
+
+type PieChartVisualization_DashboardIndicatorPieChartBlock_Fragment = (
+  { year: number | null, indicator: (
+    { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null, goals: Array<(
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorGoal' }
+    ) | null> | null, unit: (
+      { name: string, shortName: string | null }
+      & { __typename: 'Unit' }
+    ) }
+    & { __typename: 'Indicator' }
+  ) | null, dimension: (
+    { id: string, name: string, categories: Array<(
+      { id: string, name: string }
+      & { __typename: 'DimensionCategory' }
+    )> }
+    & { __typename: 'Dimension' }
+  ) | null, chartSeries: Array<(
+    { dimensionCategory: (
+      { id: string, name: string, defaultColor: string }
+      & { __typename: 'DimensionCategory' }
+    ) | null, values: Array<(
+      { id: string, value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null> }
+    & { __typename: 'DashboardIndicatorChartSeries' }
+  ) | null> | null }
+  & { __typename: 'DashboardIndicatorPieChartBlock' }
+);
+
+type PieChartVisualization_IndicatorDefaultPieChart_Fragment = (
+  { year: number | null, indicator: (
+    { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null, goals: Array<(
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorGoal' }
+    ) | null> | null, unit: (
+      { name: string, shortName: string | null }
+      & { __typename: 'Unit' }
+    ) }
+    & { __typename: 'Indicator' }
+  ), dimension: (
+    { id: string, name: string, categories: Array<(
+      { id: string, name: string }
+      & { __typename: 'DimensionCategory' }
+    )> }
+    & { __typename: 'Dimension' }
+  ) | null, chartSeries: Array<(
+    { dimensionCategory: (
+      { id: string, name: string, defaultColor: string }
+      & { __typename: 'DimensionCategory' }
+    ) | null, values: Array<(
+      { id: string, value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null> }
+    & { __typename: 'DashboardIndicatorChartSeries' }
+  )> }
+  & { __typename: 'IndicatorDefaultPieChart' }
+);
+
+export type PieChartVisualizationFragment = PieChartVisualization_DashboardIndicatorPieChartBlock_Fragment | PieChartVisualization_IndicatorDefaultPieChart_Fragment;
+
+type SummaryVisualization_DashboardIndicatorSummaryBlock_Fragment = (
+  { indicator: (
+    { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null, goals: Array<(
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorGoal' }
+    ) | null> | null, unit: (
+      { name: string, shortName: string | null }
+      & { __typename: 'Unit' }
+    ) }
+    & { __typename: 'Indicator' }
+  ) | null }
+  & { __typename: 'DashboardIndicatorSummaryBlock' }
+);
+
+type SummaryVisualization_IndicatorDefaultSummary_Fragment = (
+  { indicator: (
+    { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorValue' }
+    ) | null, goals: Array<(
+      { value: number, date: string | null }
+      & { __typename: 'IndicatorGoal' }
+    ) | null> | null, unit: (
+      { name: string, shortName: string | null }
+      & { __typename: 'Unit' }
+    ) }
+    & { __typename: 'Indicator' }
+  ) }
+  & { __typename: 'IndicatorDefaultSummary' }
+);
+
+export type SummaryVisualizationFragment = SummaryVisualization_DashboardIndicatorSummaryBlock_Fragment | SummaryVisualization_IndicatorDefaultSummary_Fragment;
 
 export type IndicatorListIndicatorFragment = (
   { id: string, name: string, timeResolution: IndicatorTimeResolution, desiredTrend: IndicatorDesiredTrend | null, valueRounding: number | null, sortKey: string | null, nonQuantifiedGoal: IndicatorNonQuantifiedGoal | null, nonQuantifiedGoalDate: string | null, organization: (
@@ -5676,22 +5946,7 @@ type StreamFieldFragment_DashboardRowBlock_Fragment = (
     { blockType: string }
     & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
   ) | (
-    { id: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
-      { dimensionCategory: (
-        { id: string, name: string, defaultColor: string }
-        & { __typename: 'DimensionCategory' }
-      ) | null, values: Array<(
-        { id: string, value: number, date: string | null }
-        & { __typename: 'IndicatorValue' }
-      ) | null> }
-      & { __typename: 'DashboardIndicatorChartSeries' }
-    ) | null> | null, dimension: (
-      { id: string, name: string, categories: Array<(
-        { id: string, name: string }
-        & { __typename: 'DimensionCategory' }
-      )> }
-      & { __typename: 'Dimension' }
-    ) | null, indicator: (
+    { id: string | null, helpText: string | null, blockType: string, showTotalLine: boolean | null, indicator: (
       { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
         { value: number, date: string | null }
         & { __typename: 'IndicatorValue' }
@@ -5703,25 +5958,25 @@ type StreamFieldFragment_DashboardRowBlock_Fragment = (
         & { __typename: 'Unit' }
       ) }
       & { __typename: 'Indicator' }
-    ) | null }
-    & { __typename: 'DashboardIndicatorAreaChartBlock' }
+    ) | null, dimension: (
+      { id: string, name: string, categories: Array<(
+        { id: string, name: string }
+        & { __typename: 'DimensionCategory' }
+      )> }
+      & { __typename: 'Dimension' }
+    ) | null, chartSeries: Array<(
+      { dimensionCategory: (
+        { id: string, name: string, defaultColor: string }
+        & { __typename: 'DimensionCategory' }
+      ) | null, values: Array<(
+        { id: string, value: number, date: string | null }
+        & { __typename: 'IndicatorValue' }
+      ) | null> }
+      & { __typename: 'DashboardIndicatorChartSeries' }
+    ) | null> | null }
+    & { __typename: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorLineChartBlock' }
   ) | (
-    { id: string | null, barType: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
-      { dimensionCategory: (
-        { id: string, name: string, defaultColor: string }
-        & { __typename: 'DimensionCategory' }
-      ) | null, values: Array<(
-        { id: string, value: number, date: string | null }
-        & { __typename: 'IndicatorValue' }
-      ) | null> }
-      & { __typename: 'DashboardIndicatorChartSeries' }
-    ) | null> | null, dimension: (
-      { id: string, name: string, categories: Array<(
-        { id: string, name: string }
-        & { __typename: 'DimensionCategory' }
-      )> }
-      & { __typename: 'Dimension' }
-    ) | null, indicator: (
+    { id: string | null, helpText: string | null, blockType: string, barType: string | null, indicator: (
       { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
         { value: number, date: string | null }
         & { __typename: 'IndicatorValue' }
@@ -5733,25 +5988,25 @@ type StreamFieldFragment_DashboardRowBlock_Fragment = (
         & { __typename: 'Unit' }
       ) }
       & { __typename: 'Indicator' }
-    ) | null }
+    ) | null, dimension: (
+      { id: string, name: string, categories: Array<(
+        { id: string, name: string }
+        & { __typename: 'DimensionCategory' }
+      )> }
+      & { __typename: 'Dimension' }
+    ) | null, chartSeries: Array<(
+      { dimensionCategory: (
+        { id: string, name: string, defaultColor: string }
+        & { __typename: 'DimensionCategory' }
+      ) | null, values: Array<(
+        { id: string, value: number, date: string | null }
+        & { __typename: 'IndicatorValue' }
+      ) | null> }
+      & { __typename: 'DashboardIndicatorChartSeries' }
+    ) | null> | null }
     & { __typename: 'DashboardIndicatorBarChartBlock' }
   ) | (
-    { id: string | null, helpText: string | null, showTotalLine: boolean | null, blockType: string, chartSeries: Array<(
-      { dimensionCategory: (
-        { id: string, name: string, defaultColor: string }
-        & { __typename: 'DimensionCategory' }
-      ) | null, values: Array<(
-        { id: string, value: number, date: string | null }
-        & { __typename: 'IndicatorValue' }
-      ) | null> }
-      & { __typename: 'DashboardIndicatorChartSeries' }
-    ) | null> | null, dimension: (
-      { id: string, name: string, categories: Array<(
-        { id: string, name: string }
-        & { __typename: 'DimensionCategory' }
-      )> }
-      & { __typename: 'Dimension' }
-    ) | null, indicator: (
+    { helpText: string | null, blockType: string, year: number | null, indicator: (
       { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
         { value: number, date: string | null }
         & { __typename: 'IndicatorValue' }
@@ -5763,10 +6018,13 @@ type StreamFieldFragment_DashboardRowBlock_Fragment = (
         & { __typename: 'Unit' }
       ) }
       & { __typename: 'Indicator' }
-    ) | null }
-    & { __typename: 'DashboardIndicatorLineChartBlock' }
-  ) | (
-    { helpText: string | null, year: number | null, blockType: string, chartSeries: Array<(
+    ) | null, dimension: (
+      { id: string, name: string, categories: Array<(
+        { id: string, name: string }
+        & { __typename: 'DimensionCategory' }
+      )> }
+      & { __typename: 'Dimension' }
+    ) | null, chartSeries: Array<(
       { dimensionCategory: (
         { id: string, name: string, defaultColor: string }
         & { __typename: 'DimensionCategory' }
@@ -5775,25 +6033,7 @@ type StreamFieldFragment_DashboardRowBlock_Fragment = (
         & { __typename: 'IndicatorValue' }
       ) | null> }
       & { __typename: 'DashboardIndicatorChartSeries' }
-    ) | null> | null, dimension: (
-      { id: string, name: string, categories: Array<(
-        { id: string, name: string }
-        & { __typename: 'DimensionCategory' }
-      )> }
-      & { __typename: 'Dimension' }
-    ) | null, indicator: (
-      { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
-        { value: number, date: string | null }
-        & { __typename: 'IndicatorValue' }
-      ) | null, goals: Array<(
-        { value: number, date: string | null }
-        & { __typename: 'IndicatorGoal' }
-      ) | null> | null, unit: (
-        { name: string, shortName: string | null }
-        & { __typename: 'Unit' }
-      ) }
-      & { __typename: 'Indicator' }
-    ) | null }
+    ) | null> | null }
     & { __typename: 'DashboardIndicatorPieChartBlock' }
   ) | (
     { id: string | null, blockType: string, indicator: (
@@ -13040,22 +13280,7 @@ export type GetContentPageQuery = (
         { blockType: string }
         & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
       ) | (
-        { id: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
-          { dimensionCategory: (
-            { id: string, name: string, defaultColor: string }
-            & { __typename: 'DimensionCategory' }
-          ) | null, values: Array<(
-            { id: string, value: number, date: string | null }
-            & { __typename: 'IndicatorValue' }
-          ) | null> }
-          & { __typename: 'DashboardIndicatorChartSeries' }
-        ) | null> | null, dimension: (
-          { id: string, name: string, categories: Array<(
-            { id: string, name: string }
-            & { __typename: 'DimensionCategory' }
-          )> }
-          & { __typename: 'Dimension' }
-        ) | null, indicator: (
+        { id: string | null, helpText: string | null, blockType: string, showTotalLine: boolean | null, indicator: (
           { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
             { value: number, date: string | null }
             & { __typename: 'IndicatorValue' }
@@ -13067,25 +13292,25 @@ export type GetContentPageQuery = (
             & { __typename: 'Unit' }
           ) }
           & { __typename: 'Indicator' }
-        ) | null }
-        & { __typename: 'DashboardIndicatorAreaChartBlock' }
+        ) | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null }
+        & { __typename: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorLineChartBlock' }
       ) | (
-        { id: string | null, barType: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
-          { dimensionCategory: (
-            { id: string, name: string, defaultColor: string }
-            & { __typename: 'DimensionCategory' }
-          ) | null, values: Array<(
-            { id: string, value: number, date: string | null }
-            & { __typename: 'IndicatorValue' }
-          ) | null> }
-          & { __typename: 'DashboardIndicatorChartSeries' }
-        ) | null> | null, dimension: (
-          { id: string, name: string, categories: Array<(
-            { id: string, name: string }
-            & { __typename: 'DimensionCategory' }
-          )> }
-          & { __typename: 'Dimension' }
-        ) | null, indicator: (
+        { id: string | null, helpText: string | null, blockType: string, barType: string | null, indicator: (
           { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
             { value: number, date: string | null }
             & { __typename: 'IndicatorValue' }
@@ -13097,25 +13322,25 @@ export type GetContentPageQuery = (
             & { __typename: 'Unit' }
           ) }
           & { __typename: 'Indicator' }
-        ) | null }
+        ) | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null }
         & { __typename: 'DashboardIndicatorBarChartBlock' }
       ) | (
-        { id: string | null, helpText: string | null, showTotalLine: boolean | null, blockType: string, chartSeries: Array<(
-          { dimensionCategory: (
-            { id: string, name: string, defaultColor: string }
-            & { __typename: 'DimensionCategory' }
-          ) | null, values: Array<(
-            { id: string, value: number, date: string | null }
-            & { __typename: 'IndicatorValue' }
-          ) | null> }
-          & { __typename: 'DashboardIndicatorChartSeries' }
-        ) | null> | null, dimension: (
-          { id: string, name: string, categories: Array<(
-            { id: string, name: string }
-            & { __typename: 'DimensionCategory' }
-          )> }
-          & { __typename: 'Dimension' }
-        ) | null, indicator: (
+        { helpText: string | null, blockType: string, year: number | null, indicator: (
           { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
             { value: number, date: string | null }
             & { __typename: 'IndicatorValue' }
@@ -13127,10 +13352,13 @@ export type GetContentPageQuery = (
             & { __typename: 'Unit' }
           ) }
           & { __typename: 'Indicator' }
-        ) | null }
-        & { __typename: 'DashboardIndicatorLineChartBlock' }
-      ) | (
-        { helpText: string | null, year: number | null, blockType: string, chartSeries: Array<(
+        ) | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, chartSeries: Array<(
           { dimensionCategory: (
             { id: string, name: string, defaultColor: string }
             & { __typename: 'DimensionCategory' }
@@ -13139,25 +13367,7 @@ export type GetContentPageQuery = (
             & { __typename: 'IndicatorValue' }
           ) | null> }
           & { __typename: 'DashboardIndicatorChartSeries' }
-        ) | null> | null, dimension: (
-          { id: string, name: string, categories: Array<(
-            { id: string, name: string }
-            & { __typename: 'DimensionCategory' }
-          )> }
-          & { __typename: 'Dimension' }
-        ) | null, indicator: (
-          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
-            { value: number, date: string | null }
-            & { __typename: 'IndicatorValue' }
-          ) | null, goals: Array<(
-            { value: number, date: string | null }
-            & { __typename: 'IndicatorGoal' }
-          ) | null> | null, unit: (
-            { name: string, shortName: string | null }
-            & { __typename: 'Unit' }
-          ) }
-          & { __typename: 'Indicator' }
-        ) | null }
+        ) | null> | null }
         & { __typename: 'DashboardIndicatorPieChartBlock' }
       ) | (
         { id: string | null, blockType: string, indicator: (
@@ -13964,22 +14174,7 @@ export type GetContentPageQuery = (
         { blockType: string }
         & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
       ) | (
-        { id: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
-          { dimensionCategory: (
-            { id: string, name: string, defaultColor: string }
-            & { __typename: 'DimensionCategory' }
-          ) | null, values: Array<(
-            { id: string, value: number, date: string | null }
-            & { __typename: 'IndicatorValue' }
-          ) | null> }
-          & { __typename: 'DashboardIndicatorChartSeries' }
-        ) | null> | null, dimension: (
-          { id: string, name: string, categories: Array<(
-            { id: string, name: string }
-            & { __typename: 'DimensionCategory' }
-          )> }
-          & { __typename: 'Dimension' }
-        ) | null, indicator: (
+        { id: string | null, helpText: string | null, blockType: string, showTotalLine: boolean | null, indicator: (
           { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
             { value: number, date: string | null }
             & { __typename: 'IndicatorValue' }
@@ -13991,25 +14186,25 @@ export type GetContentPageQuery = (
             & { __typename: 'Unit' }
           ) }
           & { __typename: 'Indicator' }
-        ) | null }
-        & { __typename: 'DashboardIndicatorAreaChartBlock' }
+        ) | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null }
+        & { __typename: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorLineChartBlock' }
       ) | (
-        { id: string | null, barType: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
-          { dimensionCategory: (
-            { id: string, name: string, defaultColor: string }
-            & { __typename: 'DimensionCategory' }
-          ) | null, values: Array<(
-            { id: string, value: number, date: string | null }
-            & { __typename: 'IndicatorValue' }
-          ) | null> }
-          & { __typename: 'DashboardIndicatorChartSeries' }
-        ) | null> | null, dimension: (
-          { id: string, name: string, categories: Array<(
-            { id: string, name: string }
-            & { __typename: 'DimensionCategory' }
-          )> }
-          & { __typename: 'Dimension' }
-        ) | null, indicator: (
+        { id: string | null, helpText: string | null, blockType: string, barType: string | null, indicator: (
           { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
             { value: number, date: string | null }
             & { __typename: 'IndicatorValue' }
@@ -14021,25 +14216,25 @@ export type GetContentPageQuery = (
             & { __typename: 'Unit' }
           ) }
           & { __typename: 'Indicator' }
-        ) | null }
+        ) | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null }
         & { __typename: 'DashboardIndicatorBarChartBlock' }
       ) | (
-        { id: string | null, helpText: string | null, showTotalLine: boolean | null, blockType: string, chartSeries: Array<(
-          { dimensionCategory: (
-            { id: string, name: string, defaultColor: string }
-            & { __typename: 'DimensionCategory' }
-          ) | null, values: Array<(
-            { id: string, value: number, date: string | null }
-            & { __typename: 'IndicatorValue' }
-          ) | null> }
-          & { __typename: 'DashboardIndicatorChartSeries' }
-        ) | null> | null, dimension: (
-          { id: string, name: string, categories: Array<(
-            { id: string, name: string }
-            & { __typename: 'DimensionCategory' }
-          )> }
-          & { __typename: 'Dimension' }
-        ) | null, indicator: (
+        { helpText: string | null, blockType: string, year: number | null, indicator: (
           { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
             { value: number, date: string | null }
             & { __typename: 'IndicatorValue' }
@@ -14051,10 +14246,13 @@ export type GetContentPageQuery = (
             & { __typename: 'Unit' }
           ) }
           & { __typename: 'Indicator' }
-        ) | null }
-        & { __typename: 'DashboardIndicatorLineChartBlock' }
-      ) | (
-        { helpText: string | null, year: number | null, blockType: string, chartSeries: Array<(
+        ) | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, chartSeries: Array<(
           { dimensionCategory: (
             { id: string, name: string, defaultColor: string }
             & { __typename: 'DimensionCategory' }
@@ -14063,25 +14261,7 @@ export type GetContentPageQuery = (
             & { __typename: 'IndicatorValue' }
           ) | null> }
           & { __typename: 'DashboardIndicatorChartSeries' }
-        ) | null> | null, dimension: (
-          { id: string, name: string, categories: Array<(
-            { id: string, name: string }
-            & { __typename: 'DimensionCategory' }
-          )> }
-          & { __typename: 'Dimension' }
-        ) | null, indicator: (
-          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
-            { value: number, date: string | null }
-            & { __typename: 'IndicatorValue' }
-          ) | null, goals: Array<(
-            { value: number, date: string | null }
-            & { __typename: 'IndicatorGoal' }
-          ) | null> | null, unit: (
-            { name: string, shortName: string | null }
-            & { __typename: 'Unit' }
-          ) }
-          & { __typename: 'Indicator' }
-        ) | null }
+        ) | null> | null }
         & { __typename: 'DashboardIndicatorPieChartBlock' }
       ) | (
         { id: string | null, blockType: string, indicator: (
@@ -14618,22 +14798,7 @@ export type GetHomePageQuery = (
         { blockType: string }
         & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
       ) | (
-        { id: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
-          { dimensionCategory: (
-            { id: string, name: string, defaultColor: string }
-            & { __typename: 'DimensionCategory' }
-          ) | null, values: Array<(
-            { id: string, value: number, date: string | null }
-            & { __typename: 'IndicatorValue' }
-          ) | null> }
-          & { __typename: 'DashboardIndicatorChartSeries' }
-        ) | null> | null, dimension: (
-          { id: string, name: string, categories: Array<(
-            { id: string, name: string }
-            & { __typename: 'DimensionCategory' }
-          )> }
-          & { __typename: 'Dimension' }
-        ) | null, indicator: (
+        { id: string | null, helpText: string | null, blockType: string, showTotalLine: boolean | null, indicator: (
           { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
             { value: number, date: string | null }
             & { __typename: 'IndicatorValue' }
@@ -14645,25 +14810,25 @@ export type GetHomePageQuery = (
             & { __typename: 'Unit' }
           ) }
           & { __typename: 'Indicator' }
-        ) | null }
-        & { __typename: 'DashboardIndicatorAreaChartBlock' }
+        ) | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null }
+        & { __typename: 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorLineChartBlock' }
       ) | (
-        { id: string | null, barType: string | null, helpText: string | null, blockType: string, chartSeries: Array<(
-          { dimensionCategory: (
-            { id: string, name: string, defaultColor: string }
-            & { __typename: 'DimensionCategory' }
-          ) | null, values: Array<(
-            { id: string, value: number, date: string | null }
-            & { __typename: 'IndicatorValue' }
-          ) | null> }
-          & { __typename: 'DashboardIndicatorChartSeries' }
-        ) | null> | null, dimension: (
-          { id: string, name: string, categories: Array<(
-            { id: string, name: string }
-            & { __typename: 'DimensionCategory' }
-          )> }
-          & { __typename: 'Dimension' }
-        ) | null, indicator: (
+        { id: string | null, helpText: string | null, blockType: string, barType: string | null, indicator: (
           { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
             { value: number, date: string | null }
             & { __typename: 'IndicatorValue' }
@@ -14675,25 +14840,25 @@ export type GetHomePageQuery = (
             & { __typename: 'Unit' }
           ) }
           & { __typename: 'Indicator' }
-        ) | null }
+        ) | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, chartSeries: Array<(
+          { dimensionCategory: (
+            { id: string, name: string, defaultColor: string }
+            & { __typename: 'DimensionCategory' }
+          ) | null, values: Array<(
+            { id: string, value: number, date: string | null }
+            & { __typename: 'IndicatorValue' }
+          ) | null> }
+          & { __typename: 'DashboardIndicatorChartSeries' }
+        ) | null> | null }
         & { __typename: 'DashboardIndicatorBarChartBlock' }
       ) | (
-        { id: string | null, helpText: string | null, showTotalLine: boolean | null, blockType: string, chartSeries: Array<(
-          { dimensionCategory: (
-            { id: string, name: string, defaultColor: string }
-            & { __typename: 'DimensionCategory' }
-          ) | null, values: Array<(
-            { id: string, value: number, date: string | null }
-            & { __typename: 'IndicatorValue' }
-          ) | null> }
-          & { __typename: 'DashboardIndicatorChartSeries' }
-        ) | null> | null, dimension: (
-          { id: string, name: string, categories: Array<(
-            { id: string, name: string }
-            & { __typename: 'DimensionCategory' }
-          )> }
-          & { __typename: 'Dimension' }
-        ) | null, indicator: (
+        { helpText: string | null, blockType: string, year: number | null, indicator: (
           { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
             { value: number, date: string | null }
             & { __typename: 'IndicatorValue' }
@@ -14705,10 +14870,13 @@ export type GetHomePageQuery = (
             & { __typename: 'Unit' }
           ) }
           & { __typename: 'Indicator' }
-        ) | null }
-        & { __typename: 'DashboardIndicatorLineChartBlock' }
-      ) | (
-        { helpText: string | null, year: number | null, blockType: string, chartSeries: Array<(
+        ) | null, dimension: (
+          { id: string, name: string, categories: Array<(
+            { id: string, name: string }
+            & { __typename: 'DimensionCategory' }
+          )> }
+          & { __typename: 'Dimension' }
+        ) | null, chartSeries: Array<(
           { dimensionCategory: (
             { id: string, name: string, defaultColor: string }
             & { __typename: 'DimensionCategory' }
@@ -14717,25 +14885,7 @@ export type GetHomePageQuery = (
             & { __typename: 'IndicatorValue' }
           ) | null> }
           & { __typename: 'DashboardIndicatorChartSeries' }
-        ) | null> | null, dimension: (
-          { id: string, name: string, categories: Array<(
-            { id: string, name: string }
-            & { __typename: 'DimensionCategory' }
-          )> }
-          & { __typename: 'Dimension' }
-        ) | null, indicator: (
-          { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
-            { value: number, date: string | null }
-            & { __typename: 'IndicatorValue' }
-          ) | null, goals: Array<(
-            { value: number, date: string | null }
-            & { __typename: 'IndicatorGoal' }
-          ) | null> | null, unit: (
-            { name: string, shortName: string | null }
-            & { __typename: 'Unit' }
-          ) }
-          & { __typename: 'Indicator' }
-        ) | null }
+        ) | null> | null }
         & { __typename: 'DashboardIndicatorPieChartBlock' }
       ) | (
         { id: string | null, blockType: string, indicator: (
@@ -15601,6 +15751,111 @@ export type IndicatorDetailsQuery = (
         & { __typename: 'Person' }
       ) | null }
       & { __typename: 'ActionChangeLogMessage' | 'CategoryChangeLogMessage' | 'IndicatorChangeLogMessage' | 'PageChangeLogMessage' }
+    ) | null, defaultVisualization: (
+      { showTotalLine: boolean | null, indicator: (
+        { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+          { value: number, date: string | null }
+          & { __typename: 'IndicatorValue' }
+        ) | null, goals: Array<(
+          { value: number, date: string | null }
+          & { __typename: 'IndicatorGoal' }
+        ) | null> | null, unit: (
+          { name: string, shortName: string | null }
+          & { __typename: 'Unit' }
+        ) }
+        & { __typename: 'Indicator' }
+      ), dimension: (
+        { id: string, name: string, categories: Array<(
+          { id: string, name: string }
+          & { __typename: 'DimensionCategory' }
+        )> }
+        & { __typename: 'Dimension' }
+      ) | null, chartSeries: Array<(
+        { dimensionCategory: (
+          { id: string, name: string, defaultColor: string }
+          & { __typename: 'DimensionCategory' }
+        ) | null, values: Array<(
+          { id: string, value: number, date: string | null }
+          & { __typename: 'IndicatorValue' }
+        ) | null> }
+        & { __typename: 'DashboardIndicatorChartSeries' }
+      )> }
+      & { __typename: 'IndicatorDefaultAreaChart' | 'IndicatorDefaultLineChart' }
+    ) | (
+      { barType: string | null, indicator: (
+        { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+          { value: number, date: string | null }
+          & { __typename: 'IndicatorValue' }
+        ) | null, goals: Array<(
+          { value: number, date: string | null }
+          & { __typename: 'IndicatorGoal' }
+        ) | null> | null, unit: (
+          { name: string, shortName: string | null }
+          & { __typename: 'Unit' }
+        ) }
+        & { __typename: 'Indicator' }
+      ), dimension: (
+        { id: string, name: string, categories: Array<(
+          { id: string, name: string }
+          & { __typename: 'DimensionCategory' }
+        )> }
+        & { __typename: 'Dimension' }
+      ) | null, chartSeries: Array<(
+        { dimensionCategory: (
+          { id: string, name: string, defaultColor: string }
+          & { __typename: 'DimensionCategory' }
+        ) | null, values: Array<(
+          { id: string, value: number, date: string | null }
+          & { __typename: 'IndicatorValue' }
+        ) | null> }
+        & { __typename: 'DashboardIndicatorChartSeries' }
+      )> }
+      & { __typename: 'IndicatorDefaultBarChart' }
+    ) | (
+      { year: number | null, indicator: (
+        { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+          { value: number, date: string | null }
+          & { __typename: 'IndicatorValue' }
+        ) | null, goals: Array<(
+          { value: number, date: string | null }
+          & { __typename: 'IndicatorGoal' }
+        ) | null> | null, unit: (
+          { name: string, shortName: string | null }
+          & { __typename: 'Unit' }
+        ) }
+        & { __typename: 'Indicator' }
+      ), dimension: (
+        { id: string, name: string, categories: Array<(
+          { id: string, name: string }
+          & { __typename: 'DimensionCategory' }
+        )> }
+        & { __typename: 'Dimension' }
+      ) | null, chartSeries: Array<(
+        { dimensionCategory: (
+          { id: string, name: string, defaultColor: string }
+          & { __typename: 'DimensionCategory' }
+        ) | null, values: Array<(
+          { id: string, value: number, date: string | null }
+          & { __typename: 'IndicatorValue' }
+        ) | null> }
+        & { __typename: 'DashboardIndicatorChartSeries' }
+      )> }
+      & { __typename: 'IndicatorDefaultPieChart' }
+    ) | (
+      { indicator: (
+        { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+          { value: number, date: string | null }
+          & { __typename: 'IndicatorValue' }
+        ) | null, goals: Array<(
+          { value: number, date: string | null }
+          & { __typename: 'IndicatorGoal' }
+        ) | null> | null, unit: (
+          { name: string, shortName: string | null }
+          & { __typename: 'Unit' }
+        ) }
+        & { __typename: 'Indicator' }
+      ) }
+      & { __typename: 'IndicatorDefaultSummary' }
     ) | null }
     & { __typename: 'Indicator' }
   ) | null }

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -4615,6 +4615,25 @@ export type DashboardIndicatorFragmentFragment = (
   & { __typename: 'Indicator' }
 );
 
+export type ChartDimensionFragmentFragment = (
+  { id: string, name: string, categories: Array<(
+    { id: string, name: string }
+    & { __typename: 'DimensionCategory' }
+  )> }
+  & { __typename: 'Dimension' }
+);
+
+export type ChartSeriesFragmentFragment = (
+  { dimensionCategory: (
+    { id: string, name: string, defaultColor: string }
+    & { __typename: 'DimensionCategory' }
+  ) | null, values: Array<(
+    { id: string, value: number, date: string | null }
+    & { __typename: 'IndicatorValue' }
+  ) | null> }
+  & { __typename: 'DashboardIndicatorChartSeries' }
+);
+
 type BarChartVisualization_DashboardIndicatorBarChartBlock_Fragment = (
   { barType: string | null, indicator: (
     { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -6568,7 +6568,112 @@ export type GetActionDetailsQuery = (
         )>, plans: Array<(
           { id: string }
           & { __typename: 'Plan' }
-        )> }
+        )>, defaultVisualization: (
+          { showTotalLine: boolean | null, indicator: (
+            { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+              { value: number, date: string | null }
+              & { __typename: 'IndicatorValue' }
+            ) | null, goals: Array<(
+              { value: number, date: string | null }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          ), dimension: (
+            { id: string, name: string, categories: Array<(
+              { id: string, name: string }
+              & { __typename: 'DimensionCategory' }
+            )> }
+            & { __typename: 'Dimension' }
+          ) | null, chartSeries: Array<(
+            { dimensionCategory: (
+              { id: string, name: string, defaultColor: string }
+              & { __typename: 'DimensionCategory' }
+            ) | null, values: Array<(
+              { id: string, value: number, date: string | null }
+              & { __typename: 'IndicatorValue' }
+            ) | null> }
+            & { __typename: 'DashboardIndicatorChartSeries' }
+          )> }
+          & { __typename: 'IndicatorDefaultAreaChart' | 'IndicatorDefaultLineChart' }
+        ) | (
+          { barType: string | null, indicator: (
+            { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+              { value: number, date: string | null }
+              & { __typename: 'IndicatorValue' }
+            ) | null, goals: Array<(
+              { value: number, date: string | null }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          ), dimension: (
+            { id: string, name: string, categories: Array<(
+              { id: string, name: string }
+              & { __typename: 'DimensionCategory' }
+            )> }
+            & { __typename: 'Dimension' }
+          ) | null, chartSeries: Array<(
+            { dimensionCategory: (
+              { id: string, name: string, defaultColor: string }
+              & { __typename: 'DimensionCategory' }
+            ) | null, values: Array<(
+              { id: string, value: number, date: string | null }
+              & { __typename: 'IndicatorValue' }
+            ) | null> }
+            & { __typename: 'DashboardIndicatorChartSeries' }
+          )> }
+          & { __typename: 'IndicatorDefaultBarChart' }
+        ) | (
+          { year: number | null, indicator: (
+            { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+              { value: number, date: string | null }
+              & { __typename: 'IndicatorValue' }
+            ) | null, goals: Array<(
+              { value: number, date: string | null }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          ), dimension: (
+            { id: string, name: string, categories: Array<(
+              { id: string, name: string }
+              & { __typename: 'DimensionCategory' }
+            )> }
+            & { __typename: 'Dimension' }
+          ) | null, chartSeries: Array<(
+            { dimensionCategory: (
+              { id: string, name: string, defaultColor: string }
+              & { __typename: 'DimensionCategory' }
+            ) | null, values: Array<(
+              { id: string, value: number, date: string | null }
+              & { __typename: 'IndicatorValue' }
+            ) | null> }
+            & { __typename: 'DashboardIndicatorChartSeries' }
+          )> }
+          & { __typename: 'IndicatorDefaultPieChart' }
+        ) | (
+          { indicator: (
+            { id: string, name: string, description: string | null, showTrendline: boolean, valueRounding: number | null, minValue: number | null, maxValue: number | null, ticksCount: number | null, ticksRounding: number | null, timeResolution: IndicatorTimeResolution, dataCategoriesAreStackable: boolean, desiredTrend: IndicatorDesiredTrend | null, latestValue: (
+              { value: number, date: string | null }
+              & { __typename: 'IndicatorValue' }
+            ) | null, goals: Array<(
+              { value: number, date: string | null }
+              & { __typename: 'IndicatorGoal' }
+            ) | null> | null, unit: (
+              { name: string, shortName: string | null }
+              & { __typename: 'Unit' }
+            ) }
+            & { __typename: 'Indicator' }
+          ) }
+          & { __typename: 'IndicatorDefaultSummary' }
+        ) | null }
         & { __typename: 'Indicator' }
       ) }
       & { __typename: 'ActionIndicator' }
@@ -17885,6 +17990,17 @@ export type GetPledgeFeatureEnabledQuery = (
       { enableCommunityEngagement: boolean }
       & { __typename: 'PlanFeatures' }
     ) }
+    & { __typename: 'Plan' }
+  ) | null }
+  & { __typename: 'Query' }
+);
+
+export type TestPlanQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type TestPlanQuery = (
+  { plan: (
+    { id: string }
     & { __typename: 'Plan' }
   ) | null }
   & { __typename: 'Query' }

--- a/src/common/__generated__/paths/graphql.ts
+++ b/src/common/__generated__/paths/graphql.ts
@@ -56,11 +56,32 @@ export enum ChangeTargetKind {
   Unknown = 'UNKNOWN'
 }
 
+export type CreateDataPointCommentInput = {
+  isReview: Scalars['Boolean']['input'];
+  isSticky: Scalars['Boolean']['input'];
+  reviewState: InputMaybe<DataPointCommentReviewState>;
+  text: Scalars['String']['input'];
+};
+
 export type CreateDataPointInput = {
   date: Scalars['Date']['input'];
   dimensionCategoryIds: InputMaybe<Array<Scalars['UUID']['input']>>;
   metricId: Scalars['UUID']['input'];
   value: InputMaybe<Scalars['Float']['input']>;
+};
+
+export type CreateDataSourceInput = {
+  authority: InputMaybe<Scalars['String']['input']>;
+  description: InputMaybe<Scalars['String']['input']>;
+  edition: InputMaybe<Scalars['String']['input']>;
+  name: Scalars['String']['input'];
+  url: InputMaybe<Scalars['String']['input']>;
+};
+
+export type CreateDatasetSourceReferenceInput = {
+  dataPointId: InputMaybe<Scalars['UUID']['input']>;
+  dataSourceId: Scalars['UUID']['input'];
+  toDataset: Scalars['Boolean']['input'];
 };
 
 export type CreateDimensionCategoryInput = {
@@ -119,6 +140,17 @@ export type CreateScenarioInput = {
   kind: Scalars['String']['input'];
   name: Scalars['String']['input'];
 };
+
+export enum DataPointCommentReviewState {
+  Resolved = 'RESOLVED',
+  Unresolved = 'UNRESOLVED'
+}
+
+export enum DatasetSourceReferenceTarget {
+  All = 'ALL',
+  Dataset = 'DATASET',
+  DataPoint = 'DATA_POINT'
+}
 
 /** Which governance level is applicable for an action */
 export enum DecisionLevel {
@@ -201,6 +233,13 @@ export type InstanceContext = {
   preview: InputMaybe<PreviewMode>;
   version: InputMaybe<Scalars['UUID']['input']>;
 };
+
+export enum InstanceMemberRole {
+  Admin = 'ADMIN',
+  Reviewer = 'REVIEWER',
+  SuperAdmin = 'SUPER_ADMIN',
+  Viewer = 'VIEWER'
+}
 
 export enum LowHigh {
   High = 'HIGH',
@@ -305,7 +344,8 @@ export enum PrimaryLayoutClass {
 export type RegisterUserInput = {
   email: Scalars['String']['input'];
   firstName: InputMaybe<Scalars['String']['input']>;
-  frameworkId: Scalars['String']['input'];
+  frameworkId: InputMaybe<Scalars['ID']['input']>;
+  invitationToken: InputMaybe<Scalars['String']['input']>;
   lastName: InputMaybe<Scalars['String']['input']>;
   password: Scalars['String']['input'];
 };
@@ -334,11 +374,26 @@ export type SimpleConfigInput = {
   nodeClass: Scalars['String']['input'];
 };
 
+export type UpdateDataPointCommentInput = {
+  isReview: InputMaybe<Scalars['Boolean']['input']>;
+  isSticky: InputMaybe<Scalars['Boolean']['input']>;
+  reviewState: InputMaybe<DataPointCommentReviewState>;
+  text: InputMaybe<Scalars['String']['input']>;
+};
+
 export type UpdateDataPointInput = {
   date: InputMaybe<Scalars['Date']['input']>;
   dimensionCategoryIds: InputMaybe<Array<Scalars['UUID']['input']>>;
   metricId: InputMaybe<Scalars['UUID']['input']>;
   value: InputMaybe<Scalars['Float']['input']>;
+};
+
+export type UpdateDataSourceInput = {
+  authority: InputMaybe<Scalars['String']['input']>;
+  description: InputMaybe<Scalars['String']['input']>;
+  edition: InputMaybe<Scalars['String']['input']>;
+  name: InputMaybe<Scalars['String']['input']>;
+  url: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdateDimensionCategoryInput = {

--- a/src/common/__generated__/paths/possible_types.json
+++ b/src/common/__generated__/paths/possible_types.json
@@ -8,8 +8,21 @@
       "OperationInfo",
       "OutputPortType"
     ],
+    "AddUserToInstancePayload": [
+      "OperationInfo",
+      "User",
+      "UserNotFoundError"
+    ],
+    "CreateDataPointCommentPayload": [
+      "DataPointComment",
+      "OperationInfo"
+    ],
     "CreateDataPointPayload": [
       "DataPoint",
+      "OperationInfo"
+    ],
+    "CreateDataSourcePayload": [
+      "DataSource",
       "OperationInfo"
     ],
     "CreateDimensionCategoriesPayload": [
@@ -33,6 +46,14 @@
       "OperationInfo",
       "ScenarioType"
     ],
+    "CreateSourceReferencePayload": [
+      "DatasetSourceReference",
+      "OperationInfo"
+    ],
+    "DeleteDataSourcePayload": [
+      "ModelDeletePayload",
+      "OperationInfo"
+    ],
     "EdgeTransformationUnion": [
       "AssignCategoryTransformationType",
       "FlattenTransformationType",
@@ -47,6 +68,10 @@
     "InputPortBindingUnion": [
       "DatasetPortType",
       "NodeEdgeType"
+    ],
+    "InviteUserToInstancePayload": [
+      "InstanceInvitation",
+      "OperationInfo"
     ],
     "NodeConfigUnion": [
       "ActionConfigType",
@@ -79,6 +104,10 @@
     "RegisterUserPayload": [
       "OperationInfo",
       "RegisterUserResult"
+    ],
+    "ResolveDataPointCommentPayload": [
+      "DataPointComment",
+      "OperationInfo"
     ],
     "SetInstanceLockedPayload": [
       "OperationInfo",
@@ -126,8 +155,20 @@
       "TimeBlock",
       "URLBlock"
     ],
+    "UnresolveDataPointCommentPayload": [
+      "DataPointComment",
+      "OperationInfo"
+    ],
+    "UpdateDataPointCommentPayload": [
+      "DataPointComment",
+      "OperationInfo"
+    ],
     "UpdateDataPointPayload": [
       "DataPoint",
+      "OperationInfo"
+    ],
+    "UpdateDataSourcePayload": [
+      "DataSource",
       "OperationInfo"
     ],
     "UpdateDimensionCategoriesPayload": [

--- a/src/common/__generated__/possible_types.json
+++ b/src/common/__generated__/possible_types.json
@@ -345,10 +345,18 @@
       "TasksColumnBlock",
       "UpdatedAtColumnBlock"
     ],
+    "IndicatorAreaChartInterface": [
+      "DashboardIndicatorAreaChartBlock",
+      "IndicatorDefaultAreaChart"
+    ],
     "IndicatorAsideContentStream": [
       "IndicatorCategoryContentBlock",
       "IndicatorContentBlock",
       "IndicatorValueSummaryContentBlock"
+    ],
+    "IndicatorBarChartInterface": [
+      "DashboardIndicatorBarChartBlock",
+      "IndicatorDefaultBarChart"
     ],
     "IndicatorContentBlockInterface": [
       "IndicatorCategoryContentBlock",
@@ -357,8 +365,19 @@
       "IndicatorValueSummaryContentBlock",
       "IndicatorVisualizationContentBlock"
     ],
+    "IndicatorDefaultVisualization": [
+      "IndicatorDefaultAreaChart",
+      "IndicatorDefaultBarChart",
+      "IndicatorDefaultLineChart",
+      "IndicatorDefaultPieChart",
+      "IndicatorDefaultSummary"
+    ],
     "IndicatorFilterBlockInterface": [
       "IndicatorFilterBlock"
+    ],
+    "IndicatorLineChartInterface": [
+      "DashboardIndicatorLineChartBlock",
+      "IndicatorDefaultLineChart"
     ],
     "IndicatorListColumnInterface": [
       "IndicatorListColumn",
@@ -415,6 +434,14 @@
       "IndicatorFactorValueSummaryContentBlock",
       "IndicatorValueSummaryContentBlock",
       "IndicatorVisualizationContentBlock"
+    ],
+    "IndicatorPieChartInterface": [
+      "DashboardIndicatorPieChartBlock",
+      "IndicatorDefaultPieChart"
+    ],
+    "IndicatorSummaryInterface": [
+      "DashboardIndicatorSummaryBlock",
+      "IndicatorDefaultSummary"
     ],
     "MenuItem": [
       "ExternalLinkMenuItem",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,7 @@ import React, { useMemo } from 'react';
 import { usePathname } from 'next/navigation';
 
 import { useTheme } from '@emotion/react';
+
 import { useSession } from 'next-auth/react';
 import { useLocale } from 'next-intl';
 
@@ -25,6 +26,7 @@ import { useCustomComponent } from './paths/custom';
 
 type MainMenu = PlanContextFragment['mainMenu'];
 type MenuItem = NonNullable<PlanContextFragment['mainMenu']>['items'][number];
+type PageMenuItem = Extract<MenuItem, { __typename: 'PageMenuItem' }>;
 
 export type NavItem = {
   id: string;
@@ -32,15 +34,17 @@ export type NavItem = {
   slug: string;
   urlPath: string;
   active: boolean;
-  children: MenuItem[] | null;
+  children: NavItem[] | null;
 };
 
 export type NavItems = NavItem[] | null;
 
-const getMenuStructure = (pages: MenuItem[], rootId: string): NavItems => {
+const isPageMenuItem = (item: MenuItem): item is PageMenuItem => item.__typename === 'PageMenuItem';
+
+const getMenuStructure = (pages: PageMenuItem[], rootId: string): NavItems => {
   const menuLevelItems: NavItems = [];
   pages.forEach((page) => {
-    if (page.parent.id === rootId) {
+    if (page.parent?.id === rootId) {
       menuLevelItems.push({
         id: `${page.id}`,
         name: page.page.title,
@@ -71,7 +75,7 @@ const setActivePages = (navLinks, pathname, activeBranch) => {
 };
 
 function createLocalizeMenuItem(currentLocale: string, primaryLocale: string) {
-  return function (menuItem: MenuItem) {
+  return function (menuItem: PageMenuItem): PageMenuItem {
     if (currentLocale === primaryLocale) {
       return menuItem;
     }
@@ -101,21 +105,16 @@ function Header() {
     let links = [];
 
     const mainMenu = plan.mainMenu;
-    const pageMenuItems: MenuItem[] = mainMenu.items
-      .filter((item) => item?.__typename == 'PageMenuItem')
+    const pageMenuItems = mainMenu.items
+      .filter(isPageMenuItem)
       .map(createLocalizeMenuItem(locale, plan.primaryLanguage));
 
     if (pageMenuItems.length > 0) {
       // find one menu item with root as parent to access the id of the rootPage
       const rootItemIndex = pageMenuItems.findIndex(
-        (page) => page.parent.page.__typename === 'PlanRootPage'
+        (page) => page.parent?.page.__typename === 'PlanRootPage'
       );
-      const staticPages = getMenuStructure(
-        pageMenuItems,
-        pageMenuItems[rootItemIndex].parent.id,
-        pathname,
-        activeBranch
-      );
+      const staticPages = getMenuStructure(pageMenuItems, pageMenuItems[rootItemIndex].parent!.id);
       links = links.concat(staticPages);
     }
     return links;

--- a/src/components/actions/blocks/ActionRelatedIndicatorsBlock.tsx
+++ b/src/components/actions/blocks/ActionRelatedIndicatorsBlock.tsx
@@ -90,7 +90,11 @@ function ActionIndicator(props: ActionIndicatorProps) {
           </h3>
         </IndicatorLink>
         {indicator.latestGraph || indicator.latestValue ? (
-          <IndicatorVisualisation indicatorId={indicator.id} />
+          <IndicatorVisualisation
+            indicatorId={indicator.id}
+            useLegacyGraph={!indicator.defaultVisualization}
+            defaultVisualization={indicator.defaultVisualization}
+          />
         ) : null}
       </CardBody>
       {actions.length > 0 && (

--- a/src/components/contentblocks/DashboardIndicatorSummaryBlock.tsx
+++ b/src/components/contentblocks/DashboardIndicatorSummaryBlock.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+
 import { useLocale, useTranslations } from 'next-intl';
 
+import type { SummaryVisualizationFragment } from '@/common/__generated__/graphql';
 import useNumberFormatter from '@/common/numbers';
 import Icon from '@/components/common/Icon';
 
 import dayjs from '../../common/dayjs';
-import type { DashboardBlock } from './DashboardRowBlock';
 
 const Container = styled.div<{ $hasDescription?: boolean }>`
   padding: 0;
@@ -95,14 +96,12 @@ const ArrowWrapper = styled.div`
   }
 `;
 
-// Extract the DashboardIndicatorSummaryBlock from the union
-type DashboardIndicatorSummaryBlockType = Extract<
-  DashboardBlock,
+type DashboardSummaryBlock = Extract<
+  SummaryVisualizationFragment,
   { __typename: 'DashboardIndicatorSummaryBlock' }
 >;
 
-// Get the indicator type from it
-type IndicatorType = DashboardIndicatorSummaryBlockType['indicator'];
+type IndicatorType = DashboardSummaryBlock['indicator'];
 
 type DashboardIndicatorSummaryBlockProps = {
   indicator: IndicatorType;

--- a/src/components/contentblocks/DashboardRowBlock.tsx
+++ b/src/components/contentblocks/DashboardRowBlock.tsx
@@ -7,13 +7,9 @@ import { Col, Container, Row } from 'reactstrap';
 
 import type { StreamFieldFragmentFragment } from '@/common/__generated__/graphql';
 import { IndicatorLink } from '@/common/links';
+import IndicatorVisualizationDispatcher from '@/components/indicators/IndicatorVisualizationDispatcher';
 
 import Card from '../common/Card';
-import DashboardIndicatorSummaryBlockComponent from './DashboardIndicatorSummaryBlock';
-import DashboardIndicatorAreaChartBlockComponent from './indicator-chart/DashboardIndicatorAreaChartBlock';
-import DashboardIndicatorBarChartBlockComponent from './indicator-chart/DashboardIndicatorBarChartBlock';
-import DashboardIndicatorLineChartBlockComponent from './indicator-chart/DashboardIndicatorLineChartBlock';
-import DashboardIndicatorPieChartBlockComponent from './indicator-chart/DashboardIndicatorPieChartBlock';
 
 const DashboardRowSection = styled.div<{
   $topPadding?: boolean;
@@ -85,15 +81,11 @@ function getBlockComponent(block: DashboardBlock) {
     case 'DashboardParagraphBlock':
       return block.text ? <div dangerouslySetInnerHTML={{ __html: block.text }} /> : null;
     case 'DashboardIndicatorSummaryBlock':
-      return <DashboardIndicatorSummaryBlockComponent indicator={block.indicator} />;
     case 'DashboardIndicatorPieChartBlock':
-      return <DashboardIndicatorPieChartBlockComponent {...block} />;
     case 'DashboardIndicatorLineChartBlock':
-      return <DashboardIndicatorLineChartBlockComponent {...block} />;
     case 'DashboardIndicatorBarChartBlock':
-      return <DashboardIndicatorBarChartBlockComponent {...block} />;
     case 'DashboardIndicatorAreaChartBlock':
-      return <DashboardIndicatorAreaChartBlockComponent {...block} />;
+      return <IndicatorVisualizationDispatcher block={block} />;
     default:
       return null;
   }

--- a/src/components/contentblocks/DashboardRowBlock.tsx
+++ b/src/components/contentblocks/DashboardRowBlock.tsx
@@ -7,7 +7,7 @@ import { Col, Container, Row } from 'reactstrap';
 
 import type { StreamFieldFragmentFragment } from '@/common/__generated__/graphql';
 import { IndicatorLink } from '@/common/links';
-import IndicatorVisualizationDispatcher from '@/components/indicators/IndicatorVisualizationDispatcher';
+import IndicatorVisualizationBlock from '@/components/indicators/IndicatorVisualizationBlock';
 
 import Card from '../common/Card';
 
@@ -85,7 +85,7 @@ function getBlockComponent(block: DashboardBlock) {
     case 'DashboardIndicatorLineChartBlock':
     case 'DashboardIndicatorBarChartBlock':
     case 'DashboardIndicatorAreaChartBlock':
-      return <IndicatorVisualizationDispatcher block={block} />;
+      return <IndicatorVisualizationBlock block={block} />;
     default:
       return null;
   }

--- a/src/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
+++ b/src/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock.tsx
@@ -16,9 +16,9 @@ import { useTranslations } from 'next-intl';
 
 import { Chart, type ECOption } from '@common/components/Chart';
 
+import type { AreaChartVisualizationFragment } from '@/common/__generated__/graphql';
 import useNumberFormatter from '@/common/numbers';
 
-import type { DashboardBlock } from '../DashboardRowBlock';
 import { getDefaultColors } from './indicator-chart-colors';
 import {
   type GraphsTheme,
@@ -32,7 +32,10 @@ import {
 
 echarts.use([LineChart, GridComponent, TooltipComponent, LegendComponent]);
 
-type Props = Extract<DashboardBlock, { __typename: 'DashboardIndicatorAreaChartBlock' }>;
+type Props = Omit<
+  Extract<AreaChartVisualizationFragment, { __typename: 'DashboardIndicatorAreaChartBlock' }>,
+  '__typename'
+>;
 
 const DashboardIndicatorAreaChartBlock = ({ chartSeries, indicator, dimension }: Props) => {
   const theme = useTheme();

--- a/src/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
+++ b/src/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock.tsx
@@ -9,9 +9,9 @@ import { useTranslations } from 'next-intl';
 
 import { Chart, type ECOption } from '@common/components/Chart';
 
+import type { BarChartVisualizationFragment } from '@/common/__generated__/graphql';
 import useNumberFormatter from '@/common/numbers';
 
-import type { DashboardBlock } from '../DashboardRowBlock';
 import { getDefaultColors } from './indicator-chart-colors';
 import {
   type GraphsTheme,
@@ -24,7 +24,10 @@ import {
 
 echarts.use([BarChart, GridComponent, TooltipComponent, LegendComponent]);
 
-type Props = Extract<DashboardBlock, { __typename: 'DashboardIndicatorBarChartBlock' }>;
+type Props = Omit<
+  Extract<BarChartVisualizationFragment, { __typename: 'DashboardIndicatorBarChartBlock' }>,
+  '__typename'
+>;
 
 // FIX: Watch the card width so we can shrink the legend on small screens
 // (e.g. 3 charts per row) and keep more space for the bars—no scroll legend.

--- a/src/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock.tsx
+++ b/src/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock.tsx
@@ -11,9 +11,9 @@ import { useTranslations } from 'next-intl';
 
 import { Chart, type ECOption } from '@common/components/Chart';
 
+import type { LineChartVisualizationFragment } from '@/common/__generated__/graphql';
 import useNumberFormatter from '@/common/numbers';
 
-import type { DashboardBlock } from '../DashboardRowBlock';
 import { getDefaultColors } from './indicator-chart-colors';
 import {
   type GraphsTheme,
@@ -28,7 +28,10 @@ import {
 
 echarts.use([LineChart, ScatterChart, GridComponent, TooltipComponent, LegendComponent]);
 
-type Props = Extract<DashboardBlock, { __typename: 'DashboardIndicatorLineChartBlock' }>;
+type Props = Omit<
+  Extract<LineChartVisualizationFragment, { __typename: 'DashboardIndicatorLineChartBlock' }>,
+  '__typename'
+>;
 
 const DashboardIndicatorLineChartBlock = ({
   chartSeries,

--- a/src/components/contentblocks/indicator-chart/DashboardIndicatorPieChartBlock.tsx
+++ b/src/components/contentblocks/indicator-chart/DashboardIndicatorPieChartBlock.tsx
@@ -10,12 +10,16 @@ import type { CallbackDataParams } from 'echarts/types/dist/shared';
 
 import { Chart, type ECOption } from '@common/components/Chart';
 
-import type { DashboardBlock } from '../DashboardRowBlock';
+import type { PieChartVisualizationFragment } from '@/common/__generated__/graphql';
+
 import { getDefaultColors } from './indicator-chart-colors';
 
 echarts.use([PieChart, LegendComponent]);
 
-type Props = Extract<DashboardBlock, { __typename: 'DashboardIndicatorPieChartBlock' }>;
+type Props = Omit<
+  Extract<PieChartVisualizationFragment, { __typename: 'DashboardIndicatorPieChartBlock' }>,
+  '__typename'
+>;
 type IndicatorType = NonNullable<Props['indicator']>;
 type UnitType = IndicatorType['unit'];
 

--- a/src/components/contentblocks/indicator-chart/indicator-charts-utility.ts
+++ b/src/components/contentblocks/indicator-chart/indicator-charts-utility.ts
@@ -1,8 +1,10 @@
+import type { LineChartVisualizationFragment } from '@/common/__generated__/graphql';
 import { linearRegression } from '@/common/math';
 
-import type { DashboardBlock } from '../DashboardRowBlock';
-
-type LineChartBlock = Extract<DashboardBlock, { __typename: 'DashboardIndicatorLineChartBlock' }>;
+type LineChartBlock = Omit<
+  Extract<LineChartVisualizationFragment, { __typename: 'DashboardIndicatorLineChartBlock' }>,
+  '__typename'
+>;
 
 type TFunction = (key: string) => string;
 

--- a/src/components/graphs/legacy/IndicatorGraph.tsx
+++ b/src/components/graphs/legacy/IndicatorGraph.tsx
@@ -6,8 +6,9 @@ import dynamic from 'next/dynamic';
 
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+
 import { merge } from 'lodash-es';
-import type { Data, Layout, PlotData } from 'plotly.js';
+import type { Data, Datum, Layout, PlotData } from 'plotly.js';
 import { transparentize } from 'polished';
 
 import { splitLines } from '@/common/utils';
@@ -223,7 +224,7 @@ const createTraces: (params: CreateTracesParams) => TracesOutput = (params) => {
 
     // we have multiple categories in one time point - draw bar groups
     if (!hasTimeDimension) {
-      modTrace.x = modTrace.x.map((name) => splitLines(name));
+      modTrace.x = (modTrace.x as Datum[]).map((name) => splitLines(name as string));
       modTrace.type = 'bar';
       modTrace.marker = {
         color:

--- a/src/components/indicators/IndicatorContent.tsx
+++ b/src/components/indicators/IndicatorContent.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 
 import styled from '@emotion/styled';
+
 import { useTranslations } from 'next-intl';
 import { Col, Container, Row } from 'reactstrap';
 
@@ -203,6 +204,7 @@ function IndicatorContent({ indicator, layout, testId }: Props) {
                           showReference={true}
                           showGraph={showIndicatorGraph}
                           showTable={showIndicatorTable}
+                          defaultVisualization={indicator.defaultVisualization}
                         />
                       </GraphContainer>
                     </Col>

--- a/src/components/indicators/IndicatorModalContentBlock.tsx
+++ b/src/components/indicators/IndicatorModalContentBlock.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+
 import { upperFirst } from 'lodash-es';
 import { useFormatter, useTranslations } from 'next-intl';
 
@@ -119,6 +120,7 @@ const IndicatorContentBlock = (props: IndicatorContentBlockProps) => {
             showGraph={showIndicatorGraph}
             showTable={showIndicatorTable}
             showReference={false}
+            defaultVisualization={indicator.defaultVisualization}
           />
         </ContentBlockWrapper>
       );
@@ -425,6 +427,7 @@ const IndicatorModalContentBlock = ({
           showFactorValues={block.showFactorValues ?? false}
           showGraph={!(indicator.hideIndicatorGraph ?? false)}
           showTable={!(indicator.hideIndicatorTable ?? false)}
+          defaultVisualization={indicator.defaultVisualization}
         />
       );
 

--- a/src/components/indicators/IndicatorVisualisation.tsx
+++ b/src/components/indicators/IndicatorVisualisation.tsx
@@ -801,15 +801,17 @@ function IndicatorVisualisation({
        will be incorporated into IndicatorGraph.
      */
     graphComponent = (
-      <LegacyIndicatorGraph
-        specification={indicatorGraphSpecification}
-        yRange={yRange}
-        timeResolution={indicator.timeResolution}
-        traces={traces}
-        goalTraces={goalTraces}
-        trendTrace={trendTrace}
-        title={plotTitle}
-      />
+      <div aria-hidden="true">
+        <LegacyIndicatorGraph
+          specification={indicatorGraphSpecification}
+          yRange={yRange}
+          timeResolution={indicator.timeResolution}
+          traces={traces}
+          goalTraces={goalTraces}
+          trendTrace={trendTrace}
+          title={plotTitle}
+        />
+      </div>
     );
   } else if (defaultVisualization && !compareTo && !normalizeByPopulation) {
     /* TODO: A generalized IndicatorGraph component
@@ -824,26 +826,32 @@ function IndicatorVisualisation({
        Also, IndicatorVisualizationDispatcher now only supports the simplified
        one-dimensioned data received straight from the backend.
      */
-    graphComponent = <IndicatorVisualizationDispatcher block={defaultVisualization} />;
+    graphComponent = (
+      <div aria-hidden={showTable}>
+        <IndicatorVisualizationDispatcher block={defaultVisualization} />
+      </div>
+    );
   } else {
     /* TODO: Generalize graphComponent to be the basis of all graphs. */
     graphComponent = (
       // TODO: Show title depending on context
-      <IndicatorGraph
-        specification={indicatorGraphSpecification}
-        yRange={yRange}
-        timeResolution={indicator.timeResolution}
-        traces={traces}
-        goalTraces={goalTraces}
-        trendTrace={trendTrace}
-        title={null}
-        desiredTrend={indicator.desiredTrend}
-        referenceValue={indicator.referenceValue}
-        nonQuantifiedGoal={{
-          trend: indicator.nonQuantifiedGoal,
-          date: indicator.nonQuantifiedGoalDate,
-        }}
-      />
+      <div aria-hidden={showTable}>
+        <IndicatorGraph
+          specification={indicatorGraphSpecification}
+          yRange={yRange}
+          timeResolution={indicator.timeResolution}
+          traces={traces}
+          goalTraces={goalTraces}
+          trendTrace={trendTrace}
+          title={null}
+          desiredTrend={indicator.desiredTrend}
+          referenceValue={indicator.referenceValue}
+          nonQuantifiedGoal={{
+            trend: indicator.nonQuantifiedGoal,
+            date: indicator.nonQuantifiedGoalDate,
+          }}
+        />
+      </div>
     );
   }
 
@@ -868,7 +876,7 @@ function IndicatorVisualisation({
           currentValue={normalizeByPopulation}
         />
       )}
-      {showGraph && <div aria-hidden="true">{graphComponent}</div>}
+      {showGraph && graphComponent}
       {showTable && (
         <GraphAsTable
           specification={yRange}

--- a/src/components/indicators/IndicatorVisualisation.tsx
+++ b/src/components/indicators/IndicatorVisualisation.tsx
@@ -28,7 +28,7 @@ import { usePlan } from '@/context/plan';
 import { GET_INDICATOR_GRAPH_DATA } from '@/queries/get-indicator-graph-data';
 
 import RichText from '../common/RichText';
-import IndicatorVisualizationDispatcher from './IndicatorVisualizationDispatcher';
+import IndicatorVisualizationBlock from './IndicatorVisualizationBlock';
 
 function generateCube(dimensions, values, path) {
   const dim = dimensions[0];
@@ -816,19 +816,19 @@ function IndicatorVisualisation({
   } else if (defaultVisualization && !compareTo && !normalizeByPopulation) {
     /* TODO: A generalized IndicatorGraph component
        will be the internal implementation of the
-       graph component that IndicatorVisualizationDispatcher
+       graph component that IndicatorVisualizationBlock
        dispatches to -- and also of all the
        Indicator Visualization Blocks.
 
        Currently, the block implementations are in use
        and they do not support normalization or comparison.
 
-       Also, IndicatorVisualizationDispatcher now only supports the simplified
+       Also, IndicatorVisualizationBlock now only supports the simplified
        one-dimensioned data received straight from the backend.
      */
     graphComponent = (
       <div aria-hidden={showTable}>
-        <IndicatorVisualizationDispatcher block={defaultVisualization} />
+        <IndicatorVisualizationBlock block={defaultVisualization} />
       </div>
     );
   } else {

--- a/src/components/indicators/IndicatorVisualisation.tsx
+++ b/src/components/indicators/IndicatorVisualisation.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
+import React, { type ReactElement, useMemo, useState } from 'react';
 
 import styled from '@emotion/styled';
 
@@ -13,6 +13,7 @@ import { Alert } from 'reactstrap';
 import ContentLoader from '@common/components/ContentLoader';
 
 import type {
+  IndicatorDetailsQuery,
   IndicatorGraphDataQuery,
   IndicatorGraphDataQueryVariables,
 } from '@/common/__generated__/graphql';
@@ -27,6 +28,7 @@ import { usePlan } from '@/context/plan';
 import { GET_INDICATOR_GRAPH_DATA } from '@/queries/get-indicator-graph-data';
 
 import RichText from '../common/RichText';
+import IndicatorVisualizationDispatcher from './IndicatorVisualizationDispatcher';
 
 function generateCube(dimensions, values, path) {
   const dim = dimensions[0];
@@ -390,6 +392,9 @@ function normalizeValuesByNormalizer(values, normalizerId) {
   );
 }
 
+type IndicatorDetailsIndicator = NonNullable<IndicatorDetailsQuery['indicator']>;
+type DefaultVisualization = IndicatorDetailsIndicator['defaultVisualization'];
+
 export type IndicatorVisualisationProps = {
   indicatorId: string;
   indicatorLink?: string;
@@ -398,6 +403,7 @@ export type IndicatorVisualisationProps = {
   showGraph?: boolean;
   showTable?: boolean;
   showFactorValues?: boolean;
+  defaultVisualization?: DefaultVisualization;
 };
 
 const FactorChartTitle = styled.div`
@@ -544,6 +550,7 @@ function IndicatorVisualisation({
   showGraph = true,
   showTable = true,
   showFactorValues = false,
+  defaultVisualization,
 }: IndicatorVisualisationProps) {
   const plan = usePlan();
   const enableIndicatorComparison = plan.features.enableIndicatorComparison === true;
@@ -788,6 +795,58 @@ function IndicatorVisualisation({
     .map((common) => common.organization)
     .filter((org) => org.id !== indicator.organization.id);
 
+  let graphComponent: ReactElement;
+  if (useLegacyGraph) {
+    /* TODO: All of the features still in use in LegacyIndicatorGraph
+       will be incorporated into IndicatorGraph.
+     */
+    graphComponent = (
+      <LegacyIndicatorGraph
+        specification={indicatorGraphSpecification}
+        yRange={yRange}
+        timeResolution={indicator.timeResolution}
+        traces={traces}
+        goalTraces={goalTraces}
+        trendTrace={trendTrace}
+        title={plotTitle}
+      />
+    );
+  } else if (defaultVisualization && !compareTo && !normalizeByPopulation) {
+    /* TODO: A generalized IndicatorGraph component
+       will be the internal implementation of the
+       graph component that IndicatorVisualizationDispatcher
+       dispatches to -- and also of all the
+       Indicator Visualization Blocks.
+
+       Currently, the block implementations are in use
+       and they do not support normalization or comparison.
+
+       Also, IndicatorVisualizationDispatcher now only supports the simplified
+       one-dimensioned data received straight from the backend.
+     */
+    graphComponent = <IndicatorVisualizationDispatcher block={defaultVisualization} />;
+  } else {
+    /* TODO: Generalize graphComponent to be the basis of all graphs. */
+    graphComponent = (
+      // TODO: Show title depending on context
+      <IndicatorGraph
+        specification={indicatorGraphSpecification}
+        yRange={yRange}
+        timeResolution={indicator.timeResolution}
+        traces={traces}
+        goalTraces={goalTraces}
+        trendTrace={trendTrace}
+        title={null}
+        desiredTrend={indicator.desiredTrend}
+        referenceValue={indicator.referenceValue}
+        nonQuantifiedGoal={{
+          trend: indicator.nonQuantifiedGoal,
+          date: indicator.nonQuantifiedGoalDate,
+        }}
+      />
+    );
+  }
+
   return (
     <div>
       {indicatorLink && (
@@ -809,38 +868,7 @@ function IndicatorVisualisation({
           currentValue={normalizeByPopulation}
         />
       )}
-      {showGraph && (
-        <div aria-hidden="true">
-          {useLegacyGraph ? (
-            <LegacyIndicatorGraph
-              specification={indicatorGraphSpecification}
-              yRange={yRange}
-              timeResolution={indicator.timeResolution}
-              traces={traces}
-              goalTraces={goalTraces}
-              trendTrace={trendTrace}
-              title={plotTitle}
-            />
-          ) : (
-            // TODO: Show title depending on context
-            <IndicatorGraph
-              specification={indicatorGraphSpecification}
-              yRange={yRange}
-              timeResolution={indicator.timeResolution}
-              traces={traces}
-              goalTraces={goalTraces}
-              trendTrace={trendTrace}
-              title={null}
-              desiredTrend={indicator.desiredTrend}
-              referenceValue={indicator.referenceValue}
-              nonQuantifiedGoal={{
-                trend: indicator.nonQuantifiedGoal,
-                date: indicator.nonQuantifiedGoalDate,
-              }}
-            />
-          )}
-        </div>
-      )}
+      {showGraph && <div aria-hidden="true">{graphComponent}</div>}
       {showTable && (
         <GraphAsTable
           specification={yRange}

--- a/src/components/indicators/IndicatorVisualizationBlock.tsx
+++ b/src/components/indicators/IndicatorVisualizationBlock.tsx
@@ -11,7 +11,7 @@ import DashboardIndicatorBarChartBlock from '@/components/contentblocks/indicato
 import DashboardIndicatorLineChartBlock from '@/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock';
 import DashboardIndicatorPieChartBlock from '@/components/contentblocks/indicator-chart/DashboardIndicatorPieChartBlock';
 
-export type IndicatorVisualizationDispatcherData =
+export type IndicatorVisualizationBlockData =
   | BarChartVisualizationFragment
   | LineChartVisualizationFragment
   | AreaChartVisualizationFragment
@@ -19,10 +19,10 @@ export type IndicatorVisualizationDispatcherData =
   | SummaryVisualizationFragment;
 
 interface Props {
-  block: IndicatorVisualizationDispatcherData;
+  block: IndicatorVisualizationBlockData;
 }
 
-const IndicatorVisualizationDispatcher = ({ block }: Props) => {
+const IndicatorVisualizationBlock = ({ block }: Props) => {
   switch (block.__typename) {
     case 'DashboardIndicatorBarChartBlock':
     case 'IndicatorDefaultBarChart': {
@@ -52,4 +52,4 @@ const IndicatorVisualizationDispatcher = ({ block }: Props) => {
   }
 };
 
-export default IndicatorVisualizationDispatcher;
+export default IndicatorVisualizationBlock;

--- a/src/components/indicators/IndicatorVisualizationDispatcher.tsx
+++ b/src/components/indicators/IndicatorVisualizationDispatcher.tsx
@@ -1,0 +1,55 @@
+import type {
+  AreaChartVisualizationFragment,
+  BarChartVisualizationFragment,
+  LineChartVisualizationFragment,
+  PieChartVisualizationFragment,
+  SummaryVisualizationFragment,
+} from '@/common/__generated__/graphql';
+import DashboardIndicatorSummaryBlock from '@/components/contentblocks/DashboardIndicatorSummaryBlock';
+import DashboardIndicatorAreaChartBlock from '@/components/contentblocks/indicator-chart/DashboardIndicatorAreaChartBlock';
+import DashboardIndicatorBarChartBlock from '@/components/contentblocks/indicator-chart/DashboardIndicatorBarChartBlock';
+import DashboardIndicatorLineChartBlock from '@/components/contentblocks/indicator-chart/DashboardIndicatorLineChartBlock';
+import DashboardIndicatorPieChartBlock from '@/components/contentblocks/indicator-chart/DashboardIndicatorPieChartBlock';
+
+export type IndicatorVisualizationDispatcherData =
+  | BarChartVisualizationFragment
+  | LineChartVisualizationFragment
+  | AreaChartVisualizationFragment
+  | PieChartVisualizationFragment
+  | SummaryVisualizationFragment;
+
+interface Props {
+  block: IndicatorVisualizationDispatcherData;
+}
+
+const IndicatorVisualizationDispatcher = ({ block }: Props) => {
+  switch (block.__typename) {
+    case 'DashboardIndicatorBarChartBlock':
+    case 'IndicatorDefaultBarChart': {
+      const { __typename, ...rest } = block;
+      return <DashboardIndicatorBarChartBlock {...rest} />;
+    }
+    case 'DashboardIndicatorLineChartBlock':
+    case 'IndicatorDefaultLineChart': {
+      const { __typename, ...rest } = block;
+      return <DashboardIndicatorLineChartBlock {...rest} />;
+    }
+    case 'DashboardIndicatorAreaChartBlock':
+    case 'IndicatorDefaultAreaChart': {
+      const { __typename, ...rest } = block;
+      return <DashboardIndicatorAreaChartBlock {...rest} />;
+    }
+    case 'DashboardIndicatorPieChartBlock':
+    case 'IndicatorDefaultPieChart': {
+      const { __typename, ...rest } = block;
+      return <DashboardIndicatorPieChartBlock {...rest} />;
+    }
+    case 'DashboardIndicatorSummaryBlock':
+    case 'IndicatorDefaultSummary':
+      return <DashboardIndicatorSummaryBlock indicator={block.indicator} />;
+    default:
+      return null;
+  }
+};
+
+export default IndicatorVisualizationDispatcher;

--- a/src/fragments/dashboard-indicator-block.fragment.ts
+++ b/src/fragments/dashboard-indicator-block.fragment.ts
@@ -1,33 +1,8 @@
 import { gql } from '@apollo/client';
 
-export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
-  fragment DashboardIndicatorFragment on Indicator {
-    id
-    name
-    description
-    showTrendline
-    valueRounding
-    minValue
-    maxValue
-    ticksCount
-    ticksRounding
-    timeResolution
-    latestValue {
-      value
-      date
-    }
-    dataCategoriesAreStackable
-    goals {
-      value
-      date
-    }
-    unit {
-      name
-      shortName
-    }
-    desiredTrend
-  }
+import { INDICATOR_CHART_FRAGMENTS } from './indicator-chart.fragment';
 
+export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
   fragment DashboardIndicatorBlockFragment on DashboardRowBlock {
     blockType
     blocks {
@@ -39,125 +14,33 @@ export const DASHBOARD_INDICATOR_BLOCK_FRAGMENT = gql`
 
       ... on DashboardIndicatorPieChartBlock {
         helpText
-        year
-        chartSeries {
-          dimensionCategory {
-            id
-            name
-            defaultColor
-          }
-          values {
-            id
-            value
-            date
-          }
-        }
-        dimension {
-          id
-          name
-          categories {
-            id
-            name
-          }
-        }
-        indicator {
-          ...DashboardIndicatorFragment
-        }
+        ...PieChartVisualization
       }
 
       ... on DashboardIndicatorLineChartBlock {
         id
         helpText
-        showTotalLine
-        chartSeries {
-          dimensionCategory {
-            id
-            name
-            defaultColor
-          }
-          values {
-            id
-            value
-            date
-          }
-        }
-        dimension {
-          id
-          name
-          categories {
-            id
-            name
-          }
-        }
-        indicator {
-          ...DashboardIndicatorFragment
-        }
+        ...LineChartVisualization
       }
 
       ... on DashboardIndicatorAreaChartBlock {
         id
         helpText
-        chartSeries {
-          dimensionCategory {
-            id
-            name
-            defaultColor
-          }
-          values {
-            id
-            value
-            date
-          }
-        }
-        dimension {
-          id
-          name
-          categories {
-            id
-            name
-          }
-        }
-        indicator {
-          ...DashboardIndicatorFragment
-        }
+        ...AreaChartVisualization
       }
 
       ... on DashboardIndicatorBarChartBlock {
         id
-        barType
         helpText
-        chartSeries {
-          dimensionCategory {
-            id
-            name
-            defaultColor
-          }
-          values {
-            id
-            value
-            date
-          }
-        }
-        dimension {
-          id
-          name
-          categories {
-            id
-            name
-          }
-        }
-        indicator {
-          ...DashboardIndicatorFragment
-        }
+        ...BarChartVisualization
       }
 
       ... on DashboardIndicatorSummaryBlock {
         id
         blockType
-        indicator {
-          ...DashboardIndicatorFragment
-        }
+        ...SummaryVisualization
       }
     }
   }
+  ${INDICATOR_CHART_FRAGMENTS}
 `;

--- a/src/fragments/indicator-chart.fragment.ts
+++ b/src/fragments/indicator-chart.fragment.ts
@@ -28,30 +28,38 @@ export const INDICATOR_CHART_FRAGMENTS = gql`
     desiredTrend
   }
 
+  fragment ChartDimensionFragment on Dimension {
+    id
+    name
+    categories {
+      id
+      name
+    }
+  }
+
+  fragment ChartSeriesFragment on DashboardIndicatorChartSeries {
+    dimensionCategory {
+      id
+      name
+      defaultColor
+    }
+    values {
+      id
+      value
+      date
+    }
+  }
+
   fragment BarChartVisualization on IndicatorBarChartInterface {
     indicator {
       ...DashboardIndicatorFragment
     }
     dimension {
-      id
-      name
-      categories {
-        id
-        name
-      }
+      ...ChartDimensionFragment
     }
     barType
     chartSeries {
-      dimensionCategory {
-        id
-        name
-        defaultColor
-      }
-      values {
-        id
-        value
-        date
-      }
+      ...ChartSeriesFragment
     }
   }
 
@@ -60,25 +68,11 @@ export const INDICATOR_CHART_FRAGMENTS = gql`
       ...DashboardIndicatorFragment
     }
     dimension {
-      id
-      name
-      categories {
-        id
-        name
-      }
+      ...ChartDimensionFragment
     }
     showTotalLine
     chartSeries {
-      dimensionCategory {
-        id
-        name
-        defaultColor
-      }
-      values {
-        id
-        value
-        date
-      }
+      ...ChartSeriesFragment
     }
   }
 
@@ -87,25 +81,11 @@ export const INDICATOR_CHART_FRAGMENTS = gql`
       ...DashboardIndicatorFragment
     }
     dimension {
-      id
-      name
-      categories {
-        id
-        name
-      }
+      ...ChartDimensionFragment
     }
     showTotalLine
     chartSeries {
-      dimensionCategory {
-        id
-        name
-        defaultColor
-      }
-      values {
-        id
-        value
-        date
-      }
+      ...ChartSeriesFragment
     }
   }
 
@@ -114,25 +94,11 @@ export const INDICATOR_CHART_FRAGMENTS = gql`
       ...DashboardIndicatorFragment
     }
     dimension {
-      id
-      name
-      categories {
-        id
-        name
-      }
+      ...ChartDimensionFragment
     }
     year
     chartSeries {
-      dimensionCategory {
-        id
-        name
-        defaultColor
-      }
-      values {
-        id
-        value
-        date
-      }
+      ...ChartSeriesFragment
     }
   }
 

--- a/src/fragments/indicator-chart.fragment.ts
+++ b/src/fragments/indicator-chart.fragment.ts
@@ -1,0 +1,144 @@
+import { gql } from '@apollo/client';
+
+export const INDICATOR_CHART_FRAGMENTS = gql`
+  fragment DashboardIndicatorFragment on Indicator {
+    id
+    name
+    description
+    showTrendline
+    valueRounding
+    minValue
+    maxValue
+    ticksCount
+    ticksRounding
+    timeResolution
+    latestValue {
+      value
+      date
+    }
+    dataCategoriesAreStackable
+    goals {
+      value
+      date
+    }
+    unit {
+      name
+      shortName
+    }
+    desiredTrend
+  }
+
+  fragment BarChartVisualization on IndicatorBarChartInterface {
+    indicator {
+      ...DashboardIndicatorFragment
+    }
+    dimension {
+      id
+      name
+      categories {
+        id
+        name
+      }
+    }
+    barType
+    chartSeries {
+      dimensionCategory {
+        id
+        name
+        defaultColor
+      }
+      values {
+        id
+        value
+        date
+      }
+    }
+  }
+
+  fragment LineChartVisualization on IndicatorLineChartInterface {
+    indicator {
+      ...DashboardIndicatorFragment
+    }
+    dimension {
+      id
+      name
+      categories {
+        id
+        name
+      }
+    }
+    showTotalLine
+    chartSeries {
+      dimensionCategory {
+        id
+        name
+        defaultColor
+      }
+      values {
+        id
+        value
+        date
+      }
+    }
+  }
+
+  fragment AreaChartVisualization on IndicatorAreaChartInterface {
+    indicator {
+      ...DashboardIndicatorFragment
+    }
+    dimension {
+      id
+      name
+      categories {
+        id
+        name
+      }
+    }
+    showTotalLine
+    chartSeries {
+      dimensionCategory {
+        id
+        name
+        defaultColor
+      }
+      values {
+        id
+        value
+        date
+      }
+    }
+  }
+
+  fragment PieChartVisualization on IndicatorPieChartInterface {
+    indicator {
+      ...DashboardIndicatorFragment
+    }
+    dimension {
+      id
+      name
+      categories {
+        id
+        name
+      }
+    }
+    year
+    chartSeries {
+      dimensionCategory {
+        id
+        name
+        defaultColor
+      }
+      values {
+        id
+        value
+        date
+      }
+    }
+  }
+
+  fragment SummaryVisualization on IndicatorSummaryInterface {
+    indicator {
+      ...DashboardIndicatorFragment
+    }
+  }
+`;

--- a/src/queries/get-action.ts
+++ b/src/queries/get-action.ts
@@ -15,6 +15,7 @@ import {
 import { ACTION_CARD_FRAGMENT } from '../fragments/action-card.fragment';
 import { CATEGORY_TYPE_FRAGMENT } from '../fragments/category-tags.fragment';
 import { RECURSIVE_CATEGORY_FRAGMENT } from '../fragments/category.fragment';
+import { INDICATOR_CHART_FRAGMENTS } from '../fragments/indicator-chart.fragment';
 import { getClient } from '../utils/apollo-rsc-client';
 
 export const getActionDetails = async (
@@ -186,6 +187,28 @@ const GET_ACTION_DETAILS = gql`
           }
           plans {
             id
+          }
+          defaultVisualization {
+            ... on IndicatorDefaultBarChart {
+              __typename
+              ...BarChartVisualization
+            }
+            ... on IndicatorDefaultLineChart {
+              __typename
+              ...LineChartVisualization
+            }
+            ... on IndicatorDefaultAreaChart {
+              __typename
+              ...AreaChartVisualization
+            }
+            ... on IndicatorDefaultPieChart {
+              __typename
+              ...PieChartVisualization
+            }
+            ... on IndicatorDefaultSummary {
+              __typename
+              ...SummaryVisualization
+            }
           }
         }
       }
@@ -547,4 +570,5 @@ const GET_ACTION_DETAILS = gql`
   ${ATTRIBUTE_WITH_NESTED_TYPE_FRAGMENT}
   ${RECURSIVE_CATEGORY_FRAGMENT}
   ${CATEGORY_TYPE_FRAGMENT}
+  ${INDICATOR_CHART_FRAGMENTS}
 `;

--- a/src/queries/get-indicator.ts
+++ b/src/queries/get-indicator.ts
@@ -2,6 +2,7 @@ import { gql } from '@apollo/client';
 
 import { CATEGORY_TYPE_FRAGMENT } from '../fragments/category-tags.fragment';
 import { RECURSIVE_CATEGORY_TAG_FRAGMENT } from '../fragments/category.fragment';
+import { INDICATOR_CHART_FRAGMENTS } from '../fragments/indicator-chart.fragment';
 
 export const GET_INDICATOR_DETAILS = gql`
   query IndicatorDetails($id: ID, $plan: ID, $sitePlan: ID) {
@@ -258,6 +259,28 @@ export const GET_INDICATOR_DETAILS = gql`
         }
         updatedAt
       }
+      defaultVisualization {
+        ... on IndicatorDefaultBarChart {
+          __typename
+          ...BarChartVisualization
+        }
+        ... on IndicatorDefaultLineChart {
+          __typename
+          ...LineChartVisualization
+        }
+        ... on IndicatorDefaultAreaChart {
+          __typename
+          ...AreaChartVisualization
+        }
+        ... on IndicatorDefaultPieChart {
+          __typename
+          ...PieChartVisualization
+        }
+        ... on IndicatorDefaultSummary {
+          __typename
+          ...SummaryVisualization
+        }
+      }
     }
   }
 
@@ -335,4 +358,5 @@ export const GET_INDICATOR_DETAILS = gql`
   }
   ${RECURSIVE_CATEGORY_TAG_FRAGMENT}
   ${CATEGORY_TYPE_FRAGMENT}
+  ${INDICATOR_CHART_FRAGMENTS}
 `;


### PR DESCRIPTION
## Description

In the backend it will be possible to set some configuration for the default visualization of an indicator (chart type, some chart related configurations). These will be used in the Indicator Details Page main visualization block, and, also an action's related indicator charts.

## Screenshots/Videos (if applicable)

Indicator Details Page
<img width="1041" height="839" alt="image" src="https://github.com/user-attachments/assets/091348ba-d8f5-41ea-b11a-546a26f6aeb9" />


Action Details Page (related indicators):

<img width="1075" height="531" alt="image" src="https://github.com/user-attachments/assets/905c6b74-b2da-4a8b-93b7-9c6b9aa23bcf" />

## Related issue

https://app.asana.com/1/1201243246741462/project/1202854091946984/task/1211406907985442?focus=true

## Requirements, dependencies and related PRs

Merge first! :arrow_down: 

[Backend PR](https://github.com/kausaltech/kausal-watch/pull/586)


## Additional Notes

There is some refactoring and migrating work left to be done to remove some duplication with the new eCharts -style chart components (merge IndicatorChart with the block chart implementations) and to remove the legacy charts (needs some testing framework effort). The plan for those is ready but the scope was too large for this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [X] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [X] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

Do not merge before backend is merged