### PR TITLE
Fix/card contrast

### DIFF
--- a/src/components/contentblocks/DashboardRowBlock.tsx
+++ b/src/components/contentblocks/DashboardRowBlock.tsx
@@ -58,6 +58,17 @@ const StyledCard = styled(Card)`
     flex-direction: column;
   }
 
+  &.outline {
+    ${({ theme }) =>
+      theme.themeColors.light === '#fefefe' &&
+      theme.cardBorderWidth === '0' &&
+      `
+        /* Improve white card contrast when dashboard section is also white. */
+        border-width: 1px;
+        border-color: ${theme.neutralLight};
+      `}
+  }
+
   h2 {
     font-size: ${({ theme }) => theme.fontSizeLg};
   }

--- a/src/components/contentblocks/DashboardRowBlock.tsx
+++ b/src/components/contentblocks/DashboardRowBlock.tsx
@@ -61,9 +61,8 @@ const StyledCard = styled(Card)`
   &.outline {
     ${({ theme }) =>
       theme.themeColors.light === '#fefefe' &&
-      theme.cardBorderWidth === '0' &&
       `
-        /* Improve white card contrast when dashboard section is also white. */
+        /* Improve white card contrast when dashboard section is also near-white. */
         border-width: 1px;
         border-color: ${theme.neutralLight};
       `}

--- a/src/components/home/HeroSmallImage.tsx
+++ b/src/components/home/HeroSmallImage.tsx
@@ -33,6 +33,14 @@ const MainCard = styled.div`
   box-shadow: 4px 4px 8px rgba(0, 0, 0, 0.1);
   z-index: 100;
 
+  ${({ theme, color }) =>
+    color !== 'dark' &&
+    theme.themeColors.light === '#fefefe' &&
+    `
+      /* Improve white hero card contrast when used on a near-white theme. */
+      border: 1px solid ${theme.neutralLight};
+    `}
+
   h1 {
     font-size: ${(props) => props.theme.fontSizeLg};
     margin-bottom: ${(props) => props.theme.spaces.s100};


### PR DESCRIPTION
## Description

Beautification: Improve front page card contrast for a plan where white cards are displayed on near-white sections.

* Add a 1px border to the `DashboardRowBlock` cards when the dashboard section background is near-white.
* Add a 1 px border to the `HeroSmallImage` card when used with a near-white theme (themeColors.light === '#fefefe') background.

## Screenshots/Videos (if applicable)

before:

<img width="980" height="773" alt="Screenshot 2026-05-27 at 16 18 09" src="https://github.com/user-attachments/assets/d3042d6d-91dd-4fce-ab3e-c318a1bf83b9" />


after:

<img width="1006" height="785" alt="Screenshot 2026-05-27 at 16 18 59" src="https://github.com/user-attachments/assets/758f52c6-5fd7-4672-950b-e87b7b9c53a6" />


## Related issue
[asana](https://app.asana.com/1/1201243246741462/project/1214727092940640/task/1214727092940654?focus=true)

## Requirements, dependencies and related PRs

none

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [ ] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
