### PR TITLE
Address theme update review

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,7 +26,7 @@ let nextConfig: NextConfig = {
     },
   },
   webpack: (cfg: Webpack.Configuration, context) => {
-    const result = baseConfig.webpack?.(cfg, context) as Webpack.Configuration;
+    const result = (baseConfig.webpack?.(cfg, context) ?? cfg) as Webpack.Configuration;
     if (result.resolve?.alias) {
       // `@/public` must come before `@` in iteration order: enhanced-resolve
       // tries aliases sequentially, and `@` would otherwise match first,


### PR DESCRIPTION
Address comment on previous PR

Use const result = baseConfig.webpack?.(cfg, context) ?? cfg (and/or result?.resolve) so webpack builds still work when no base hook exists