### PR TITLE
Align CardListBlock lead text with category list

### DIFF
--- a/src/components/contentblocks/CardListBlock.tsx
+++ b/src/components/contentblocks/CardListBlock.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+
 import { readableColor } from 'polished';
 import { Col, Container, Row } from 'reactstrap';
 
@@ -43,6 +44,8 @@ const SectionHeader = styled.h2`
 `;
 
 const Content = styled.p`
+  max-width: 720px;
+  margin: 0 auto;
   text-align: center;
   color: ${(props) =>
     readableColor(
@@ -50,8 +53,14 @@ const Content = styled.p`
       props.theme.themeColors.black,
       props.theme.themeColors.white
     )};
-  font-size: ${(props) => props.theme.fontSizeMd};
+  font-size: ${(props) => props.theme.fontSizeBase};
+  line-height: ${(props) => props.theme.lineHeightMd};
   margin-bottom: ${(props) => props.theme.spaces.s300};
+
+  @media (min-width: ${(props) => props.theme.breakpointMd}) {
+    font-size: ${(props) => props.theme.fontSizeMd};
+    line-height: ${(props) => props.theme.lineHeightBase};
+  }
 `;
 
 const CardHeader = styled.h3`
@@ -73,7 +82,7 @@ const CardListBlock = (props) => {
     <CardListSection id={id}>
       <Container>
         {heading && <SectionHeader>{heading}</SectionHeader>}
-        <Content>{lead}</Content>
+        {lead && <Content>{lead}</Content>}
         <Row tag="ul" className="justify-content-center">
           {cards?.map((card, inx) => (
             <Col


### PR DESCRIPTION
## Description

Beautification: Align `CardListBlock` lead text  styling (width and typography) with lead text used in `CategoryListBlock`.

* Applied the same centered lead text styling from `CategoryListBlock` to `CardListBlock`.

## Screenshots/Videos (if applicable)

before:

<img width="1468" height="462" alt="Screenshot 2026-05-25 at 12 42 26" src="https://github.com/user-attachments/assets/e24258b3-b29d-4e34-8f99-497190275ed3" />




after:

<img width="1468" height="522" alt="Screenshot 2026-05-25 at 12 42 38" src="https://github.com/user-attachments/assets/0f9add0a-873a-4e80-99ca-c9e50f3e3516" />


## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1214727092940640/task/1214830054312739?focus=true)

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [fix] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
