### PR TITLE
Fix/change log overrides

### DIFF
--- a/e2e-tests/__generated__/graphql.ts
+++ b/e2e-tests/__generated__/graphql.ts
@@ -1083,24 +1083,6 @@ export enum SiteGeneralContentOrganizationTerm {
   Organization = 'ORGANIZATION'
 }
 
-export type TestUserInput = {
-  defaultAdminPlanId: InputMaybe<Scalars['ID']['input']>;
-  email: Scalars['String']['input'];
-  isSuperuser: Scalars['Boolean']['input'];
-  password: Scalars['String']['input'];
-  roles: Array<TestUserRoleInput>;
-};
-
-export type TestUserRoleInput = {
-  kind: TestUserRoleKind;
-  targetId: Scalars['ID']['input'];
-};
-
-export enum TestUserRoleKind {
-  ActionContact = 'ACTION_CONTACT',
-  PlanAdmin = 'PLAN_ADMIN'
-}
-
 export type UserFeedbackMutationInput = {
   action: InputMaybe<Scalars['ID']['input']>;
   additionalFields: InputMaybe<Scalars['String']['input']>;

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -8790,19 +8790,19 @@ export type GetActionDetailsQuery = (
           & { __typename: 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionPledgesBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'ChangeLogMessageBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardHeaderBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' }
+          & { __typename: 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardHeaderBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' }
+          & { __typename: 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'IndicatorBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' }
+          & { __typename: 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' }
+          & { __typename: 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+          & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
         ) | (
           { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
             { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
@@ -8838,7 +8838,7 @@ export type GetActionDetailsQuery = (
           & { __typename: 'ActionOfficialNameBlock' }
         ) | (
           { id: string | null, fieldLabel: string | null, fieldHelpText: string | null }
-          & { __typename: 'ActionRelatedActionsBlock' | 'ActionTasksBlock' }
+          & { __typename: 'ActionRelatedActionsBlock' | 'ActionTasksBlock' | 'ChangeLogMessageBlock' }
         ) | (
           { id: string | null, reportField: string | null, reportType: (
             { name: string }
@@ -9522,19 +9522,19 @@ export type GetActionDetailsQuery = (
           & { __typename: 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionPledgesBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'ChangeLogMessageBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardHeaderBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' }
+          & { __typename: 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardHeaderBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' }
+          & { __typename: 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'IndicatorBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' }
+          & { __typename: 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' }
+          & { __typename: 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+          & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
         ) | (
           { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
             { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
@@ -9570,7 +9570,7 @@ export type GetActionDetailsQuery = (
           & { __typename: 'ActionOfficialNameBlock' }
         ) | (
           { id: string | null, fieldLabel: string | null, fieldHelpText: string | null }
-          & { __typename: 'ActionRelatedActionsBlock' | 'ActionTasksBlock' }
+          & { __typename: 'ActionRelatedActionsBlock' | 'ActionTasksBlock' | 'ChangeLogMessageBlock' }
         ) | (
           { id: string | null, reportField: string | null, reportType: (
             { name: string }
@@ -10945,19 +10945,19 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
     & { __typename: 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionPledgesBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionUpdatedAtBlock' | 'AdaptiveEmbedBlock' | 'BlockQuoteBlock' | 'BooleanBlock' | 'CardBlock' | 'CardListBlock' }
   ) | (
     { id: string | null }
-    & { __typename: 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'ChangeLogMessageBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardHeaderBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' }
+    & { __typename: 'CartographyVisualisationBlock' | 'CategoryListBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTreeMapBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'CategoryTypeLevelListBlock' | 'CharBlock' | 'ChoiceBlock' | 'ContinuousActionFilterBlock' | 'DashboardHeaderBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' }
   ) | (
     { id: string | null }
-    & { __typename: 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' }
+    & { __typename: 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' }
   ) | (
     { id: string | null }
-    & { __typename: 'IndicatorBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' }
+    & { __typename: 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' }
   ) | (
     { id: string | null }
-    & { __typename: 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' }
+    & { __typename: 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' }
   ) | (
     { id: string | null }
-    & { __typename: 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+    & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
   ) | (
     { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
       { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
@@ -10993,7 +10993,7 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
     & { __typename: 'ActionOfficialNameBlock' }
   ) | (
     { id: string | null, fieldLabel: string | null, fieldHelpText: string | null }
-    & { __typename: 'ActionRelatedActionsBlock' | 'ActionTasksBlock' }
+    & { __typename: 'ActionRelatedActionsBlock' | 'ActionTasksBlock' | 'ChangeLogMessageBlock' }
   ) | (
     { id: string | null, reportField: string | null, reportType: (
       { name: string }

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -1084,24 +1084,6 @@ export enum SiteGeneralContentOrganizationTerm {
   Organization = 'ORGANIZATION'
 }
 
-export type TestUserInput = {
-  defaultAdminPlanId: InputMaybe<Scalars['ID']['input']>;
-  email: Scalars['String']['input'];
-  isSuperuser: Scalars['Boolean']['input'];
-  password: Scalars['String']['input'];
-  roles: Array<TestUserRoleInput>;
-};
-
-export type TestUserRoleInput = {
-  kind: TestUserRoleKind;
-  targetId: Scalars['ID']['input'];
-};
-
-export enum TestUserRoleKind {
-  ActionContact = 'ACTION_CONTACT',
-  PlanAdmin = 'PLAN_ADMIN'
-}
-
 export type UserFeedbackMutationInput = {
   action: InputMaybe<Scalars['ID']['input']>;
   additionalFields: InputMaybe<Scalars['String']['input']>;
@@ -5252,24 +5234,24 @@ type StreamFieldFragment_R09yqk4psU42m1Xyl5uzMj8ASeDltROxoT0mwLuSlc_Fragment = (
   & { __typename: 'ActionManualStatusReasonBlock' | 'ActionMergedActionsBlock' | 'ActionOfficialNameBlock' | 'ActionPledgesBlock' | 'ActionPrimaryOrgBlock' | 'ActionRelatedActionsBlock' | 'ActionRelatedIndicatorsBlock' | 'ActionResponsiblePartiesBlock' | 'ActionResponsiblePartyReportFieldBlock' | 'ActionScheduleBlock' | 'ActionScheduleContinuousBlock' | 'ActionScheduleFilterBlock' | 'ActionStartDateBlock' | 'ActionStatusFilterBlock' | 'ActionStatusGraphsBlock' | 'ActionStatusReportFieldBlock' | 'ActionTasksBlock' | 'ActionUpdatedAtBlock' | 'BlockQuoteBlock' | 'BooleanBlock' }
 );
 
-type StreamFieldFragment_JcAgCTcuFwxZpf8b4voMy1vApiHQdH3As00DYaD3Tgm_Fragment = (
+type StreamFieldFragment_OVWpOvqViBr7pviLj3iLFobjZcWpuNlFBt5QfC4_Fragment = (
   { id: string | null, blockType: string, field: string }
-  & { __typename: 'CardBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'ChangeLogMessageBlock' | 'ContinuousActionFilterBlock' | 'DashboardHeaderBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' }
+  & { __typename: 'CardBlock' | 'CategoryPageAttributeTypeBlock' | 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'CategoryPageContactFormBlock' | 'CategoryPageProgressBlock' | 'CategoryTypeDatasetsBlock' | 'CategoryTypeFilterBlock' | 'ContinuousActionFilterBlock' | 'DashboardHeaderBlock' | 'DashboardIndicatorAreaChartBlock' | 'DashboardIndicatorBarChartBlock' | 'DashboardIndicatorLineChartBlock' | 'DashboardIndicatorPieChartBlock' | 'DashboardIndicatorSummaryBlock' | 'DashboardParagraphBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' }
 );
 
-type StreamFieldFragment_APZjNLnndh7iRd9qAjBzv9K4y6GooFDzOcjk39RkKeQ_Fragment = (
+type StreamFieldFragment_W2zOgck3SpPtZi5A5saJLpenH2ogwhIsYhGosbJ8c_Fragment = (
   { id: string | null, blockType: string, field: string }
-  & { __typename: 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorHighlightsBlock' }
+  & { __typename: 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' }
 );
 
-type StreamFieldFragment_VYbmLMfvNTozDKqhT2uRZfvFr2YqqIpSjZhK6dLkxe_Fragment = (
+type StreamFieldFragment_KTz1TgIjno5h7oJvKjoqnZxozYxzJxRk5jUApXzq_Fragment = (
   { id: string | null, blockType: string, field: string }
-  & { __typename: 'IndicatorListColumn' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' }
+  & { __typename: 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
 );
 
-type StreamFieldFragment_Ys4HYkQAlXwzZQnj9p7hTlYcZtqFBmul0FyeNgEuCf8_Fragment = (
+type StreamFieldFragment_ROQtCmpbhpHtWju3UmvLJiPdRdNespIkDrUlcLsw8s_Fragment = (
   { id: string | null, blockType: string, field: string }
-  & { __typename: 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+  & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
 );
 
 type StreamFieldFragment_AccessibilityStatementContactInformationBlock_Fragment = (
@@ -5947,6 +5929,11 @@ type StreamFieldFragment_CategoryTypeLevelListBlock_Fragment = (
   & { __typename: 'CategoryTypeLevelListBlock' }
 );
 
+type StreamFieldFragment_ChangeLogMessageBlock_Fragment = (
+  { fieldLabel: string | null, fieldHelpText: string | null, id: string | null, blockType: string, field: string }
+  & { __typename: 'ChangeLogMessageBlock' }
+);
+
 type StreamFieldFragment_CharBlock_RichTextBlock_TextBlock_Fragment = (
   { value: string, id: string | null, blockType: string, field: string }
   & { __typename: 'CharBlock' | 'RichTextBlock' | 'TextBlock' }
@@ -6258,7 +6245,7 @@ type StreamFieldFragment_QuestionAnswerBlock_Fragment = (
   & { __typename: 'QuestionAnswerBlock' }
 );
 
-export type StreamFieldFragmentFragment = StreamFieldFragment_CsWpOaD0dUEdhV96j5U9TnlDssZTxlWikakK8ZjePw_Fragment | StreamFieldFragment_R09yqk4psU42m1Xyl5uzMj8ASeDltROxoT0mwLuSlc_Fragment | StreamFieldFragment_JcAgCTcuFwxZpf8b4voMy1vApiHQdH3As00DYaD3Tgm_Fragment | StreamFieldFragment_APZjNLnndh7iRd9qAjBzv9K4y6GooFDzOcjk39RkKeQ_Fragment | StreamFieldFragment_VYbmLMfvNTozDKqhT2uRZfvFr2YqqIpSjZhK6dLkxe_Fragment | StreamFieldFragment_Ys4HYkQAlXwzZQnj9p7hTlYcZtqFBmul0FyeNgEuCf8_Fragment | StreamFieldFragment_AccessibilityStatementContactInformationBlock_Fragment | StreamFieldFragment_ActionCategoryFilterCardsBlock_Fragment | StreamFieldFragment_ActionListBlock_Fragment | StreamFieldFragment_AdaptiveEmbedBlock_Fragment | StreamFieldFragment_CardListBlock_Fragment | StreamFieldFragment_CartographyVisualisationBlock_Fragment | StreamFieldFragment_CategoryListBlock_Fragment | StreamFieldFragment_CategoryTreeMapBlock_Fragment | StreamFieldFragment_CategoryTypeLevelListBlock_Fragment | StreamFieldFragment_CharBlock_RichTextBlock_TextBlock_Fragment | StreamFieldFragment_ChoiceBlock_Fragment | StreamFieldFragment_DashboardRowBlock_Fragment | StreamFieldFragment_FrontPageHeroBlock_Fragment | StreamFieldFragment_IndicatorBlock_Fragment | StreamFieldFragment_IndicatorGroupBlock_Fragment | StreamFieldFragment_IndicatorShowcaseBlock_Fragment | StreamFieldFragment_LargeImageBlock_Fragment | StreamFieldFragment_PathsOutcomeBlock_Fragment | StreamFieldFragment_QuestionAnswerBlock_Fragment;
+export type StreamFieldFragmentFragment = StreamFieldFragment_CsWpOaD0dUEdhV96j5U9TnlDssZTxlWikakK8ZjePw_Fragment | StreamFieldFragment_R09yqk4psU42m1Xyl5uzMj8ASeDltROxoT0mwLuSlc_Fragment | StreamFieldFragment_OVWpOvqViBr7pviLj3iLFobjZcWpuNlFBt5QfC4_Fragment | StreamFieldFragment_W2zOgck3SpPtZi5A5saJLpenH2ogwhIsYhGosbJ8c_Fragment | StreamFieldFragment_KTz1TgIjno5h7oJvKjoqnZxozYxzJxRk5jUApXzq_Fragment | StreamFieldFragment_ROQtCmpbhpHtWju3UmvLJiPdRdNespIkDrUlcLsw8s_Fragment | StreamFieldFragment_AccessibilityStatementContactInformationBlock_Fragment | StreamFieldFragment_ActionCategoryFilterCardsBlock_Fragment | StreamFieldFragment_ActionListBlock_Fragment | StreamFieldFragment_AdaptiveEmbedBlock_Fragment | StreamFieldFragment_CardListBlock_Fragment | StreamFieldFragment_CartographyVisualisationBlock_Fragment | StreamFieldFragment_CategoryListBlock_Fragment | StreamFieldFragment_CategoryTreeMapBlock_Fragment | StreamFieldFragment_CategoryTypeLevelListBlock_Fragment | StreamFieldFragment_ChangeLogMessageBlock_Fragment | StreamFieldFragment_CharBlock_RichTextBlock_TextBlock_Fragment | StreamFieldFragment_ChoiceBlock_Fragment | StreamFieldFragment_DashboardRowBlock_Fragment | StreamFieldFragment_FrontPageHeroBlock_Fragment | StreamFieldFragment_IndicatorBlock_Fragment | StreamFieldFragment_IndicatorGroupBlock_Fragment | StreamFieldFragment_IndicatorShowcaseBlock_Fragment | StreamFieldFragment_LargeImageBlock_Fragment | StreamFieldFragment_PathsOutcomeBlock_Fragment | StreamFieldFragment_QuestionAnswerBlock_Fragment;
 
 export type GetActionDetailsQueryVariables = Exact<{
   plan: Scalars['ID']['input'];
@@ -13397,8 +13384,8 @@ export type GetContentPageQuery = (
       ) | null }
       & { __typename: 'CategoryListBlock' }
     ) | (
-      { id: string | null, blockType: string, field: string }
-      & { __typename: 'ChangeLogMessageBlock' | 'RelatedIndicatorsBlock' }
+      { fieldLabel: string | null, fieldHelpText: string | null, id: string | null, blockType: string, field: string }
+      & { __typename: 'ChangeLogMessageBlock' }
     ) | (
       { id: string | null, blockType: string, field: string, blocks: Array<(
         { blockType: string }
@@ -13555,6 +13542,9 @@ export type GetContentPageQuery = (
         & { __typename: 'QuestionBlock' }
       )> | null }
       & { __typename: 'QuestionAnswerBlock' }
+    ) | (
+      { id: string | null, blockType: string, field: string }
+      & { __typename: 'RelatedIndicatorsBlock' }
     ) | (
       { value: string, id: string | null, blockType: string, field: string }
       & { __typename: 'RichTextBlock' }
@@ -14291,7 +14281,7 @@ export type GetContentPageQuery = (
       ) }
       & { __typename: 'CategoryTypeLevelListBlock' }
     ) | (
-      { id: string | null, blockType: string, field: string }
+      { fieldLabel: string | null, fieldHelpText: string | null, id: string | null, blockType: string, field: string }
       & { __typename: 'ChangeLogMessageBlock' }
     ) | (
       { id: string | null, blockType: string, field: string, blocks: Array<(
@@ -14565,7 +14555,7 @@ export type GetHomePageQuery = (
       & { __typename: 'ActionCategoryFilterCardsBlock' }
     ) | (
       { id: string | null, blockType: string, field: string }
-      & { __typename: 'ActionHighlightsBlock' | 'ActionStatusGraphsBlock' | 'ChangeLogMessageBlock' | 'IndicatorHighlightsBlock' | 'RelatedPlanListBlock' }
+      & { __typename: 'ActionHighlightsBlock' | 'ActionStatusGraphsBlock' | 'IndicatorHighlightsBlock' | 'RelatedPlanListBlock' }
     ) | (
       { title: string | null, description: string | null, fullWidth: boolean | null, id: string | null, blockType: string, field: string, embed: (
         { html: string | null }
@@ -14917,6 +14907,9 @@ export type GetHomePageQuery = (
         & { __typename: 'CategoryType' }
       ) }
       & { __typename: 'CategoryTreeMapBlock' }
+    ) | (
+      { fieldLabel: string | null, fieldHelpText: string | null, id: string | null, blockType: string, field: string }
+      & { __typename: 'ChangeLogMessageBlock' }
     ) | (
       { id: string | null, blockType: string, field: string, blocks: Array<(
         { blockType: string }

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -9173,7 +9173,7 @@ export type GetActionDetailsQuery = (
         ) | null }
         & { __typename: 'ActionOfficialNameBlock' }
       ) | (
-        { id: string | null }
+        { id: string | null, fieldLabel: string | null, fieldHelpText: string | null }
         & { __typename: 'ChangeLogMessageBlock' }
       ) | (
         { id: string | null, field: string, meta: (
@@ -9905,7 +9905,7 @@ export type GetActionDetailsQuery = (
         ) | null }
         & { __typename: 'ActionOfficialNameBlock' }
       ) | (
-        { id: string | null }
+        { id: string | null, fieldLabel: string | null, fieldHelpText: string | null }
         & { __typename: 'ChangeLogMessageBlock' }
       ) | (
         { id: string | null, field: string, meta: (
@@ -10259,7 +10259,7 @@ export type GetActionDetailsQuery = (
         ) | null }
         & { __typename: 'ActionResponsiblePartiesBlock' }
       ) | (
-        { id: string | null }
+        { id: string | null, fieldLabel: string | null, fieldHelpText: string | null }
         & { __typename: 'ChangeLogMessageBlock' }
       )> | null }
       & { __typename: 'ActionListPage' }
@@ -10898,7 +10898,7 @@ type ActionAsideContentBlocksFragment_ActionResponsiblePartiesBlock_Fragment = (
 );
 
 type ActionAsideContentBlocksFragment_ChangeLogMessageBlock_Fragment = (
-  { id: string | null }
+  { id: string | null, fieldLabel: string | null, fieldHelpText: string | null }
   & { __typename: 'ChangeLogMessageBlock' }
 );
 
@@ -11336,7 +11336,7 @@ type ActionMainContentBlocksFragment_ActionOfficialNameBlock_Fragment = (
 );
 
 type ActionMainContentBlocksFragment_ChangeLogMessageBlock_Fragment = (
-  { id: string | null }
+  { id: string | null, fieldLabel: string | null, fieldHelpText: string | null }
   & { __typename: 'ChangeLogMessageBlock' }
 );
 

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -12376,7 +12376,7 @@ export type TemplatedCategoryPageFragmentFragment = (
         & { __typename: 'AttributeType' }
       ) }
       & { __typename: 'CategoryPageAttributeTypeBlock' }
-    ) | { __typename: 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'ChangeLogMessageBlock' } | (
+    ) | { __typename: 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' } | (
       { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
         { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
           { choiceLabel: string | null, choiceValue: string | null }
@@ -12391,6 +12391,9 @@ export type TemplatedCategoryPageFragmentFragment = (
         & { __typename: 'DatasetSchema' }
       ) }
       & { __typename: 'CategoryTypeDatasetsBlock' }
+    ) | (
+      { fieldLabel: string | null, fieldHelpText: string | null }
+      & { __typename: 'ChangeLogMessageBlock' }
     )> | null }
     & { __typename: 'CategoryTypePageLevelLayout' }
   ) | null }
@@ -13570,7 +13573,7 @@ export type GetContentPageQuery = (
           & { __typename: 'AttributeType' }
         ) }
         & { __typename: 'CategoryPageAttributeTypeBlock' }
-      ) | { __typename: 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' | 'ChangeLogMessageBlock' } | (
+      ) | { __typename: 'CategoryPageBodyBlock' | 'CategoryPageCategoryListBlock' } | (
         { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
           { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
             { choiceLabel: string | null, choiceValue: string | null }
@@ -13585,6 +13588,9 @@ export type GetContentPageQuery = (
           & { __typename: 'DatasetSchema' }
         ) }
         & { __typename: 'CategoryTypeDatasetsBlock' }
+      ) | (
+        { fieldLabel: string | null, fieldHelpText: string | null }
+        & { __typename: 'ChangeLogMessageBlock' }
       )> | null }
       & { __typename: 'CategoryTypePageLevelLayout' }
     ) | null }

--- a/src/common/__generated__/possible_types.json
+++ b/src/common/__generated__/possible_types.json
@@ -223,9 +223,6 @@
       "AttributeRichText",
       "AttributeText"
     ],
-    "CategoryPageAsideBlock": [
-      "CategoryPageAttributeTypeBlock"
-    ],
     "CategoryPageBodyUnion": [
       "ActionListBlock",
       "AdaptiveEmbedBlock",
@@ -279,10 +276,6 @@
     "CreatePlanPayload": [
       "OperationInfo",
       "Plan"
-    ],
-    "CreateTestUserPayload": [
-      "OperationInfo",
-      "User"
     ],
     "DashboardColumnInterface": [
       "FieldColumnBlock",

--- a/src/components/actions/ActionContent.tsx
+++ b/src/components/actions/ActionContent.tsx
@@ -333,6 +333,8 @@ function ActionContentBlock(props: ActionContentBlockProps) {
           entityType="action"
           entityId={String(action.id)}
           entry={action.changeLogMessage}
+          fieldLabel={block.fieldLabel}
+          fieldHelpText={block.fieldHelpText}
         />
       );
     }

--- a/src/components/common/CategoryPageStreamField.tsx
+++ b/src/components/common/CategoryPageStreamField.tsx
@@ -54,6 +54,12 @@ export type CategoryPageMainBottomBlock = NonNullable<
   CategoryPageLayout['layoutMainBottom']
 >[number];
 
+type ChangeLogMessageBlockWithOverrides = {
+  __typename: 'ChangeLogMessageBlock';
+  fieldLabel?: string | null;
+  fieldHelpText?: string | null;
+};
+
 interface Props {
   page: CategoryPage;
   context?: 'hero' | 'main' | 'aside';
@@ -223,6 +229,7 @@ export default function CategoryPageStreamField({
       if (!plan.features.enableChangeLog || !page.category?.id || !page.category?.changeLogMessage)
         return null;
 
+      const changeLogBlock = block as ChangeLogMessageBlockWithOverrides;
       const withContainer = context === 'main';
 
       return (
@@ -232,6 +239,8 @@ export default function CategoryPageStreamField({
               entityType="page"
               entityId={String(page.category.id)}
               entry={page.category.changeLogMessage}
+              fieldLabel={changeLogBlock.fieldLabel}
+              fieldHelpText={changeLogBlock.fieldHelpText}
             />
           </Col>
         </Wrapper>

--- a/src/components/common/ChangeHistory.tsx
+++ b/src/components/common/ChangeHistory.tsx
@@ -144,11 +144,9 @@ const FooterMeta = styled.div`
   gap: ${(props) => props.theme.spaces.s050};
 `;
 
-const HelpText = styled.p`
-  margin: 0 0 ${(props) => props.theme.spaces.s150};
-  color: ${(props) => props.theme.themeColors.dark};
-  font-size: ${(props) => props.theme.fontSizeSm};
-  line-height: 1.5;
+const ChangesLabel = styled.div`
+  font-weight: 600;
+  margin-bottom: ${(props) => props.theme.spaces.s050};
 `;
 
 const ChangeHistory: React.FC<ChangeHistoryProps> = ({
@@ -165,7 +163,7 @@ const ChangeHistory: React.FC<ChangeHistoryProps> = ({
   const formattedDate = dayjs(entry.updatedAt).format('L');
 
   const modalTitle = fieldLabel?.trim() || t('change-history.modal-title');
-  const descriptionHelpText = fieldHelpText?.trim();
+  const descriptionLabel = fieldHelpText?.trim() || t('change-history.description-label');
 
   const open = () => setIsOpen(true);
   const close = () => setIsOpen(false);
@@ -208,7 +206,7 @@ const ChangeHistory: React.FC<ChangeHistoryProps> = ({
               <Icon.Times />
             </CloseButton>
           </DialogHeader>
-          {descriptionHelpText && <HelpText>{descriptionHelpText}</HelpText>}
+          <ChangesLabel>{descriptionLabel}</ChangesLabel>
           {entry.content && <ChangesText>{entry.content}</ChangesText>}
           <ModalFooterRow>
             {entry.createdBy && <Avatar $url={entry.createdBy.avatarUrl} />}

--- a/src/components/common/ChangeHistory.tsx
+++ b/src/components/common/ChangeHistory.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from 'react';
 
 import styled from '@emotion/styled';
+
 import { useTranslations } from 'next-intl';
 
 import dayjs from '@/common/dayjs';
@@ -24,6 +25,8 @@ type ChangeHistoryProps = {
   entityType: EntityType;
   entityId: string;
   entry?: ChangeHistoryEntry | null;
+  fieldLabel?: string | null;
+  fieldHelpText?: string | null;
 };
 
 const Wrapper = styled.div`
@@ -122,11 +125,6 @@ const ChangesTitle = styled.h2`
   margin: 0 0 ${(props) => props.theme.spaces.s150};
 `;
 
-const ChangesLabel = styled.div`
-  font-weight: 600;
-  margin-bottom: ${(props) => props.theme.spaces.s050};
-`;
-
 const ChangesText = styled.p`
   margin: 0 0 ${(props) => props.theme.spaces.s200};
   line-height: 1.5;
@@ -146,12 +144,28 @@ const FooterMeta = styled.div`
   gap: ${(props) => props.theme.spaces.s050};
 `;
 
-const ChangeHistory: React.FC<ChangeHistoryProps> = ({ entityType, entityId, entry }) => {
+const HelpText = styled.p`
+  margin: 0 0 ${(props) => props.theme.spaces.s150};
+  color: ${(props) => props.theme.themeColors.dark};
+  font-size: ${(props) => props.theme.fontSizeSm};
+  line-height: 1.5;
+`;
+
+const ChangeHistory: React.FC<ChangeHistoryProps> = ({
+  entityType,
+  entityId,
+  entry,
+  fieldLabel,
+  fieldHelpText,
+}) => {
   const t = useTranslations();
   const [isOpen, setIsOpen] = useState(false);
   if (!entry) return null;
 
   const formattedDate = dayjs(entry.updatedAt).format('L');
+
+  const modalTitle = fieldLabel?.trim() || t('change-history.modal-title');
+  const descriptionHelpText = fieldHelpText?.trim();
 
   const open = () => setIsOpen(true);
   const close = () => setIsOpen(false);
@@ -185,7 +199,7 @@ const ChangeHistory: React.FC<ChangeHistoryProps> = ({ entityType, entityId, ent
       >
         <Dialog onClick={(e) => e.stopPropagation()}>
           <DialogHeader>
-            <ChangesTitle>{t('change-history.modal-title')}</ChangesTitle>
+            <ChangesTitle>{modalTitle}</ChangesTitle>
             <CloseButton
               type="button"
               onClick={close}
@@ -194,8 +208,8 @@ const ChangeHistory: React.FC<ChangeHistoryProps> = ({ entityType, entityId, ent
               <Icon.Times />
             </CloseButton>
           </DialogHeader>
-          <ChangesLabel>{t('change-history.description-label')}</ChangesLabel>
-          <ChangesText>{entry.content}</ChangesText>
+          {descriptionHelpText && <HelpText>{descriptionHelpText}</HelpText>}
+          {entry.content && <ChangesText>{entry.content}</ChangesText>}
           <ModalFooterRow>
             {entry.createdBy && <Avatar $url={entry.createdBy.avatarUrl} />}
             <FooterMeta>

--- a/src/components/common/StreamField.tsx
+++ b/src/components/common/StreamField.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+
 import * as Sentry from '@sentry/nextjs';
 import { useTranslations } from 'next-intl';
 import type { ColProps } from 'reactstrap';
@@ -658,7 +659,15 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
         const entityId = page.category?.id;
         if (!entry || !entityId) return null;
 
-        return <ChangeHistory entityType="category" entityId={entityId} entry={entry} />;
+        return (
+          <ChangeHistory
+            entityType="category"
+            entityId={entityId}
+            entry={entry}
+            fieldLabel={block.fieldLabel}
+            fieldHelpText={block.fieldHelpText}
+          />
+        );
       }
       // Static + Home
       if (page.__typename === 'StaticPage' || page.__typename === 'PlanRootPage') {
@@ -672,7 +681,13 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
                 xl={{ size: hasSidebar ? 9 : 12, offset: hasSidebar ? 3 : 0 }}
                 lg={{ size: hasSidebar ? 8 : 12, offset: hasSidebar ? 4 : 0 }}
               >
-                <ChangeHistory entityType="page" entityId={String(page.id)} entry={entry} />
+                <ChangeHistory
+                  entityType="page"
+                  entityId={String(page.id)}
+                  entry={entry}
+                  fieldLabel={block.fieldLabel}
+                  fieldHelpText={block.fieldHelpText}
+                />
               </Col>
             </Row>
           </Container>

--- a/src/fragments/stream-field.fragment.ts
+++ b/src/fragments/stream-field.fragment.ts
@@ -15,6 +15,8 @@ export const STREAM_FIELD_FRAGMENT = gql`
     }
     ... on ChangeLogMessageBlock {
       __typename
+      fieldLabel
+      fieldHelpText
     }
     ... on TextBlock {
       value

--- a/src/queries/get-action.ts
+++ b/src/queries/get-action.ts
@@ -497,6 +497,10 @@ const GET_ACTION_DETAILS = gql`
             ...CategoryTypeFragment
           }
         }
+        ... on ChangeLogMessageBlock {
+          fieldLabel
+          fieldHelpText
+        }
         ... on ReportComparisonBlock {
           ...ReportComparisonBlockActionContent
         }

--- a/src/queries/get-action.ts
+++ b/src/queries/get-action.ts
@@ -369,6 +369,10 @@ const GET_ACTION_DETAILS = gql`
     ... on StreamFieldInterface {
       id
     }
+    ... on ChangeLogMessageBlock {
+      fieldLabel
+      fieldHelpText
+    }
     ... on ActionContentAttributeTypeBlock {
       attributeType {
         ...AttributesBlockAttributeType
@@ -401,6 +405,10 @@ const GET_ACTION_DETAILS = gql`
       fieldHelpText
     }
     ... on ActionDependenciesBlock {
+      fieldLabel
+      fieldHelpText
+    }
+    ... on ChangeLogMessageBlock {
       fieldLabel
       fieldHelpText
     }

--- a/src/queries/get-content-page.ts
+++ b/src/queries/get-content-page.ts
@@ -88,6 +88,10 @@ const TEMPLATED_CATEGORY_PAGE_FRAGMENT = gql`
             uuid
           }
         }
+        ... on ChangeLogMessageBlock {
+          fieldLabel
+          fieldHelpText
+        }
       }
     }
   }


### PR DESCRIPTION
## Description

Asana: Field label and help text overrides not applied in Watch UI change history message content block

Add support for configured in Admin field label and help text overrides in the change history block.

* Fetch `fieldLabel` and `fieldHelpText` for `ChangeLogMessageBlock` in action content blocks and streamfield.
* Update`ChangeHistory`:
  - `fieldLabel` overrides the modal title.
  - `fieldHelpText` is displayed under the modal title.
  -  fallback to the default label and text  when overrides are not configured.
  
## Screenshots/Videos (if applicable)

Confugured fields in Admin:
<img width="1144" height="431" alt="Screenshot 2026-06-09 at 11 19 22" src="https://github.com/user-attachments/assets/d96b4286-b3c6-412b-beb5-d0f10c86aca7" />

Before:

<img width="1209" height="264" alt="Screenshot 2026-06-09 at 11 25 00" src="https://github.com/user-attachments/assets/fd05689a-fdd4-46df-88ab-af7dba61c1b9" />

After: 

<img width="1074" height="252" alt="Screenshot 2026-06-09 at 11 28 35" src="https://github.com/user-attachments/assets/7d4caae0-6467-437a-985b-776213cc0d84" />


## Related issue

[asana](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1214996585128603?focus=true)

## Requirements, dependencies and related PRs

Describe or link possible requirements, dependencies and related PRs here

## Additional Notes

Change history block for Indicator pages is rendered automatically when the change log feature is enabled and does not currently have corresponding configurable label/help text fields in Admin.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [fix] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [ ] **New strings are translatable** (all user-facing text uses i18n)
- [ ] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [ ] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
