### PR TITLE
Fix/improve mobile table scroll

### DIFF
--- a/src/components/common/stickyTableStyles.ts
+++ b/src/components/common/stickyTableStyles.ts
@@ -1,0 +1,145 @@
+import { css } from '@emotion/react';
+
+export const STICKY_TABLE_NAME_COLUMN_CLASS = 'sticky-table-name-column';
+
+type ThemeProps = {
+  theme: {
+    breakpointMd: string;
+    spaces: {
+      s050: string;
+      s100: string;
+    };
+    themeColors: {
+      white: string;
+    };
+  };
+};
+
+type MobileStickyTableStylesOptions = {
+  scrollableColumnWidth?: string;
+  stickyColumnWidth?: string;
+  stickyColumnMinWidth?: string;
+  stickyColumnMaxWidth?: string;
+  containScrollableCellContent?: boolean;
+};
+
+export const mobileScrollableTableWrapperStyles = (props: ThemeProps) => css`
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+
+  @media (max-width: ${props.theme.breakpointMd}) {
+    max-height: calc(100vh - ${props.theme.spaces.s100});
+    overflow: auto;
+  }
+`;
+
+export const mobileStickyTableStyles = (
+  props: ThemeProps,
+  {
+    scrollableColumnWidth,
+    stickyColumnWidth = 'min(44vw, 11rem)',
+    stickyColumnMinWidth = '8.5rem',
+    stickyColumnMaxWidth = '11rem',
+    containScrollableCellContent = false,
+  }: MobileStickyTableStylesOptions = {}
+) => css`
+  @media (max-width: ${props.theme.breakpointMd}) {
+    border-collapse: separate;
+    border-spacing: 0;
+    min-width: max-content;
+
+    th,
+    td {
+      left: auto;
+      z-index: auto;
+      padding-left: ${props.theme.spaces.s050};
+      padding-right: ${props.theme.spaces.s050};
+    }
+
+    ${scrollableColumnWidth &&
+    css`
+      th:not(.${STICKY_TABLE_NAME_COLUMN_CLASS}),
+      td:not(.${STICKY_TABLE_NAME_COLUMN_CLASS}) {
+        width: ${scrollableColumnWidth};
+        min-width: ${scrollableColumnWidth};
+        max-width: ${scrollableColumnWidth};
+      }
+    `}
+
+    tbody td:not(.${STICKY_TABLE_NAME_COLUMN_CLASS}) {
+      position: static !important;
+    }
+
+    th:not(.${STICKY_TABLE_NAME_COLUMN_CLASS}) {
+      white-space: normal;
+      overflow-wrap: break-word;
+      word-break: normal;
+      hyphens: auto;
+    }
+
+    td:not(.${STICKY_TABLE_NAME_COLUMN_CLASS}) {
+      white-space: normal;
+      overflow-wrap: normal;
+      word-break: normal;
+
+      ${containScrollableCellContent &&
+      css`
+        hyphens: none;
+        overflow: hidden;
+      `}
+    }
+
+    ${containScrollableCellContent &&
+    css`
+      td:not(.${STICKY_TABLE_NAME_COLUMN_CLASS}) > * {
+        max-width: 100%;
+        min-width: 0;
+        box-sizing: border-box;
+      }
+
+      td:not(.${STICKY_TABLE_NAME_COLUMN_CLASS}) * {
+        max-width: 100%;
+        white-space: normal;
+        overflow-wrap: break-word;
+        word-break: normal;
+        hyphens: none;
+      }
+    `}
+
+    thead th {
+      position: sticky !important;
+      top: -1px;
+      z-index: 30 !important;
+      background-color: ${props.theme.themeColors.white};
+      background-clip: padding-box;
+      box-shadow:
+        0 -2px 0 ${props.theme.themeColors.white},
+        0 2px 4px rgba(0, 0, 0, 0.08);
+    }
+
+    .${STICKY_TABLE_NAME_COLUMN_CLASS} {
+      position: sticky !important;
+      left: 0 !important;
+
+      width: ${stickyColumnWidth};
+      min-width: ${stickyColumnMinWidth};
+      max-width: ${stickyColumnMaxWidth};
+
+      white-space: normal;
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: auto;
+
+      background-color: ${props.theme.themeColors.white};
+      background-clip: padding-box;
+    }
+
+    thead .${STICKY_TABLE_NAME_COLUMN_CLASS} {
+      z-index: 50 !important;
+    }
+
+    tbody .${STICKY_TABLE_NAME_COLUMN_CLASS} {
+      z-index: 20 !important;
+    }
+  }
+`;

--- a/src/components/dashboard/ActionStatusTable.tsx
+++ b/src/components/dashboard/ActionStatusTable.tsx
@@ -61,11 +61,29 @@ const DashTable = styled(Table)`
     td {
       left: auto;
       z-index: auto;
+      padding-left: ${(props) => props.theme.spaces.s050};
+      padding-right: ${(props) => props.theme.spaces.s050};
     }
 
     th:not(.${STICKY_ACTION_NAME_CLASS}),
     td:not(.${STICKY_ACTION_NAME_CLASS}) {
       position: static !important;
+      width: 8.5rem;
+      min-width: 8.5rem;
+      max-width: 8.5rem;
+    }
+
+    th:not(.${STICKY_ACTION_NAME_CLASS}) {
+      white-space: normal;
+      overflow-wrap: break-word;
+      word-break: normal;
+      hyphens: auto;
+    }
+
+    td:not(.${STICKY_ACTION_NAME_CLASS}) {
+      white-space: normal;
+      overflow-wrap: normal;
+      word-break: normal;
     }
 
     .${STICKY_ACTION_NAME_CLASS} {

--- a/src/components/dashboard/ActionStatusTable.tsx
+++ b/src/components/dashboard/ActionStatusTable.tsx
@@ -72,9 +72,9 @@ const DashTable = styled(Table)`
 
     th:not(.${STICKY_ACTION_NAME_CLASS}),
     td:not(.${STICKY_ACTION_NAME_CLASS}) {
-      width: 8.5rem;
-      min-width: 8.5rem;
-      max-width: 8.5rem;
+      width: 9rem;
+      min-width: 9rem;
+      max-width: 9rem;
     }
 
     tbody td:not(.${STICKY_ACTION_NAME_CLASS}) {
@@ -92,6 +92,22 @@ const DashTable = styled(Table)`
       white-space: normal;
       overflow-wrap: normal;
       word-break: normal;
+      hyphens: none;
+      overflow: hidden;
+    }
+
+    td:not(.${STICKY_ACTION_NAME_CLASS}) > * {
+      max-width: 100%;
+      min-width: 0;
+      box-sizing: border-box;
+    }
+
+    td:not(.${STICKY_ACTION_NAME_CLASS}) * {
+      max-width: 100%;
+      white-space: normal;
+      overflow-wrap: break-word;
+      word-break: normal;
+      hyphens: none;
     }
 
     thead th {

--- a/src/components/dashboard/ActionStatusTable.tsx
+++ b/src/components/dashboard/ActionStatusTable.tsx
@@ -16,10 +16,12 @@ import ActionStatusExport from './ActionStatusExport';
 import { COLUMN_CONFIG } from './dashboard.constants';
 import { ActionListAction, ActionListOrganization, ColumnConfig } from './dashboard.types';
 
+const STICKY_ACTION_NAME_CLASS = 'sticky-action-name-column';
+
 const TableWrapper = styled.div`
   width: 100%;
-  display: flex;
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 
   padding: 0 0 ${(props) => props.theme.spaces.s100} 0;
   background-image:
@@ -48,6 +50,48 @@ const DashTable = styled(Table)`
 
   .logo-column {
     width: 2rem;
+  }
+
+  @media (max-width: ${(props) => props.theme.breakpointMd}) {
+    border-collapse: separate;
+    border-spacing: 0;
+    min-width: max-content;
+
+    th,
+    td {
+      left: auto;
+      z-index: auto;
+    }
+
+    th:not(.${STICKY_ACTION_NAME_CLASS}),
+    td:not(.${STICKY_ACTION_NAME_CLASS}) {
+      position: static !important;
+    }
+
+    .${STICKY_ACTION_NAME_CLASS} {
+      position: sticky !important;
+      left: 0 !important;
+
+      width: min(44vw, 11rem);
+      min-width: 8.5rem;
+      max-width: 11rem;
+
+      white-space: normal;
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: auto;
+
+      background-color: ${(props) => props.theme.themeColors.white};
+      background-clip: padding-box;
+    }
+
+    thead .${STICKY_ACTION_NAME_CLASS} {
+      z-index: 30 !important;
+    }
+
+    tbody .${STICKY_ACTION_NAME_CLASS} {
+      z-index: 20 !important;
+    }
   }
 `;
 
@@ -197,6 +241,16 @@ const compareNullableNumber = (a: number | null, b: number | null) => {
 const compareNullableString = (a?: string | null, b?: string | null) =>
   (a ?? '').localeCompare(b ?? '');
 
+const getColumnClassName = (column: ColumnConfig) => {
+  const columnConfig = COLUMN_CONFIG[column.__typename];
+  return [
+    columnConfig?.headerClassName,
+    columnConfig?.rowHeader ? STICKY_ACTION_NAME_CLASS : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ');
+};
+
 interface Props {
   actions: ActionListAction[];
   orgs: ActionListOrganization[];
@@ -315,6 +369,7 @@ const ActionStatusTable = (props: Props) => {
                   return null;
                 }
 
+                const className = getColumnClassName(column);
                 const headerLabel = column.columnLabel || column?.attributeType?.name;
                 const isFieldColumn =
                   column.__typename === 'FieldColumnBlock' && !!column.attributeType?.id;
@@ -335,7 +390,7 @@ const ActionStatusTable = (props: Props) => {
                       sort={sort}
                       headerKey={headerKey}
                       onClick={sortHandler(headerKey)}
-                      className={columnConfig.headerClassName}
+                      className={className}
                     >
                       {columnConfig.renderHeader(t, plan, headerLabel)}
                     </SortableTableHeader>
@@ -343,7 +398,7 @@ const ActionStatusTable = (props: Props) => {
                 }
 
                 return (
-                  <th key={i} scope="col" className={columnConfig.headerClassName}>
+                  <th key={i} scope="col" className={className}>
                     {columnConfig.renderHeader(t, plan, headerLabel)}
                   </th>
                 );

--- a/src/components/dashboard/ActionStatusTable.tsx
+++ b/src/components/dashboard/ActionStatusTable.tsx
@@ -14,14 +14,17 @@ import ActionTableRow from '@/components/dashboard/ActionTableRow';
 
 import ActionStatusExport from './ActionStatusExport';
 import { COLUMN_CONFIG } from './dashboard.constants';
+import {
+  mobileScrollableTableWrapperStyles,
+  mobileStickyTableStyles,
+  STICKY_TABLE_NAME_COLUMN_CLASS,
+} from '@/components/common/stickyTableStyles';
 import { ActionListAction, ActionListOrganization, ColumnConfig } from './dashboard.types';
 
-const STICKY_ACTION_NAME_CLASS = 'sticky-action-name-column';
 
 const TableWrapper = styled.div`
   width: 100%;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
+  ${(props) => mobileScrollableTableWrapperStyles(props)};
 
   padding: 0 0 ${(props) => props.theme.spaces.s100} 0;
   background-image:
@@ -57,95 +60,11 @@ const DashTable = styled(Table)`
     width: 2rem;
   }
 
-  @media (max-width: ${(props) => props.theme.breakpointMd}) {
-    border-collapse: separate;
-    border-spacing: 0;
-    min-width: max-content;
-
-    th,
-    td {
-      left: auto;
-      z-index: auto;
-      padding-left: ${(props) => props.theme.spaces.s050};
-      padding-right: ${(props) => props.theme.spaces.s050};
-    }
-
-    th:not(.${STICKY_ACTION_NAME_CLASS}),
-    td:not(.${STICKY_ACTION_NAME_CLASS}) {
-      width: 9rem;
-      min-width: 9rem;
-      max-width: 9rem;
-    }
-
-    tbody td:not(.${STICKY_ACTION_NAME_CLASS}) {
-      position: static !important;
-    }
-
-    th:not(.${STICKY_ACTION_NAME_CLASS}) {
-      white-space: normal;
-      overflow-wrap: break-word;
-      word-break: normal;
-      hyphens: auto;
-    }
-
-    td:not(.${STICKY_ACTION_NAME_CLASS}) {
-      white-space: normal;
-      overflow-wrap: normal;
-      word-break: normal;
-      hyphens: none;
-      overflow: hidden;
-    }
-
-    td:not(.${STICKY_ACTION_NAME_CLASS}) > * {
-      max-width: 100%;
-      min-width: 0;
-      box-sizing: border-box;
-    }
-
-    td:not(.${STICKY_ACTION_NAME_CLASS}) * {
-      max-width: 100%;
-      white-space: normal;
-      overflow-wrap: break-word;
-      word-break: normal;
-      hyphens: none;
-    }
-
-    thead th {
-      position: sticky !important;
-      top: -1px;
-      z-index: 30 !important;
-      background-color: ${(props) => props.theme.themeColors.white};
-      background-clip: padding-box;
-      box-shadow:
-        0 -2px 0 ${(props) => props.theme.themeColors.white},
-        0 2px 4px rgba(0, 0, 0, 0.08);
-    }
-
-    .${STICKY_ACTION_NAME_CLASS} {
-      position: sticky !important;
-      left: 0 !important;
-
-      width: min(44vw, 11rem);
-      min-width: 8.5rem;
-      max-width: 11rem;
-
-      white-space: normal;
-      overflow-wrap: normal;
-      word-break: normal;
-      hyphens: auto;
-
-      background-color: ${(props) => props.theme.themeColors.white};
-      background-clip: padding-box;
-    }
-
-    thead .${STICKY_ACTION_NAME_CLASS} {
-      z-index: 50 !important;
-    }
-
-    tbody .${STICKY_ACTION_NAME_CLASS} {
-      z-index: 20 !important;
-    }
-  }
+  ${(props) =>
+    mobileStickyTableStyles(props, {
+      scrollableColumnWidth: '9rem',
+      containScrollableCellContent: true,
+    })};
 `;
 
 const ToolBar = styled.div`
@@ -299,7 +218,7 @@ const getColumnClassName = (column: ColumnConfig) => {
 
   return [
     columnConfig?.headerClassName,
-    columnConfig?.rowHeader ? STICKY_ACTION_NAME_CLASS : undefined,
+    columnConfig?.rowHeader ? STICKY_TABLE_NAME_COLUMN_CLASS : undefined,
   ]
     .filter(Boolean)
     .join(' ');

--- a/src/components/dashboard/ActionStatusTable.tsx
+++ b/src/components/dashboard/ActionStatusTable.tsx
@@ -41,6 +41,11 @@ const TableWrapper = styled.div`
     10px 100%,
     10px 100%;
   background-attachment: local, local, scroll, scroll;
+
+  @media (max-width: ${(props) => props.theme.breakpointMd}) {
+    max-height: calc(100vh - ${(props) => props.theme.spaces.s100});
+    overflow: auto;
+  }
 `;
 
 const DashTable = styled(Table)`
@@ -67,10 +72,13 @@ const DashTable = styled(Table)`
 
     th:not(.${STICKY_ACTION_NAME_CLASS}),
     td:not(.${STICKY_ACTION_NAME_CLASS}) {
-      position: static !important;
       width: 8.5rem;
       min-width: 8.5rem;
       max-width: 8.5rem;
+    }
+
+    tbody td:not(.${STICKY_ACTION_NAME_CLASS}) {
+      position: static !important;
     }
 
     th:not(.${STICKY_ACTION_NAME_CLASS}) {
@@ -84,6 +92,17 @@ const DashTable = styled(Table)`
       white-space: normal;
       overflow-wrap: normal;
       word-break: normal;
+    }
+
+    thead th {
+      position: sticky !important;
+      top: -1px;
+      z-index: 30 !important;
+      background-color: ${(props) => props.theme.themeColors.white};
+      background-clip: padding-box;
+      box-shadow:
+        0 -2px 0 ${(props) => props.theme.themeColors.white},
+        0 2px 4px rgba(0, 0, 0, 0.08);
     }
 
     .${STICKY_ACTION_NAME_CLASS} {
@@ -104,7 +123,7 @@ const DashTable = styled(Table)`
     }
 
     thead .${STICKY_ACTION_NAME_CLASS} {
-      z-index: 30 !important;
+      z-index: 50 !important;
     }
 
     tbody .${STICKY_ACTION_NAME_CLASS} {
@@ -261,6 +280,7 @@ const compareNullableString = (a?: string | null, b?: string | null) =>
 
 const getColumnClassName = (column: ColumnConfig) => {
   const columnConfig = COLUMN_CONFIG[column.__typename];
+
   return [
     columnConfig?.headerClassName,
     columnConfig?.rowHeader ? STICKY_ACTION_NAME_CLASS : undefined,

--- a/src/components/dashboard/ActionTableRow.tsx
+++ b/src/components/dashboard/ActionTableRow.tsx
@@ -10,8 +10,7 @@ import type { PlanContextFragment } from '@/common/__generated__/graphql';
 
 import { COLUMN_CONFIG } from './dashboard.constants';
 import type { ActionListAction, ColumnConfig } from './dashboard.types';
-
-const STICKY_ACTION_NAME_CLASS = 'sticky-action-name-column';
+import { STICKY_TABLE_NAME_COLUMN_CLASS } from '@/components/common/stickyTableStyles';
 
 const StyledRow = styled.tr`
   font-family: ${(props) => `${props.theme.fontFamilyContent}, ${props.theme.fontFamilyFallback}`};
@@ -71,7 +70,7 @@ const getCellClassName = ({
     cellClassName,
     hasTooltip ? 'has-tooltip' : undefined,
     rowHeader ? 'row-title' : undefined,
-    rowHeader ? STICKY_ACTION_NAME_CLASS : undefined,
+    rowHeader ? STICKY_TABLE_NAME_COLUMN_CLASS : undefined,
   ]
     .filter(Boolean)
     .join(' ');

--- a/src/components/dashboard/ActionTableRow.tsx
+++ b/src/components/dashboard/ActionTableRow.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
-import styled from '@emotion/styled';
 import Tooltip from '@mui/material/Tooltip';
+
+import styled from '@emotion/styled';
+
 import { useTranslations } from 'next-intl';
 
 import type { PlanContextFragment } from '@/common/__generated__/graphql';
@@ -9,13 +11,16 @@ import type { PlanContextFragment } from '@/common/__generated__/graphql';
 import { COLUMN_CONFIG } from './dashboard.constants';
 import type { ActionListAction, ColumnConfig } from './dashboard.types';
 
+const STICKY_ACTION_NAME_CLASS = 'sticky-action-name-column';
+
 const StyledRow = styled.tr`
   font-family: ${(props) => `${props.theme.fontFamilyContent}, ${props.theme.fontFamilyFallback}`};
   &.merged {
     opacity: 0.25;
   }
 
-  td {
+  td,
+  th {
     vertical-align: top;
     min-height: 1px;
 
@@ -53,6 +58,24 @@ interface Props {
   planViewUrl?: string | null;
 }
 
+const getCellClassName = ({
+  cellClassName,
+  hasTooltip,
+  rowHeader,
+}: {
+  cellClassName?: string;
+  hasTooltip: boolean;
+  rowHeader?: boolean;
+}) =>
+  [
+    cellClassName,
+    hasTooltip ? 'has-tooltip' : undefined,
+    rowHeader ? 'row-title' : undefined,
+    rowHeader ? STICKY_ACTION_NAME_CLASS : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
 const ActionTableRow = ({ columns, action, plan, planViewUrl }: Props) => {
   const t = useTranslations();
 
@@ -69,9 +92,7 @@ const ActionTableRow = ({ columns, action, plan, planViewUrl }: Props) => {
         const hasTooltip = !!renderTooltipContent;
         const content = renderCell(t, action, plan, planViewUrl, column?.attributeType);
         const id = `row-${action.id}-${i}`;
-        const className = `${cellClassName} ${
-          hasTooltip ? 'has-tooltip' : ''
-        } ${rowHeader ? 'row-title' : ''}`;
+        const className = getCellClassName({ cellClassName, hasTooltip, rowHeader });
         const tooltipContent = hasTooltip
           ? renderTooltipContent(t, action, plan, column?.attributeType)
           : undefined;

--- a/src/components/dashboard/ActionTableRow.tsx
+++ b/src/components/dashboard/ActionTableRow.tsx
@@ -100,6 +100,7 @@ const ActionTableRow = ({ columns, action, plan, planViewUrl }: Props) => {
           title: tooltipContent,
           arrow: true,
           placement: 'top' as const,
+          disableTouchListener: true,
           slotProps: {
             tooltip: {
               sx: {

--- a/src/components/indicators/IndicatorListFiltered.tsx
+++ b/src/components/indicators/IndicatorListFiltered.tsx
@@ -8,6 +8,12 @@ import { Alert, Table } from 'reactstrap';
 import { transientOptions } from '@common/themes/styles/styled';
 
 import {
+  mobileScrollableTableWrapperStyles,
+  mobileStickyTableStyles,
+  STICKY_TABLE_NAME_COLUMN_CLASS,
+} from '@/components/common/stickyTableStyles';
+
+import {
   IndicatorDashboardFieldName,
   type IndicatorListPageFragmentFragment,
 } from '@/common/__generated__/graphql';
@@ -22,13 +28,10 @@ import type { Hierarchy } from './process-indicators';
 
 export const isEmptyFilter = (val) => val == null || val === '';
 
-const STICKY_INDICATOR_NAME_CLASS = 'sticky-indicator-name-column';
-
 const TableWrapper = styled.div`
   /*div className="mt-5 mb-5 pb-5"*/
   width: 100%;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
+   ${(props) => mobileScrollableTableWrapperStyles(props)};
 
   margin: ${(props) => props.theme.spaces.s200} 0;
   padding-bottom: ${(props) => props.theme.spaces.s200};
@@ -58,62 +61,10 @@ const TableWrapper = styled.div`
     25px 100%,
     25px 100%;
   background-attachment: local, local, scroll, scroll;
-
-  @media (max-width: ${(props) => props.theme.breakpointMd}) {
-    max-height: calc(100vh - ${(props) => props.theme.spaces.s100});
-    overflow: auto;
-  }
 `;
 
 const IndicatorListTable = styled(Table)`
-  @media (max-width: ${(props) => props.theme.breakpointMd}) {
-    border-collapse: separate;
-    border-spacing: 0;
-    min-width: max-content;
-
-    th,
-    td {
-      left: auto;
-      z-index: auto;
-    }
-
-    tbody td:not(.${STICKY_INDICATOR_NAME_CLASS}) {
-      position: static !important;
-    }
-
-    thead th {
-      position: sticky !important;
-      top: -1px;
-      z-index: 30 !important;
-      background-color: ${(props) => props.theme.themeColors.white};
-      background-clip: padding-box;
-      box-shadow:
-        0 -2px 0 ${(props) => props.theme.themeColors.white},
-        0 2px 4px rgba(0, 0, 0, 0.08);
-    }
-
-    .${STICKY_INDICATOR_NAME_CLASS} {
-      position: sticky !important;
-      left: 0 !important;
-      width: min(44vw, 11rem);
-      min-width: 8.5rem;
-      max-width: 11rem;
-      white-space: normal;
-      overflow-wrap: normal;
-      word-break: normal;
-      hyphens: auto;
-      background-color: ${(props) => props.theme.themeColors.white};
-      background-clip: padding-box;
-    }
-
-    thead .${STICKY_INDICATOR_NAME_CLASS} {
-      z-index: 50 !important;
-    }
-
-    tbody .${STICKY_INDICATOR_NAME_CLASS} {
-      z-index: 20 !important;
-    }
-  }
+ ${(props) => mobileStickyTableStyles(props)};
 `;
 
 const Cell = styled.td`
@@ -364,7 +315,7 @@ export default function IndicatorListFiltered(props: IndicatorListFilteredProps)
                             hasChildren={false}
                             expanded={false}
                             className={
-                              isNameColumn(column) ? STICKY_INDICATOR_NAME_CLASS : undefined
+                              isNameColumn(column) ? STICKY_TABLE_NAME_COLUMN_CLASS : undefined
                             }
                           >
                             <IndicatorTableCell
@@ -399,7 +350,7 @@ export default function IndicatorListFiltered(props: IndicatorListFilteredProps)
                               ? () => toggleCollapse(commonId)
                               : undefined
                           }
-                          className={isNameColumn(column) ? STICKY_INDICATOR_NAME_CLASS : undefined}
+                          className={isNameColumn(column) ? STICKY_TABLE_NAME_COLUMN_CLASS : undefined}
                         >
                           <IndicatorTableCell
                             column={column}

--- a/src/components/indicators/IndicatorListFiltered.tsx
+++ b/src/components/indicators/IndicatorListFiltered.tsx
@@ -7,7 +7,10 @@ import { Alert, Table } from 'reactstrap';
 
 import { transientOptions } from '@common/themes/styles/styled';
 
-import type { IndicatorListPageFragmentFragment } from '@/common/__generated__/graphql';
+import {
+  IndicatorDashboardFieldName,
+  type IndicatorListPageFragmentFragment,
+} from '@/common/__generated__/graphql';
 
 import Icon from '../common/Icon';
 import type { CategoryType, IndicatorListIndicator } from './IndicatorList';
@@ -19,11 +22,13 @@ import type { Hierarchy } from './process-indicators';
 
 export const isEmptyFilter = (val) => val == null || val === '';
 
+const STICKY_INDICATOR_NAME_CLASS = 'sticky-indicator-name-column';
+
 const TableWrapper = styled.div`
   /*div className="mt-5 mb-5 pb-5"*/
   width: 100%;
-  display: flex;
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 
   margin: ${(props) => props.theme.spaces.s200} 0;
   padding-bottom: ${(props) => props.theme.spaces.s200};
@@ -53,6 +58,62 @@ const TableWrapper = styled.div`
     25px 100%,
     25px 100%;
   background-attachment: local, local, scroll, scroll;
+
+  @media (max-width: ${(props) => props.theme.breakpointMd}) {
+    max-height: calc(100vh - ${(props) => props.theme.spaces.s100});
+    overflow: auto;
+  }
+`;
+
+const IndicatorListTable = styled(Table)`
+  @media (max-width: ${(props) => props.theme.breakpointMd}) {
+    border-collapse: separate;
+    border-spacing: 0;
+    min-width: max-content;
+
+    th,
+    td {
+      left: auto;
+      z-index: auto;
+    }
+
+    tbody td:not(.${STICKY_INDICATOR_NAME_CLASS}) {
+      position: static !important;
+    }
+
+    thead th {
+      position: sticky !important;
+      top: -1px;
+      z-index: 30 !important;
+      background-color: ${(props) => props.theme.themeColors.white};
+      background-clip: padding-box;
+      box-shadow:
+        0 -2px 0 ${(props) => props.theme.themeColors.white},
+        0 2px 4px rgba(0, 0, 0, 0.08);
+    }
+
+    .${STICKY_INDICATOR_NAME_CLASS} {
+      position: sticky !important;
+      left: 0 !important;
+      width: min(44vw, 11rem);
+      min-width: 8.5rem;
+      max-width: 11rem;
+      white-space: normal;
+      overflow-wrap: normal;
+      word-break: normal;
+      hyphens: auto;
+      background-color: ${(props) => props.theme.themeColors.white};
+      background-clip: padding-box;
+    }
+
+    thead .${STICKY_INDICATOR_NAME_CLASS} {
+      z-index: 50 !important;
+    }
+
+    tbody .${STICKY_INDICATOR_NAME_CLASS} {
+      z-index: 20 !important;
+    }
+  }
 `;
 
 const Cell = styled.td`
@@ -111,10 +172,12 @@ const StyledCell = (props: {
   hasChildren: boolean;
   expanded: boolean;
   onToggle?: () => void;
+  className?: string;
 }) => {
-  const { indent, children, hasChildren, expanded, onToggle } = props;
+  const { indent, children, hasChildren, expanded, onToggle, className } = props;
+
   return (
-    <Cell>
+    <Cell className={className}>
       <CellWrapper>
         {indent > 0 ? <div style={{ paddingLeft: `${indent * 16}px` }}> </div> : null}
         {hasChildren ? (
@@ -233,9 +296,13 @@ export default function IndicatorListFiltered(props: IndicatorListFilteredProps)
   const groupedIndicators = groupIndicatorsByCommonCategory(indicators);
   const columnCount = listColumns.length;
 
+  const isNameColumn = (column: (typeof listColumns)[number]) =>
+    column.__typename === 'IndicatorListColumn' &&
+    column.sourceField === IndicatorDashboardFieldName.Name;
+
   return (
     <TableWrapper>
-      <Table hover>
+      <IndicatorListTable hover>
         <thead>
           <tr>
             {listColumns.map((column) => (
@@ -296,6 +363,9 @@ export default function IndicatorListFiltered(props: IndicatorListFilteredProps)
                             indent={index === 0 ? indent + 1 : 0}
                             hasChildren={false}
                             expanded={false}
+                            className={
+                              isNameColumn(column) ? STICKY_INDICATOR_NAME_CLASS : undefined
+                            }
                           >
                             <IndicatorTableCell
                               column={column}
@@ -329,6 +399,7 @@ export default function IndicatorListFiltered(props: IndicatorListFilteredProps)
                               ? () => toggleCollapse(commonId)
                               : undefined
                           }
+                          className={isNameColumn(column) ? STICKY_INDICATOR_NAME_CLASS : undefined}
                         >
                           <IndicatorTableCell
                             column={column}
@@ -344,7 +415,7 @@ export default function IndicatorListFiltered(props: IndicatorListFilteredProps)
             );
           })}
         </tbody>
-      </Table>
+      </IndicatorListTable>
     </TableWrapper>
   );
 }

--- a/src/components/indicators/IndicatorTableHeader.tsx
+++ b/src/components/indicators/IndicatorTableHeader.tsx
@@ -15,6 +15,8 @@ import Icon from '@/components/common/Icon';
 import PopoverTip from '../common/PopoverTip';
 import type { SortState } from './indicatorUtils';
 
+const STICKY_INDICATOR_NAME_CLASS = 'sticky-indicator-name-column';
+
 const StyledTh = styled.th<{ $numeric?: boolean }>`
   text-align: ${(props) => (props?.$numeric ? 'right' : 'left')};
   line-height: ${(props) => props.theme.lineHeightSm};
@@ -87,7 +89,8 @@ const getColumnLabel = (
         default:
           return '';
       }
-    case 'IndicatorValueColumn':
+
+    case 'IndicatorValueColumn': {
       const normalized = column.isNormalized
         ? `(${t('indicator-population-normalized-value')})`
         : '';
@@ -125,6 +128,7 @@ const getColumnLabel = (
             </>
           );
       }
+    }
     default:
       return '';
   }
@@ -149,12 +153,14 @@ const IndicatorTableHeader = (props: IndicatorTableHeaderProps) => {
   const iconName = selected ? (sort?.direction === 'asc' ? 'sort-down' : 'sort-up') : 'sort';
 
   const Th = isSortable ? SortableTh : StyledTh;
+  const className = isNameColumn ? STICKY_INDICATOR_NAME_CLASS : undefined;
 
   return (
     <Th
       key={column.id}
       $numeric={isNumericColumn(column)}
       scope="col"
+      className={className}
       onClick={isSortable && sortKey ? () => onSortState?.(sortKey) : undefined}
       aria-sort={
         isSortable

--- a/src/components/indicators/IndicatorTableHeader.tsx
+++ b/src/components/indicators/IndicatorTableHeader.tsx
@@ -9,13 +9,12 @@ import {
   IndicatorColumnValueType,
   IndicatorDashboardFieldName,
 } from '@/common/__generated__/graphql';
+import { STICKY_TABLE_NAME_COLUMN_CLASS } from '@/components/common/stickyTableStyles';
 import type { TFunction } from '@/common/i18n';
 import Icon from '@/components/common/Icon';
 
 import PopoverTip from '../common/PopoverTip';
 import type { SortState } from './indicatorUtils';
-
-const STICKY_INDICATOR_NAME_CLASS = 'sticky-indicator-name-column';
 
 const StyledTh = styled.th<{ $numeric?: boolean }>`
   text-align: ${(props) => (props?.$numeric ? 'right' : 'left')};
@@ -153,7 +152,7 @@ const IndicatorTableHeader = (props: IndicatorTableHeaderProps) => {
   const iconName = selected ? (sort?.direction === 'asc' ? 'sort-down' : 'sort-up') : 'sort';
 
   const Th = isSortable ? SortableTh : StyledTh;
-  const className = isNameColumn ? STICKY_INDICATOR_NAME_CLASS : undefined;
+  const className = isNameColumn ? STICKY_TABLE_NAME_COLUMN_CLASS : undefined;
 
   return (
     <Th


### PR DESCRIPTION
## Description

Improve action list dashboard usability on mobile (reduce horizontal scrolling).

* The Action list now has the action name column sticky on the left on mobile, so users don't lose context while scrolling horizontally. It also keeps table headers sticky at the top while scrolling the list vertically.
* The same mobile sticky-headers behavior was added to the indicator list table for consistency.
* Also made some additional fixes to reduce empty cell space. 

## Screenshots/Videos (if applicable)

https://github.com/user-attachments/assets/2a927706-bf71-4767-b662-11c5081de50a





## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1214727092940686?focus=true)

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [ ] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
