### PR TITLE
Fix/remove section header background

### DIFF
--- a/src/components/actions/ActionHighlightsList.tsx
+++ b/src/components/actions/ActionHighlightsList.tsx
@@ -78,13 +78,15 @@ export const GET_ACTION_LIST = gql`
   ${images.fragments.multiUseImage}
 `;
 
-const ListHeader = styled(Col)`
+const ListHeader = styled(Col, transientOptions)<{
+  $embed?: { active: boolean };
+}>`
   h2 {
     text-align: center;
     padding: 0;
     color: ${(props) =>
       getReadableThemeTextColor(
-        props.theme.neutralLight,
+        props.$embed?.active ? props.theme.themeColors.white : props.theme.neutralLight,
         props.theme.headingsColor,
         props.theme.themeColors.white
       )};
@@ -93,10 +95,6 @@ const ListHeader = styled(Col)`
 
     @media (min-width: ${(props) => props.theme.breakpointMd}) {
       font-size: ${(props) => props.theme.fontSizeXl};
-    }
-
-    @media print {
-      background-color: #fff;
     }
   }
 `;
@@ -141,7 +139,7 @@ function ActionCardList(props: ActionCardListProps) {
   return (
     <Row>
       {displayHeader && (
-        <ListHeader xs="12">
+        <ListHeader xs="12" $embed={embed}>
           <h2>{t('recently-updated-actions', getActionTermContext(plan) || {})}</h2>
         </ListHeader>
       )}

--- a/src/components/actions/ActionHighlightsList.tsx
+++ b/src/components/actions/ActionHighlightsList.tsx
@@ -19,6 +19,7 @@ import images, { getActionImage } from '@/common/images';
 import { ActionListLink } from '@/common/links';
 import Button from '@/components/common/Button';
 import ErrorMessage from '@/components/common/ErrorMessage';
+import { getReadableThemeTextColor } from '@/components/contentblocks/colorUtils';
 import EmbedContext from '@/context/embed';
 
 import Icon from '../common/Icon';
@@ -80,10 +81,13 @@ export const GET_ACTION_LIST = gql`
 const ListHeader = styled(Col)`
   h2 {
     text-align: center;
-    padding: ${(props) => props.theme.spaces.s100};
-    border-radius: ${(props) => props.theme.cardBorderRadius};
-    background-color: ${(props) => props.theme.themeColors.white};
-    color: ${(props) => props.theme.headingsColor};
+    padding: 0;
+    color: ${(props) =>
+      getReadableThemeTextColor(
+        props.theme.neutralLight,
+        props.theme.headingsColor,
+        props.theme.themeColors.white
+      )};
     margin-bottom: ${(props) => props.theme.spaces.s300};
     font-size: ${(props) => props.theme.fontSizeLg};
 

--- a/src/components/contentblocks/ActionListBlock.tsx
+++ b/src/components/contentblocks/ActionListBlock.tsx
@@ -22,6 +22,8 @@ import ErrorMessage from '@/components/common/ErrorMessage';
 import { usePlan } from '@/context/plan';
 import { useWorkflowSelector } from '@/context/workflow-selector';
 
+import { getReadableThemeTextColor } from './colorUtils';
+
 const GET_ACTION_LIST_FOR_BLOCK = gql`
   query GetActionListForBlock(
     $plan: ID!
@@ -44,10 +46,14 @@ const ActionListSection = styled.div`
 
 export const SectionHeader = styled.h2`
   text-align: center;
-  padding: ${(props) => props.theme.spaces.s100};
-  border-radius: ${(props) => props.theme.cardBorderRadius};
-  background-color: ${(props) => props.theme.themeColors.white};
-  color: ${(props) => props.theme.headingsColor};
+  padding: 0;
+  background-color: transparent;
+  color: ${(props) =>
+    getReadableThemeTextColor(
+      props.theme.neutralLight,
+      props.theme.headingsColor,
+      props.theme.themeColors.white
+    )};
   margin-bottom: ${(props) => props.theme.spaces.s300};
   font-size: ${(props) => props.theme.fontSizeLg};
 

--- a/src/components/contentblocks/ActionListBlock.tsx
+++ b/src/components/contentblocks/ActionListBlock.tsx
@@ -47,7 +47,6 @@ const ActionListSection = styled.div`
 export const SectionHeader = styled.h2`
   text-align: center;
   padding: 0;
-  background-color: transparent;
   color: ${(props) =>
     getReadableThemeTextColor(
       props.theme.neutralLight,

--- a/src/components/contentblocks/CategoryListBlock.tsx
+++ b/src/components/contentblocks/CategoryListBlock.tsx
@@ -12,6 +12,7 @@ import { Link } from '@/common/links';
 import Card from '@/components/common/Card';
 import RichText from '@/components/common/RichText';
 import { SectionHeader } from '@/components/contentblocks/ActionListBlock';
+import { getReadableThemeTextColor } from './colorUtils';
 import { useFallbackCategories } from '@/context/categories';
 import { CATEGORY_FRAGMENT } from '@/fragments/category.fragment';
 
@@ -67,6 +68,15 @@ const CategoryListSection = styled.div`
       line-height: ${(props) => props.theme.lineHeightBase};
     }
   }
+`;
+
+const CategoryListHeader = styled(SectionHeader)`
+  color: ${({ theme }) =>
+    getReadableThemeTextColor(
+      getBackgroundColor(theme),
+      theme.headingsColor,
+      theme.themeColors.white
+    )};
 `;
 
 const CardHeader = styled.h3`
@@ -147,7 +157,7 @@ export default function CategoryListBlock(props: CategoryListBlockProps) {
   return (
     <CategoryListSection id={id}>
       <Container>
-        {heading ? <SectionHeader>{heading}</SectionHeader> : null}
+        {heading ? <CategoryListHeader>{heading}</CategoryListHeader> : null}
         {lead ? <RichText html={lead} className="lead-text" /> : null}
         <Row tag="ul" className="justify-content-center">
           {categories

--- a/src/components/contentblocks/colorUtils.ts
+++ b/src/components/contentblocks/colorUtils.ts
@@ -1,0 +1,17 @@
+import { readableColor } from 'polished';
+
+export const getReadableThemeTextColor = (
+  backgroundColor?: string,
+  darkColor?: string,
+  lightColor?: string
+) => {
+  if (!backgroundColor) {
+    return darkColor ?? '#000';
+  }
+
+  try {
+    return readableColor(backgroundColor, darkColor ?? '#000', lightColor ?? '#fff');
+  } catch {
+    return darkColor ?? '#000';
+  }
+};

--- a/src/components/paths/contentblocks/ActionListBlock.tsx
+++ b/src/components/paths/contentblocks/ActionListBlock.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from 'next-intl';
 import { Container } from 'reactstrap';
 
 import ContentLoader from '@common/components/ContentLoader';
+import { getReadableThemeTextColor } from '@/components/contentblocks/colorUtils';
 
 import type {
   ActionCardFragment,
@@ -94,10 +95,13 @@ const TabTitle = styled.h3`
 
 const SectionHeader = styled.h2`
   text-align: center;
-  padding: ${(props) => props.theme.spaces.s100};
-  border-radius: ${(props) => props.theme.cardBorderRadius};
-  background-color: ${(props) => props.theme.themeColors.white};
-  color: ${(props) => props.theme.headingsColor};
+  padding: 0;
+  color: ${(props) =>
+    getReadableThemeTextColor(
+      props.theme.neutralLight,
+      props.theme.headingsColor,
+      props.theme.themeColors.white
+    )};
   margin-bottom: ${(props) => props.theme.spaces.s300};
   font-size: ${(props) => props.theme.fontSizeLg};
 


### PR DESCRIPTION
## Description
Beautification: Remove the white background behind section headers and replace it with dynamic readable text color.
* Add shared `getReadableThemeTextColor` helper and reuse it in `ActionListBlock`, `ActionHighlightsList` and Paths `ActionListBlock`;
* `SectionHeader` is reused by other content blocks 

## Screenshots/Videos (if applicable)

Before:

<img width="706" height="757" alt="Screenshot 2026-05-28 at 16 37 48" src="https://github.com/user-attachments/assets/b4f2090b-3b91-4a5a-bdc5-0754262dfa9b" />


After:

<img width="715" height="735" alt="Screenshot 2026-05-28 at 16 38 41" src="https://github.com/user-attachments/assets/6682b999-03a0-493c-ad07-332f6c53f3cb" />

## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1214727092940640/task/1214727092940660?focus=true)

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes
---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)

