### PR TITLE
Fix/mobile dropdown overlap

### DIFF
--- a/src/components/common/GlobalNav.tsx
+++ b/src/components/common/GlobalNav.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { css, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+
 import type { Theme } from '@kausal/themes/types';
 import { useScrollPosition } from '@n8tb1t/use-scroll-position';
 import debounce from 'lodash-es/debounce';
@@ -369,10 +370,34 @@ const StyledDropdown = styled(UncontrolledDropdown)`
   }
 `;
 
+const DropdownMenuWrapper = styled.div`
+  position: static;
+
+  @media (min-width: ${(props) => props.theme.breakpointMd}) {
+    position: absolute;
+  }
+`;
+
 const StyledDropdownMenu = styled(DropdownMenu)`
-  min-width: 260px;
+  min-width: 0;
+  width: 100%;
+
+  &.dropdown-menu {
+    position: static;
+    transform: none !important;
+  }
+
   &.dropdown-menu[data-bs-popper] {
     top: unset;
+  }
+
+  @media (min-width: ${(props) => props.theme.breakpointMd}) {
+    min-width: 260px;
+    width: auto;
+
+    &.dropdown-menu {
+      position: absolute;
+    }
   }
 `;
 
@@ -437,7 +462,7 @@ function DropdownList(props) {
           {parentName}
         </NavHighlighter>
       </StyledDropdownToggle>
-      <div style={{ position: 'absolute' }}>
+      <DropdownMenuWrapper>
         <StyledDropdownMenu>
           {items &&
             items.map((child) => (
@@ -450,7 +475,7 @@ function DropdownList(props) {
               </DropdownItem>
             ))}
         </StyledDropdownMenu>
-      </div>
+      </DropdownMenuWrapper>
     </StyledDropdown>
   );
 }

--- a/src/components/common/GlobalNav.tsx
+++ b/src/components/common/GlobalNav.tsx
@@ -391,12 +391,20 @@ const StyledDropdownMenu = styled(DropdownMenu)`
     top: unset;
   }
 
+  .dropdown-item {
+    width: auto;
+  }
+
   @media (min-width: ${(props) => props.theme.breakpointMd}) {
     min-width: 260px;
     width: auto;
 
     &.dropdown-menu {
       position: absolute;
+    }
+
+    .dropdown-item {
+      width: 100%;
     }
   }
 `;


### PR DESCRIPTION
## Description

Fix the language selector overlapping the expanded dropdown navigation menu on mobile.

* Set the sector dropdown menu to use static positioning on mobile. 
* Kept absolute positioning on desktop.

## Screenshots/Videos (if applicable)

Before:

<img width="323" height="383" alt="Screenshot 2026-05-15 at 14 46 25" src="https://github.com/user-attachments/assets/536ae8ed-151e-41b8-b3a2-4e7006e0bb06" />

After:

<img width="324" height="503" alt="Screenshot 2026-05-15 at 14 57 56" src="https://github.com/user-attachments/assets/fe7fe55f-15a3-4eea-a915-c14118a0ceee" />

## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1214727092940682?focus=true)

## Requirements, dependencies and related PRs

none

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
 Steps to reproduce: open menu on mobile size, expand themes/sectoren, the expnanded items overlap the language selector, making same items not selectable.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
