### PR TITLE
Sort action reports by latest

### DIFF
--- a/src/components/actions/blocks/ReportComparisonBlock.tsx
+++ b/src/components/actions/blocks/ReportComparisonBlock.tsx
@@ -104,12 +104,13 @@ const ReportComparisonBlock = (props) => {
       ({ field }) =>
         field.id === reportField && field.__typename === 'ActionAttributeTypeReportFieldBlock'
     )?.[0]?.attribute,
-  }));
-  reports.sort((a, b) => {
-    if (a.endDate == null || b.endDate == null) {
-      return 0;
-    }
-    return dayjs(a.endDate).diff(dayjs(b.endDate));
+  }))
+  .sort((a, b) => {
+    if (a.endDate == null && b.endDate == null) return 0;
+    if (a.endDate == null) return 1;
+    if (b.endDate == null) return -1;
+
+    return dayjs(b.endDate).diff(dayjs(a.endDate));
   });
 
   return (


### PR DESCRIPTION
## Description

Update the action report comparison block to sort reports by their end date, with the newest report shown first.
Previously we displayed reports in ascending order.

## Screenshots/Videos (if applicable)

before:

<img width="579" height="415" alt="Screenshot 2026-06-03 at 14 08 46" src="https://github.com/user-attachments/assets/1c303f50-8473-4b2f-947d-2d47f8a8cd68" />


after:

<img width="576" height="422" alt="Screenshot 2026-06-03 at 14 11 13" src="https://github.com/user-attachments/assets/0c201ee0-c551-41a0-b960-6b5b1d26ed20" />




## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1205310117865974/task/1215274566031526?focus=true)

## Requirements, dependencies and related PRs

nope

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [ feat ] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
