### PR TITLE
Reduce indicator graph table width on mobile

### DIFF
--- a/src/components/graphs/GraphAsTable.tsx
+++ b/src/components/graphs/GraphAsTable.tsx
@@ -61,6 +61,16 @@ const TableContainer = styled.div`
     th {
       text-align: right;
     }
+
+    @media (max-width: ${(p) => p.theme.breakpointMd}) {
+      width: 100%;
+      min-width: 0;
+
+      th[scope='row'] {
+        width: 1%;
+        white-space: nowrap;
+      }
+    }
   }
 `;
 const TriggerButton = styled(Button)`


### PR DESCRIPTION
## Description

Beautification: Improve the mobile layout of indicator graph table (reduce scroll).

On mobile screen width, the table no longer keeps the fixed 480px min width. The row header column is compact, which helps indicator graph table fit within the viewport and avoid horizontal scrolling.

## Screenshots/Videos (if applicable)

before:

<img width="323" height="594" alt="Screenshot 2026-05-20 at 15 17 19" src="https://github.com/user-attachments/assets/6c9c5ab2-8af7-4dd5-a3dc-a4abbece5c5c" />

after:

<img width="324" height="577" alt="Screenshot 2026-05-20 at 15 18 51" src="https://github.com/user-attachments/assets/1502197b-4a2b-4ee3-b8ba-8ae6abcb5717" />


## Related issue
[asana](https://app.asana.com/1/1201243246741462/project/1214727092940640/task/1214727092940694?focus=true)

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
