### PR TITLE
Improve Q&A section heading and icon alignment

### DIFF
--- a/src/components/common/Accordion.tsx
+++ b/src/components/common/Accordion.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { usePathname } from 'next/navigation';
 
 import styled from '@emotion/styled';
+
 import { useTranslations } from 'next-intl';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { Collapse, UncontrolledTooltip } from 'reactstrap';
@@ -14,7 +15,7 @@ import { replaceHashWithoutScrolling } from '../../common/links';
 
 const Header = styled.h3<{ $small?: boolean }>`
   position: relative;
-  font-size: ${({ theme, $small }) => ($small ? theme.fontSizeMd : theme.fontSizeLg)};
+  font-size: ${({ theme, $small }) => ($small ? theme.fontSizeSm : theme.fontSizeMd)};
 
   &:hover {
     .copy-link {
@@ -35,6 +36,7 @@ const CopyLink = styled.button`
   @media print {
     display: none;
   }
+
   width: 2rem;
   right: -1rem;
   top: -0.5rem;
@@ -58,14 +60,16 @@ const CopyLink = styled.button`
 `;
 
 const TriggerIcon = styled.span`
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex-basis: ${(props) => props.theme.spaces.s200};
   flex-grow: 0;
   flex-shrink: 0;
   margin-right: ${(props) => props.theme.spaces.s050};
   color: ${(props) => props.theme.linkColor};
-  font-size: 2.5rem;
-  line-height: 1.5rem;
+  font-size: 1.15em;
+  line-height: 1;
   font-weight: ${(props) => props.theme.fontWeightNormal};
   text-align: center;
 
@@ -76,6 +80,7 @@ const TriggerIcon = styled.span`
 
 const QuestionTrigger = styled.button`
   display: flex;
+  align-items: flex-start;
   flex-grow: 1;
   width: 100%;
   padding: 0;
@@ -89,7 +94,6 @@ const QuestionTrigger = styled.button`
   border: none;
   overflow: visible;
   background: transparent;
-  line-height: normal;
   border-radius: 0;
   -webkit-appearance: none;
 `;
@@ -169,7 +173,7 @@ const AccordionHeader = ({
   identifier,
   small = false,
 }: AccordionHeaderProps) => (
-  <Header className={isOpen && 'is-open'} $small={small}>
+  <Header className={isOpen ? 'is-open' : undefined} $small={small}>
     <QuestionTrigger
       className="question-trigger"
       onClick={onClick}


### PR DESCRIPTION
## Description

Beatification: Reduce heading size in the Q&A section and align plus icon.

## Screenshots/Videos (if applicable)

before:

<img width="1255" height="621" alt="Screenshot 2026-05-22 at 14 15 20" src="https://github.com/user-attachments/assets/8713c311-dd37-4cc0-8409-4d00fe45fd15" />


after:

<img width="1185" height="558" alt="Screenshot 2026-05-22 at 14 15 41" src="https://github.com/user-attachments/assets/f5ae36f0-da37-4810-b542-0ae151e5facf" />


## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1205310117865974/task/1214727092940672?focus=true)

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [ ] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
