### PR TITLE
Gate indicator goal-met tick on column block flag

### DIFF
--- a/e2e-tests/__generated__/graphql.ts
+++ b/e2e-tests/__generated__/graphql.ts
@@ -1083,6 +1083,24 @@ export enum SiteGeneralContentOrganizationTerm {
   Organization = 'ORGANIZATION'
 }
 
+export type TestUserInput = {
+  defaultAdminPlanId: InputMaybe<Scalars['ID']['input']>;
+  email: Scalars['String']['input'];
+  isSuperuser: Scalars['Boolean']['input'];
+  password: Scalars['String']['input'];
+  roles: Array<TestUserRoleInput>;
+};
+
+export type TestUserRoleInput = {
+  kind: TestUserRoleKind;
+  targetId: Scalars['ID']['input'];
+};
+
+export enum TestUserRoleKind {
+  ActionContact = 'ACTION_CONTACT',
+  PlanAdmin = 'PLAN_ADMIN'
+}
+
 export type UserFeedbackMutationInput = {
   action: InputMaybe<Scalars['ID']['input']>;
   additionalFields: InputMaybe<Scalars['String']['input']>;

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -1084,6 +1084,24 @@ export enum SiteGeneralContentOrganizationTerm {
   Organization = 'ORGANIZATION'
 }
 
+export type TestUserInput = {
+  defaultAdminPlanId: InputMaybe<Scalars['ID']['input']>;
+  email: Scalars['String']['input'];
+  isSuperuser: Scalars['Boolean']['input'];
+  password: Scalars['String']['input'];
+  roles: Array<TestUserRoleInput>;
+};
+
+export type TestUserRoleInput = {
+  kind: TestUserRoleKind;
+  targetId: Scalars['ID']['input'];
+};
+
+export enum TestUserRoleKind {
+  ActionContact = 'ACTION_CONTACT',
+  PlanAdmin = 'PLAN_ADMIN'
+}
+
 export type UserFeedbackMutationInput = {
   action: InputMaybe<Scalars['ID']['input']>;
   additionalFields: InputMaybe<Scalars['String']['input']>;
@@ -5164,7 +5182,7 @@ export type IndicatorListPageFragmentFragment = (
     { id: string | null, columnLabel: string | null, columnHelpText: string | null, sourceField: IndicatorDashboardFieldName | null }
     & { __typename: 'IndicatorListColumn' }
   ) | (
-    { id: string | null, columnLabel: string | null, columnHelpText: string | null, sourceField: IndicatorDashboardFieldName | null, isNormalized: boolean, valueType: IndicatorColumnValueType, referenceYear: number | null, defaultYear: number | null, hideUnit: boolean }
+    { id: string | null, columnLabel: string | null, columnHelpText: string | null, sourceField: IndicatorDashboardFieldName | null, isNormalized: boolean, valueType: IndicatorColumnValueType, referenceYear: number | null, defaultYear: number | null, hideUnit: boolean, highlightGoalMet: boolean }
     & { __typename: 'IndicatorValueColumn' }
   )> | null, primaryFilters: Array<(
     { style: string | null, showAllLabel: string | null, depth: number | null, field: string, id: string | null, categoryType: (
@@ -13601,7 +13619,7 @@ export type GetContentPageQuery = (
       { id: string | null, columnLabel: string | null, columnHelpText: string | null, sourceField: IndicatorDashboardFieldName | null }
       & { __typename: 'IndicatorListColumn' }
     ) | (
-      { id: string | null, columnLabel: string | null, columnHelpText: string | null, sourceField: IndicatorDashboardFieldName | null, isNormalized: boolean, valueType: IndicatorColumnValueType, referenceYear: number | null, defaultYear: number | null, hideUnit: boolean }
+      { id: string | null, columnLabel: string | null, columnHelpText: string | null, sourceField: IndicatorDashboardFieldName | null, isNormalized: boolean, valueType: IndicatorColumnValueType, referenceYear: number | null, defaultYear: number | null, hideUnit: boolean, highlightGoalMet: boolean }
       & { __typename: 'IndicatorValueColumn' }
     )> | null, primaryFilters: Array<(
       { style: string | null, showAllLabel: string | null, depth: number | null, field: string, id: string | null, categoryType: (

--- a/src/common/__generated__/possible_types.json
+++ b/src/common/__generated__/possible_types.json
@@ -280,6 +280,10 @@
       "OperationInfo",
       "Plan"
     ],
+    "CreateTestUserPayload": [
+      "OperationInfo",
+      "User"
+    ],
     "DashboardColumnInterface": [
       "FieldColumnBlock",
       "IndicatorCategoryColumn",

--- a/src/components/indicators/IndicatorList.tsx
+++ b/src/components/indicators/IndicatorList.tsx
@@ -238,6 +238,7 @@ const getDefaultColumns = (
     defaultYear: null,
     referenceYear: null, // @deprecated, remove when type is updated
     hideUnit: false,
+    highlightGoalMet: true,
   });
 
   if (displayNormalizedValues) {
@@ -252,6 +253,7 @@ const getDefaultColumns = (
       defaultYear: null,
       referenceYear: null, // @deprecated, remove when type is updated
       hideUnit: false,
+      highlightGoalMet: true,
     });
   }
   return columns;

--- a/src/components/indicators/IndicatorTableCell.tsx
+++ b/src/components/indicators/IndicatorTableCell.tsx
@@ -255,10 +255,11 @@ interface IndicatorValueCellProps {
   valueType: IndicatorColumnValueType;
   defaultYear: number | null;
   hideUnit: boolean;
+  highlightGoalMet: boolean;
 }
 
 const IndicatorValueCell = (props: IndicatorValueCellProps) => {
-  const { indicator, isNormalized, valueType, defaultYear, hideUnit } = props;
+  const { indicator, isNormalized, valueType, defaultYear, hideUnit, highlightGoalMet } = props;
   const formatNumber = useNumberFormatter({
     maximumSignificantDigits: indicator.valueRounding ?? undefined,
   });
@@ -306,10 +307,11 @@ const IndicatorValueCell = (props: IndicatorValueCellProps) => {
 
   const unitName = unit.shortName || unit.name;
 
-  // Show the tick only for the Latest/current-status column.
-  // This uses the same goal-exceeded logic as the indicator summary utility.
+  // Show the tick only for the Latest/current-status column when the
+  // admin has enabled `highlightGoalMet` on the column block.
   const showGoalAchievedIcon =
     valueType === IndicatorColumnValueType.Latest &&
+    highlightGoalMet &&
     isGoalAlreadyExceeded({
       currentValue: value,
       values: indicator.values,
@@ -475,6 +477,7 @@ const IndicatorTableCell = (props: IndicatorTableCellProps) => {
           valueType={column.valueType}
           defaultYear={column.defaultYear}
           hideUnit={column.hideUnit}
+          highlightGoalMet={column.highlightGoalMet}
         />
       );
     case 'IndicatorCategoryColumn':

--- a/src/fragments/indicator-list.fragment.ts
+++ b/src/fragments/indicator-list.fragment.ts
@@ -82,6 +82,7 @@ export const INDICATOR_LIST_PAGE_FRAGMENT = gql`
         referenceYear
         defaultYear
         hideUnit
+        highlightGoalMet
       }
       ... on IndicatorCategoryColumn {
         id


### PR DESCRIPTION
## Description
Read highlightGoalMet from the IndicatorValueColumn fragment and require it (in addition to the existing Latest-value check) before rendering the green check next to a value. Default-column fallbacks default the flag to true so plans without configured list_columns keep the tick.

Companion to the kausal-watch backend change adding the per-column flag on IndicatorValueColumn.

## Screenshots/Videos (if applicable)
<img width="180" height="95" alt="image" src="https://github.com/user-attachments/assets/b52d0ca3-4991-4ecc-af79-d146dc5298fb" />


## Related issue
https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1214566034369730

## Requirements, dependencies and related PRs
Backend: https://github.com/kausaltech/kausal-watch/pull/612

## Additional Notes

Any additional information that reviewers should know about this PR.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [-] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
