### PR TITLE
Fix/indicator single year dimension colors

### DIFF
--- a/src/components/graphs/legacy/IndicatorGraph.tsx
+++ b/src/components/graphs/legacy/IndicatorGraph.tsx
@@ -216,8 +216,8 @@ const createTraces: (params: CreateTracesParams) => TracesOutput = (params) => {
 
   const getMainColor = (index: number) => {
     const colors = plotColors.mainScale?.length ? plotColors.mainScale : ['#000000'];
-
-    return colors[index % colors.length];
+    const colorCount = Math.max(1, Math.min(numColors, colors.length));
+    return colors[index % colorCount];
   };
 
   const allXValues = [];

--- a/src/components/graphs/legacy/IndicatorGraph.tsx
+++ b/src/components/graphs/legacy/IndicatorGraph.tsx
@@ -430,14 +430,16 @@ function IndicatorGraph(props: IndicatorGraphProps) {
       return '#000000';
     });
 
+  const themeCategoryColors = theme.settings?.graphs?.categoryColors;
+
   const plotColors = {
     trace: theme.settings.graphs.totalLineColor,
     trend: theme.settings.graphs.trendLineColor,
     goalScale: theme.settings.graphs.goalLineColors,
     mainScale: categoryColors?.length
       ? categoryColors
-      : theme.settings.graphs.categoryColors?.length
-        ? theme.settings.graphs.categoryColors
+      : themeCategoryColors?.length
+        ? themeCategoryColors
         : ['#000000'],
     fillMarkers: theme.settings.graphs.fillMarkers,
     symbols: theme.settings.graphs.categorySymbols,

--- a/src/components/graphs/legacy/IndicatorGraph.tsx
+++ b/src/components/graphs/legacy/IndicatorGraph.tsx
@@ -214,6 +214,12 @@ const createTraces: (params: CreateTracesParams) => TracesOutput = (params) => {
     numSymbols = numColors = styleCount;
   }
 
+  const getMainColor = (index: number) => {
+    const colors = plotColors.mainScale?.length ? plotColors.mainScale : ['#000000'];
+
+    return colors[index % colors.length];
+  };
+
   const allXValues = [];
 
   const newTraces = traces.map((trace, idx) => {
@@ -226,11 +232,12 @@ const createTraces: (params: CreateTracesParams) => TracesOutput = (params) => {
     if (!hasTimeDimension) {
       modTrace.x = (modTrace.x as Datum[]).map((name) => splitLines(name as string));
       modTrace.type = 'bar';
+      const hasSingleTraceWithMultipleBars = traceCount === 1 && trace.x.length > 1;
       modTrace.marker = {
         color:
-          categoryCount < 2
-            ? trace.y.map((y, i) => plotColors.mainScale[i % numColors])
-            : plotColors.mainScale[idx % numColors],
+          categoryCount < 2 || hasSingleTraceWithMultipleBars
+            ? trace.y.map((y, i) => getMainColor(i))
+            : getMainColor(idx),
       };
       layoutConfig.barmode = 'group';
       layoutConfig.xaxis!.type = 'category';
@@ -401,11 +408,15 @@ function IndicatorGraph(props: IndicatorGraphProps) {
   const traceNames = traces.map((trace, idx) => {
     return trace.name;
   });
+  const traceCategoryNames = traces.flatMap((trace) =>
+    Array.isArray(trace.x) ? trace.x.map(String) : []
+  );
   const categoryColors = specification.dimensions[0]?.categories
     ?.filter((category) => {
       // Only include colours of existing traces. (Takes care of filtering out
       // total line if visualization has been defined not to include total line)
-      if (traceNames.includes(category.name)) return true;
+      if (traceNames.includes(category.name) || traceCategoryNames.includes(category.name))
+        return true;
       return false;
     })
     .map((category, idx) => {
@@ -423,7 +434,11 @@ function IndicatorGraph(props: IndicatorGraphProps) {
     trace: theme.settings.graphs.totalLineColor,
     trend: theme.settings.graphs.trendLineColor,
     goalScale: theme.settings.graphs.goalLineColors,
-    mainScale: categoryColors ?? theme.settings.graphs.categoryColors,
+    mainScale: categoryColors?.length
+      ? categoryColors
+      : theme.settings.graphs.categoryColors?.length
+        ? theme.settings.graphs.categoryColors
+        : ['#000000'],
     fillMarkers: theme.settings.graphs.fillMarkers,
     symbols: theme.settings.graphs.categorySymbols,
     goalSymbol: theme.settings.graphs.goalSymbol,


### PR DESCRIPTION
## Description

Fix: Indicator dimension colors configured in Admin are not displayed in the UI when an indicator has only one year of data.
Single-year indicators shown as bar charts, and their category names are stored differently from multi-year charts. The code only checked the multi-year structure, so it did not find the colours configured in Admin.

* Find dimension colors also from bar chart category names,
* Apply the admin-configured color to each bar;
* Add fallback if there are no colors available.

## Screenshots/Videos (if applicable)

Before:

<img width="1244" height="650" alt="newplot (1)" src="https://github.com/user-attachments/assets/045149dc-2184-4cb0-8e4a-a287ec38a14e" />

After:

<img width="1244" height="650" alt="newplot" src="https://github.com/user-attachments/assets/7749f49f-c334-462e-ad50-24d499cff57b" />


## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1205310117865974/task/1214768773911498?focus=true)

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [fix] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
