### PR TITLE
Fix/site name and og title

### DIFF
--- a/e2e-tests/common/context.ts
+++ b/e2e-tests/common/context.ts
@@ -344,7 +344,8 @@ export class PlanContext {
     if (this.plan.parent?.name) {
       await expect(siteName).toHaveAttribute('content', this.plan.parent?.name);
     } else {
-      await expect(siteName).toHaveAttribute('content', this.plan.generalContent.siteTitle);
+      const expected = this.plan.generalContent.siteTitle || this.plan.name;
+      await expect(siteName).toHaveAttribute('content', expected);
     }
   }
 

--- a/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/page.tsx
+++ b/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/page.tsx
@@ -33,9 +33,11 @@ export async function generateMetadata(props: Props, parent: ResolvingMetadata):
     title: `${data.planPage.title} | ${resolvedParent.title?.absolute}`,
     description: getMetaDescription(data.planPage),
     openGraph: {
+      type: 'website',
       title: `${data.planPage.title} | ${resolvedParent.openGraph?.title?.absolute}`,
       url: resolvedParent.openGraph?.url ?? undefined,
-      images: metaImage ? [metaImage] : undefined,
+      images: metaImage ? [metaImage] : (resolvedParent.openGraph?.images ?? undefined),
+      siteName: resolvedParent.openGraph?.siteName ?? undefined,
     },
   };
 }

--- a/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/actions/[id]/page.tsx
+++ b/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/actions/[id]/page.tsx
@@ -56,9 +56,12 @@ export async function generateMetadata(props: Props, parent: ResolvingMetadata):
     title: `${title} | ${resolvedParent.title?.absolute}`,
     description: data.action.name,
     openGraph: {
+      type: 'website',
       title: `${title} | ${resolvedParent.openGraph?.title?.absolute}`,
       description: data.action.name,
-      images: image?.social?.src ? [image.social.src] : undefined,
+      images: image?.social?.src
+        ? [image.social.src]
+        : (resolvedParent.openGraph?.images ?? undefined),
       url: resolvedParent.openGraph?.url ?? undefined,
       siteName: resolvedParent.openGraph?.siteName ?? undefined,
     },

--- a/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/indicators/[id]/page.tsx
+++ b/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/indicators/[id]/page.tsx
@@ -38,8 +38,11 @@ export async function generateMetadata(props: Props, parent: ResolvingMetadata):
   return {
     title: `${name} | ${resolvedParent.title?.absolute}`,
     openGraph: {
+      type: 'website',
       title: `${name} | ${resolvedParent.openGraph?.title?.absolute}`,
       url: resolvedParent.openGraph?.url ?? undefined,
+      images: resolvedParent.openGraph?.images ?? undefined,
+      siteName: resolvedParent.openGraph?.siteName ?? undefined,
     },
   };
 }


### PR DESCRIPTION
Fix some e2e test where in some cases the site name was not tested according to specs and also where we failed to set some OpenGraph metadata in specific navigation situations.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [ ] Set the PR's label to match the nature of this change

### Testing

- [X] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [ ] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
