### PR TITLE
Fix squished avatar icon and indicator translations

### DIFF
--- a/src/common/i18n.ts
+++ b/src/common/i18n.ts
@@ -17,7 +17,7 @@ export function getIndicatorTermContext(plan: {
   generalContent?: { indicatorTerm?: SiteGeneralContentIndicatorTerm };
 }) {
   const indicatorTerm = plan.generalContent?.indicatorTerm;
-  return { context: indicatorTerm || 'INDICATOR' };
+  return { context: indicatorTerm || SiteGeneralContentIndicatorTerm.Indicator };
 }
 
 export function getActionTaskTermContext(plan: {

--- a/src/components/actions/ActionListFilters.tsx
+++ b/src/components/actions/ActionListFilters.tsx
@@ -3,6 +3,7 @@ import React, { createRef, useCallback, useEffect, useMemo, useState } from 'rea
 
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+
 import escapeStringRegexp from 'escape-string-regexp';
 import { debounce } from 'lodash-es';
 import { useTranslations } from 'next-intl';

--- a/src/components/actions/ContactPerson.tsx
+++ b/src/components/actions/ContactPerson.tsx
@@ -90,6 +90,7 @@ type AvatarProps = {
 const Avatar = styled.div<AvatarProps>`
   width: 5em;
   height: 5em;
+  flex-shrink: 0;
   border-radius: 50%;
   background-color: transparent;
   background-size: cover;

--- a/src/components/indicators/IndicatorCard.tsx
+++ b/src/components/indicators/IndicatorCard.tsx
@@ -8,6 +8,7 @@ import { Card, CardBody, CardTitle } from 'reactstrap';
 
 import { transientOptions } from '@common/themes/styles/styled';
 
+import { SiteGeneralContentIndicatorTerm } from '@/common/__generated__/graphql';
 import dayjs from '@/common/dayjs';
 import type { TFunction } from '@/common/i18n';
 import { getActionTermContext, getIndicatorTermContext } from '@/common/i18n';
@@ -203,7 +204,7 @@ function CardLink(props: CardLinkProps) {
 export function getIndicatorTranslation(
   level: string | null,
   t: TFunction,
-  indicatorTermContext: { context: string } = { context: 'INDICATOR' }
+  indicatorTermContext: { context: string } = { context: SiteGeneralContentIndicatorTerm.Indicator }
 ) {
   if (!level) {
     return t('indicator', indicatorTermContext);

--- a/src/components/indicators/IndicatorCard.tsx
+++ b/src/components/indicators/IndicatorCard.tsx
@@ -1,6 +1,7 @@
 import React, { type PropsWithChildren } from 'react';
 
 import styled from '@emotion/styled';
+
 import { useTranslations } from 'next-intl';
 import { readableColor } from 'polished';
 import { Card, CardBody, CardTitle } from 'reactstrap';
@@ -202,7 +203,7 @@ function CardLink(props: CardLinkProps) {
 export function getIndicatorTranslation(
   level: string | null,
   t: TFunction,
-  indicatorTermContext?: { context: string }
+  indicatorTermContext: { context: string } = { context: 'INDICATOR' }
 ) {
   if (!level) {
     return t('indicator', indicatorTermContext);

--- a/src/components/indicators/IndicatorHighlightCard.tsx
+++ b/src/components/indicators/IndicatorHighlightCard.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
-
 import styled from '@emotion/styled';
+
 import { useTranslations } from 'next-intl';
 import { readableColor } from 'polished';
 import { Card, CardBody, CardImgOverlay, CardTitle } from 'reactstrap';
 
-import { getActionTermContext } from '@/common/i18n';
+import { getActionTermContext, getIndicatorTermContext } from '@/common/i18n';
 import { IndicatorLink } from '@/common/links';
 import useNumberFormatter from '@/common/numbers';
 import { usePlan } from '@/context/plan';
@@ -108,7 +107,7 @@ function IndicatorHighlightCard({
   const indicatorType =
     level === 'action'
       ? t('action', getActionTermContext(plan))
-      : getIndicatorTranslation(level ?? null, t);
+      : getIndicatorTranslation(level ?? null, t, getIndicatorTermContext(plan));
 
   return (
     <StyledCard>

--- a/src/components/indicators/IndicatorLevelChip.tsx
+++ b/src/components/indicators/IndicatorLevelChip.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
+
 import { useTranslations } from 'next-intl';
 import { readableColor } from 'polished';
 
-import { getActionTermContext } from '@/common/i18n';
+import { getActionTermContext, getIndicatorTermContext } from '@/common/i18n';
 import { IndicatorListLink } from '@/common/links';
 import { usePlan } from '@/context/plan';
 
@@ -74,7 +75,7 @@ const IndicatorLevelChip = ({ level }: { level: string }) => {
     level === 'action'
       ? t('action', getActionTermContext(plan))
       : level != null
-        ? getIndicatorTranslation(level, t)
+        ? getIndicatorTranslation(level, t, getIndicatorTermContext(plan))
         : null;
   return (
     <IndicatorLevel $level={level}>

--- a/src/components/indicators/IndicatorTableCell.tsx
+++ b/src/components/indicators/IndicatorTableCell.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
+
 import * as Sentry from '@sentry/nextjs';
-import type { truncate } from 'fs/promises';
 import { type DateTimeFormatOptions, useFormatter, useTranslations } from 'next-intl';
 import { readableColor } from 'polished';
 import { Button } from 'reactstrap';
@@ -11,16 +11,16 @@ import {
   type IndicatorListPageFragmentFragment,
   IndicatorTimeResolution,
 } from '@/common/__generated__/graphql';
+import { getActionTermContext, getIndicatorTermContext } from '@/common/i18n';
 import { IndicatorLink } from '@/common/links';
 import useNumberFormatter from '@/common/numbers';
+import { usePlan } from '@/context/plan';
 
 import BadgeTooltip from '../common/BadgeTooltip';
 import Icon from '../common/Icon';
 import { getIndicatorTranslation } from './IndicatorCard';
 import type { IndicatorListIndicator } from './IndicatorList';
 import { isGoalAlreadyExceeded } from './indicatorUtils';
-
-const DEFAULT_ROUNDING = 2;
 
 const CellContent = styled.div<{ $numeric?: boolean }>`
   flex: 1;
@@ -415,6 +415,7 @@ const IndicatorListColumnCell = (props: IndicatorListColumnCellProps) => {
   const { sourceField, indicator } = props;
   const format = useFormatter();
   const t = useTranslations();
+  const plan = usePlan();
 
   switch (sourceField) {
     case IndicatorDashboardFieldName.Name:
@@ -422,7 +423,9 @@ const IndicatorListColumnCell = (props: IndicatorListColumnCellProps) => {
     case IndicatorDashboardFieldName.Level:
       // TODO: Use action name context
       const indicatorLevelName =
-        indicator.level === 'action' ? t('action') : getIndicatorTranslation(indicator.level, t);
+        indicator.level === 'action'
+          ? t('action', getActionTermContext(plan))
+          : getIndicatorTranslation(indicator.level, t, getIndicatorTermContext(plan));
       return (
         <CellContent>
           <IndicatorLevelBadge $level={indicator.level}>{indicatorLevelName}</IndicatorLevelBadge>


### PR DESCRIPTION
## Description

A few quick fixes discovered while testing:

1. Prevent circular avatars being squished horizontally into ovals
2. Fix some indicator translations that were missing the terminology context

| Before | After |
|-|-|
| <img width="400" height="194" alt="image" src="https://github.com/user-attachments/assets/95d80eee-2873-405e-8ed7-a5dad1c5e19e" /> | <img width="440" height="208" alt="image" src="https://github.com/user-attachments/assets/dc73bdff-d770-4526-9e85-3f995fdf09c2" /> |
| <img width="1232" height="638" alt="Screenshot 2026-05-20 at 15 02 33" src="https://github.com/user-attachments/assets/b6573c0a-f1ca-4ed9-a1b7-bd41fc433bd0" /> | <img width="1158" height="694" alt="Screenshot 2026-05-20 at 15 04 01" src="https://github.com/user-attachments/assets/405151aa-5dbe-4e11-ae7a-5af7ec416b01" /> |