### PR TITLE
Add block spacing css vars and update components

### DIFF
--- a/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/ContentPage.tsx
+++ b/src/app/root/[domain]/[lang]/[plan]/(with-layout-elements)/[...slug]/ContentPage.tsx
@@ -153,6 +153,9 @@ export default function ContentPage({ page, testId }: { page: GeneralPlanPage; t
     page.body[0]?.blockType &&
     streamFieldBlockTypesThatHavePageHeader.includes(page.body[0]?.blockType);
 
+  const hasPageHeader =
+    typenameMatches(page, 'CategoryPage', 'StaticPage') && !pageHeaderinStreamField;
+
   const categoryColor = isCategoryPage && (page.category?.color || page.category?.parent?.color);
   const pageSectionColor = categoryColor || theme.themeColors.light;
   const pageBodyHasBlocks = isPageWithBody && (page.body?.length ?? 0) > 0;
@@ -186,7 +189,11 @@ export default function ContentPage({ page, testId }: { page: GeneralPlanPage; t
       ) : null}
 
       {isCategoryPage ? (
-        <CategoryPageContent page={page} pageSectionColor={pageSectionColor} />
+        <CategoryPageContent
+          page={page}
+          pageSectionColor={pageSectionColor}
+          precedingBlockHasBackground={hasPageHeader}
+        />
       ) : (
         <div>
           {typenameMatches(page, 'ActionListPage') && <ActionListPage actionListPage={page} />}
@@ -213,7 +220,12 @@ export default function ContentPage({ page, testId }: { page: GeneralPlanPage; t
           ) : null}
 
           {isPageWithBody && page.body && pageBodyHasBlocks && (
-            <StreamField page={page} blocks={page.body} hasSidebar={siblings.length > 1} />
+            <StreamField
+              page={page}
+              blocks={page.body}
+              hasSidebar={siblings.length > 1}
+              precedingBlockHasBackground={hasPageHeader}
+            />
           )}
         </div>
       )}

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -5222,14 +5222,14 @@ type StreamFieldFragment_W2zOgck3SpPtZi5A5saJLpenH2ogwhIsYhGosbJ8c_Fragment = (
   & { __typename: 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' }
 );
 
-type StreamFieldFragment_KTz1TgIjno5h7oJvKjoqnZxozYxzJxRk5jUApXzq_Fragment = (
+type StreamFieldFragment_VYbmLMfvNTozDKqhT2uRZfvFr2YqqIpSjZhK6dLkxe_Fragment = (
   { id: string | null, blockType: string, field: string }
-  & { __typename: 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
+  & { __typename: 'IndicatorListColumn' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' }
 );
 
-type StreamFieldFragment_ROQtCmpbhpHtWju3UmvLJiPdRdNespIkDrUlcLsw8s_Fragment = (
+type StreamFieldFragment_Ys4HYkQAlXwzZQnj9p7hTlYcZtqFBmul0FyeNgEuCf8_Fragment = (
   { id: string | null, blockType: string, field: string }
-  & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+  & { __typename: 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
 );
 
 type StreamFieldFragment_AccessibilityStatementContactInformationBlock_Fragment = (
@@ -8777,13 +8777,13 @@ export type GetActionDetailsQuery = (
           & { __typename: 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' }
+          & { __typename: 'IndicatorBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' }
+          & { __typename: 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+          & { __typename: 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
         ) | (
           { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
             { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
@@ -9509,13 +9509,13 @@ export type GetActionDetailsQuery = (
           & { __typename: 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' }
+          & { __typename: 'IndicatorBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' }
+          & { __typename: 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+          & { __typename: 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
         ) | (
           { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
             { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
@@ -10932,13 +10932,13 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
     & { __typename: 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' }
   ) | (
     { id: string | null }
-    & { __typename: 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' }
+    & { __typename: 'IndicatorBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' }
   ) | (
     { id: string | null }
-    & { __typename: 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' }
+    & { __typename: 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' }
   ) | (
     { id: string | null }
-    & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+    & { __typename: 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
   ) | (
     { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
       { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(

--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -5222,14 +5222,14 @@ type StreamFieldFragment_W2zOgck3SpPtZi5A5saJLpenH2ogwhIsYhGosbJ8c_Fragment = (
   & { __typename: 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' }
 );
 
-type StreamFieldFragment_VYbmLMfvNTozDKqhT2uRZfvFr2YqqIpSjZhK6dLkxe_Fragment = (
+type StreamFieldFragment_KTz1TgIjno5h7oJvKjoqnZxozYxzJxRk5jUApXzq_Fragment = (
   { id: string | null, blockType: string, field: string }
-  & { __typename: 'IndicatorListColumn' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' }
+  & { __typename: 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportComparisonBlock' | 'ReportTypeFieldChooserBlock' }
 );
 
-type StreamFieldFragment_Ys4HYkQAlXwzZQnj9p7hTlYcZtqFBmul0FyeNgEuCf8_Fragment = (
+type StreamFieldFragment_ROQtCmpbhpHtWju3UmvLJiPdRdNespIkDrUlcLsw8s_Fragment = (
   { id: string | null, blockType: string, field: string }
-  & { __typename: 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+  & { __typename: 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
 );
 
 type StreamFieldFragment_AccessibilityStatementContactInformationBlock_Fragment = (
@@ -8777,13 +8777,13 @@ export type GetActionDetailsQuery = (
           & { __typename: 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'IndicatorBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' }
+          & { __typename: 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' }
+          & { __typename: 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+          & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
         ) | (
           { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
             { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
@@ -9509,13 +9509,13 @@ export type GetActionDetailsQuery = (
           & { __typename: 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'IndicatorBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' }
+          & { __typename: 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' }
+          & { __typename: 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' }
         ) | (
           { id: string | null }
-          & { __typename: 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+          & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
         ) | (
           { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
             { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(
@@ -10932,13 +10932,13 @@ type ActionMainContentBlocksFragment_ActionContentSectionBlock_Fragment = (
     & { __typename: 'DashboardParagraphBlock' | 'DashboardRowBlock' | 'DateBlock' | 'DateTimeBlock' | 'DecimalBlock' | 'DocumentChooserBlock' | 'EmailBlock' | 'EmbedBlock' | 'EndDateColumnBlock' | 'FieldColumnBlock' | 'FloatBlock' | 'FormChoiceBlock' | 'FormFieldBlock' | 'FrontPageHeroAdditionalSettingsBlock' | 'FrontPageHeroBlock' | 'IdentifierColumnBlock' | 'ImageBlock' | 'ImageChooserBlock' | 'ImplementationPhaseColumnBlock' | 'IndicatorBlock' }
   ) | (
     { id: string | null }
-    & { __typename: 'IndicatorBlock' | 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' }
+    & { __typename: 'IndicatorCategoryColumn' | 'IndicatorCategoryContentBlock' | 'IndicatorCausalChainBlock' | 'IndicatorContentBlock' | 'IndicatorFactorValueSummaryContentBlock' | 'IndicatorFilterBlock' | 'IndicatorGroupBlock' | 'IndicatorHighlightsBlock' | 'IndicatorListColumn' | 'IndicatorShowcaseBlock' | 'IndicatorValueColumn' | 'IndicatorValueSummaryContentBlock' | 'IndicatorVisualizationContentBlock' | 'IndicatorsColumnBlock' | 'IntegerBlock' | 'LargeImageBlock' | 'NameColumnBlock' | 'OrganizationColumnBlock' | 'PageChooserBlock' | 'PageLinkBlock' }
   ) | (
     { id: string | null }
-    & { __typename: 'PageLinkBlock' | 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' }
+    & { __typename: 'PathsNodeSummaryBlock' | 'PathsOutcomeBlock' | 'PlanDatasetsBlock' | 'PlanFilterBlock' | 'PrimaryOrganizationFilterBlock' | 'QuestionAnswerBlock' | 'QuestionBlock' | 'RawHTMLBlock' | 'RegexBlock' | 'RelatedIndicatorsBlock' | 'RelatedPlanListBlock' | 'ReportTypeFieldChooserBlock' | 'ResponsiblePartiesColumnBlock' | 'ResponsiblePartyFilterBlock' | 'RichTextBlock' | 'ScheduleContinuousColumnBlock' | 'SnippetChooserBlock' | 'StartDateColumnBlock' | 'StaticBlock' | 'StatusColumnBlock' }
   ) | (
     { id: string | null }
-    & { __typename: 'StatusColumnBlock' | 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
+    & { __typename: 'StreamBlock' | 'StreamFieldBlock' | 'StructBlock' | 'TasksColumnBlock' | 'TextBlock' | 'TimeBlock' | 'URLBlock' | 'UpdatedAtColumnBlock' }
   ) | (
     { id: string | null, heading: string | null, description: string | null, emailVisible: boolean | null, emailRequired: boolean | null, feedbackVisible: boolean | null, feedbackRequired: boolean | null, fields: Array<(
       { id: string | null, fieldLabel: string | null, fieldType: string | null, fieldRequired: boolean | null, choices: Array<(

--- a/src/common/__generated__/paths/graphql.ts
+++ b/src/common/__generated__/paths/graphql.ts
@@ -231,6 +231,8 @@ export type InstanceContext = {
   identifier: InputMaybe<Scalars['ID']['input']>;
   locale: InputMaybe<Scalars['String']['input']>;
   preview: InputMaybe<PreviewMode>;
+  /** Run the model in fault-tolerant mode: quarantine node failures and report them as node status (via the node editor) instead of aborting the whole computation. For draft model editing; defaults to false. See docs/architecture/fault-tolerance.md. */
+  tolerateNodeFailures: Scalars['Boolean']['input'];
   version: InputMaybe<Scalars['UUID']['input']>;
 };
 
@@ -285,11 +287,23 @@ export type NodeConfigInput = {
   simple: InputMaybe<SimpleConfigInput>;
 };
 
+export enum NodeErrorPhase {
+  Computation = 'COMPUTATION',
+  Initialization = 'INITIALIZATION'
+}
+
 export enum NodeKind {
   Action = 'ACTION',
   Formula = 'FORMULA',
   Pipeline = 'PIPELINE',
   Simple = 'SIMPLE'
+}
+
+export enum NodeStatus {
+  Degraded = 'DEGRADED',
+  Failed = 'FAILED',
+  Incomplete = 'INCOMPLETE',
+  Ok = 'OK'
 }
 
 export enum OperationMessageKind {

--- a/src/common/__generated__/paths/possible_types.json
+++ b/src/common/__generated__/paths/possible_types.json
@@ -1,10 +1,18 @@
 {
   "possibleTypes": {
+    "AddInputPortPayload": [
+      "InputPortType",
+      "OperationInfo"
+    ],
     "AddNodeInputPortPayload": [
       "InputPortType",
       "OperationInfo"
     ],
     "AddNodeOutputPortPayload": [
+      "OperationInfo",
+      "OutputPortType"
+    ],
+    "AddOutputPortPayload": [
       "OperationInfo",
       "OutputPortType"
     ],
@@ -180,6 +188,11 @@
       "OperationInfo"
     ],
     "UpdateNodePayload": [
+      "ActionNode",
+      "Node",
+      "OperationInfo"
+    ],
+    "UpdatePayload": [
       "ActionNode",
       "Node",
       "OperationInfo"

--- a/src/components/categories/CategoryPageContent.tsx
+++ b/src/components/categories/CategoryPageContent.tsx
@@ -59,9 +59,11 @@ const ContentArea = styled.div<ContentAreaProps>`
 
 export default function CategoryPageContent({
   page,
+  precedingBlockHasBackground,
 }: {
   page: CategoryPage;
   pageSectionColor: string;
+  precedingBlockHasBackground?: boolean;
 }) {
   const hasMainContentTemplate = !!page.layout?.layoutMainBottom?.length;
 
@@ -72,7 +74,13 @@ export default function CategoryPageContent({
           ? page.layout?.layoutMainBottom?.map((block, i) => (
               <CategoryPageStreamField key={i} page={page} block={block} />
             ))
-          : page.body && <StreamField page={page} blocks={page.body} />}
+          : page.body && (
+              <StreamField
+                page={page}
+                blocks={page.body}
+                precedingBlockHasBackground={precedingBlockHasBackground}
+              />
+            )}
       </MainContent>
     </ContentArea>
   );

--- a/src/components/common/StreamField.tsx
+++ b/src/components/common/StreamField.tsx
@@ -3,6 +3,7 @@ import React, { Suspense, useEffect, useId, useRef } from 'react';
 
 import dynamic from 'next/dynamic';
 
+import type { Theme } from '@emotion/react';
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -14,6 +15,7 @@ import type { ColumnProps } from 'reactstrap/types/lib/Col';
 
 import { showSettingsPanelVar } from '@common/apollo/paths-cache';
 import ContentLoader from '@common/components/ContentLoader';
+import { transientOptions } from '@common/themes/styles/styled';
 
 import type {
   MultiUseImageFragmentFragment,
@@ -170,6 +172,44 @@ const ResponsiveStyles = styled.div`
   }
 `;
 
+function blockHasBackground(block: StreamFieldFragmentFragment, theme: Theme): boolean {
+  switch (block.__typename) {
+    case 'CardListBlock':
+    case 'ActionListBlock':
+    case 'ActionHighlightsBlock':
+    case 'CategoryListBlock':
+    case 'DashboardRowBlock':
+    case 'QuestionAnswerBlock':
+    case 'IndicatorShowcaseBlock':
+    case 'ActionCategoryFilterCardsBlock':
+    case 'CategoryTypeLevelListBlock':
+    case 'RelatedPlanListBlock':
+    case 'FrontPageHeroBlock':
+    case 'RelatedIndicatorsBlock':
+    case 'IndicatorGroupBlock':
+      return true;
+    case 'RichTextBlock':
+      return theme.section.richText.sectionBackground !== theme.themeColors.white;
+    default:
+      return false;
+  }
+}
+
+interface BlockWrapperProps {
+  $hasBackground: boolean;
+  $prevHasBackground: boolean;
+  $isFirst: boolean;
+}
+
+const BlockWrapper = styled('div', transientOptions)<BlockWrapperProps>`
+  margin-top: ${({ $isFirst, $hasBackground, $prevHasBackground }) => {
+    if ($isFirst) return '0';
+    if ($hasBackground && $prevHasBackground) return 'var(--block-gap-coloured)';
+    if ($hasBackground || $prevHasBackground) return '0';
+    return 'var(--block-gap)';
+  }};
+`;
+
 function hasPathsContent(body: StreamFieldFragmentFragment[]) {
   return body.some(
     (block) =>
@@ -177,11 +217,9 @@ function hasPathsContent(body: StreamFieldFragmentFragment[]) {
   );
 }
 
-const RichTextSection = styled.div<{ $topPadding: boolean; $bottomPadding: boolean }>`
-  padding-top: ${(props) =>
-    props.$topPadding ? props.theme.spaces.s400 : props.theme.spaces.s100};
-  padding-bottom: ${(props) =>
-    props.$bottomPadding ? props.theme.spaces.s400 : props.theme.spaces.s100};
+const RichTextSection = styled.div`
+  padding-top: var(--block-padding-top);
+  padding-bottom: var(--block-padding-bottom);
   background-color: ${({ theme }) => theme.section.richText.sectionBackground};
 `;
 
@@ -189,10 +227,14 @@ const RichTextContainer = styled.div`
   display: flex;
   justify-content: center;
   background-color: ${({ theme }) => theme.themeColors.white};
-  padding: ${({ theme }) => theme.spaces.s200};
+  padding: 0 ${({ theme }) => theme.spaces.s200};
 
   > div {
     flex: 0 1 800px;
+
+    > *:first-child {
+      margin-top: 0;
+    }
   }
 `;
 
@@ -277,12 +319,10 @@ type StreamFieldBlockProps = {
   block: StreamFieldFragmentFragment;
   hasSidebar: boolean;
   columnProps?: ColProps;
-  previousBlockType?: string;
-  nextBlockType?: string;
 };
 
 function StreamFieldBlock(props: StreamFieldBlockProps) {
-  const { id, page, block, hasSidebar, columnProps, previousBlockType, nextBlockType } = props;
+  const { id, page, block, hasSidebar, columnProps } = props;
   const { __typename } = block;
   const plan = usePlan();
   const theme = useTheme();
@@ -301,16 +341,7 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
       const COLLAPSIBLE_BREAKPOINT = 1200;
       const isCollapsible = canCollapse && value.length > COLLAPSIBLE_BREAKPOINT;
       return (
-        <RichTextSection
-          $topPadding={
-            previousBlockType !== 'RichTextBlock' &&
-            theme.section.richText.sectionBackground !== theme.themeColors.white
-          }
-          $bottomPadding={
-            nextBlockType !== 'RichTextBlock' &&
-            theme.section.richText.sectionBackground !== theme.themeColors.white
-          }
-        >
+        <RichTextSection>
           <Container id={id}>
             <Row>
               <Col
@@ -645,14 +676,7 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
       );
     }
     case 'DashboardRowBlock': {
-      return (
-        <DashboardRowBlock
-          {...block}
-          id={id}
-          topPadding={previousBlockType !== 'DashboardRowBlock'}
-          bottomPadding={nextBlockType !== 'DashboardRowBlock'}
-        />
-      );
+      return <DashboardRowBlock {...block} id={id} />;
     }
     case 'ChangeLogMessageBlock': {
       if (!plan.features.enableChangeLog) return null;
@@ -708,11 +732,13 @@ interface StreamFieldProps {
   blocks: StreamFieldFragmentFragment[];
   hasSidebar?: boolean;
   columnProps?: ColProps;
+  precedingBlockHasBackground?: boolean;
 }
 
 export default function StreamField(props: StreamFieldProps) {
-  const { page, blocks, hasSidebar = false, columnProps } = props;
+  const { page, blocks, hasSidebar = false, columnProps, precedingBlockHasBackground } = props;
   const t = useTranslations();
+  const theme = useTheme();
 
   const isCategoryPage = page.__typename === 'CategoryPage';
   useEffect(() => {
@@ -728,28 +754,40 @@ export default function StreamField(props: StreamFieldProps) {
 
   return (
     <div className={`custom-${page.slug}`}>
-      {blocks.map((block, index) => (
-        <ErrorBoundary
-          key={block.id}
-          fallback={<ErrorMessage message={t('error-loading-data')} details={block.__typename} />}
-          errorExtras={{
-            type: 'StreamFieldBlock',
-            block: JSON.stringify(block),
-          }}
-        >
-          <Suspense fallback={<ContentLoader message={t('loading')} />}>
-            <StreamFieldBlock
-              id={`section-${index + 1}`}
-              block={block}
-              page={page}
-              hasSidebar={hasSidebar}
-              columnProps={columnProps}
-              previousBlockType={blocks[index - 1]?.__typename}
-              nextBlockType={blocks[index + 1]?.__typename}
-            />
-          </Suspense>
-        </ErrorBoundary>
-      ))}
+      {blocks.map((block, index) => {
+        const hasBackground = blockHasBackground(block, theme);
+        const prevHasBackground =
+          index === 0
+            ? (precedingBlockHasBackground ?? false)
+            : blockHasBackground(blocks[index - 1], theme);
+
+        return (
+          <ErrorBoundary
+            key={block.id}
+            fallback={<ErrorMessage message={t('error-loading-data')} details={block.__typename} />}
+            errorExtras={{
+              type: 'StreamFieldBlock',
+              block: JSON.stringify(block),
+            }}
+          >
+            <Suspense fallback={<ContentLoader message={t('loading')} />}>
+              <BlockWrapper
+                $hasBackground={hasBackground}
+                $prevHasBackground={prevHasBackground}
+                $isFirst={index === 0}
+              >
+                <StreamFieldBlock
+                  id={`section-${index + 1}`}
+                  block={block}
+                  page={page}
+                  hasSidebar={hasSidebar}
+                  columnProps={columnProps}
+                />
+              </BlockWrapper>
+            </Suspense>
+          </ErrorBoundary>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/contentblocks/ActionCategoryFilterCardsBlock.tsx
+++ b/src/components/contentblocks/ActionCategoryFilterCardsBlock.tsx
@@ -2,17 +2,18 @@ import React from 'react';
 
 import { useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+
 import { readableColor } from 'polished';
 import { Col, Container, Row } from 'reactstrap';
 
-import { CommonContentBlockProps } from '@/common/blocks.types';
+import type { CommonContentBlockProps } from '@/common/blocks.types';
 import { getCategoryString } from '@/common/categories';
 import { Link } from '@/common/links';
 import Card from '@/components/common/Card';
 
 const CategoryListSection = styled.div`
   background-color: ${(props) => props.theme.brandDark};
-  padding: ${(props) => props.theme.spaces.s400} 0;
+  padding: var(--block-padding-top) 0 var(--block-padding-bottom);
 
   a.card-wrapper {
     display: flex;
@@ -40,6 +41,11 @@ const CategoryListSection = styled.div`
     font-size: ${(props) => props.theme.fontSizeMd};
     margin-bottom: ${(props) => props.theme.spaces.s300};
   }
+
+  ul {
+    padding: 0;
+    margin-bottom: 0;
+  }
 `;
 
 const CardLead = styled.p`
@@ -65,7 +71,7 @@ const CategoryListBlock = ({ id = '', cards }: Props) => {
   return (
     <CategoryListSection id={id} bg={theme.themeColors.dark}>
       <Container>
-        <Row tag="ul" className="justify-content-center">
+        <Row tag="ul" className="justify-content-center gy-4">
           {cards?.map((card) => (
             <Col
               tag="li"
@@ -73,7 +79,7 @@ const CategoryListBlock = ({ id = '', cards }: Props) => {
               sm="6"
               lg="4"
               key={card.category.id}
-              className="mb-2 d-flex align-items-stretch"
+              className="d-flex align-items-stretch"
               style={{ transition: 'all 0.5s ease' }}
             >
               <Link

--- a/src/components/contentblocks/ActionHighlightsBlock.tsx
+++ b/src/components/contentblocks/ActionHighlightsBlock.tsx
@@ -1,17 +1,16 @@
-import React, { useContext } from 'react';
-
 import styled from '@emotion/styled';
+
 import { readableColor } from 'polished';
 import { Container } from 'reactstrap';
 
-import { CommonContentBlockProps } from '@/common/blocks.types';
+import type { CommonContentBlockProps } from '@/common/blocks.types';
 import ActionHighlightsList from '@/components/actions/ActionHighlightsList';
-import PlanContext, { usePlan } from '@/context/plan';
+import { usePlan } from '@/context/plan';
 
 const ActionsSection = styled.div`
   background-color: ${(props) => props.theme.neutralLight};
   position: relative;
-  padding: ${(props) => props.theme.spaces.s800} 0 ${(props) => props.theme.spaces.s400};
+  padding: var(--block-padding-bottom) 0 var(--block-padding-bottom);
   color: ${(props) =>
     readableColor(
       props.theme.neutralLight,

--- a/src/components/contentblocks/ActionListBlock.tsx
+++ b/src/components/contentblocks/ActionListBlock.tsx
@@ -41,7 +41,7 @@ const GET_ACTION_LIST_FOR_BLOCK = gql`
 
 const ActionListSection = styled.div`
   background-color: ${(props) => props.theme.neutralLight};
-  padding: ${(props) => props.theme.spaces.s400} 0;
+  padding: var(--block-padding-top) 0 var(--block-padding-bottom);
 `;
 
 export const SectionHeader = styled.h2`
@@ -53,7 +53,7 @@ export const SectionHeader = styled.h2`
       props.theme.headingsColor,
       props.theme.themeColors.white
     )};
-  margin-bottom: ${(props) => props.theme.spaces.s300};
+  margin-bottom: var(--block-header-margin-bottom);
   font-size: ${(props) => props.theme.fontSizeLg};
 
   @media (min-width: ${(props) => props.theme.breakpointMd}) {

--- a/src/components/contentblocks/CardListBlock.tsx
+++ b/src/components/contentblocks/CardListBlock.tsx
@@ -10,7 +10,7 @@ import Card from '@/components/common/Card';
 
 const CardListSection = styled.div`
   background-color: ${(props) => props.theme.brandDark};
-  padding: ${(props) => `${props.theme.spaces.s400} 0 ${props.theme.spaces.s100} 0`};
+  padding: var(--block-padding-top) 0 var(--block-padding-bottom) 0;
 
   a.card-wrapper {
     display: flex;
@@ -29,6 +29,7 @@ const CardListSection = styled.div`
 
   ul {
     padding: 0;
+    margin-bottom: 0;
   }
 `;
 
@@ -40,7 +41,7 @@ const SectionHeader = styled.h2`
       props.theme.themeColors.black,
       props.theme.themeColors.white
     )} !important;
-  margin-bottom: ${(props) => props.theme.spaces.s100};
+  margin-bottom: var(--block-header-margin-bottom);
 `;
 
 const Content = styled.p`
@@ -83,16 +84,9 @@ const CardListBlock = (props) => {
       <Container>
         {heading && <SectionHeader>{heading}</SectionHeader>}
         {lead && <Content>{lead}</Content>}
-        <Row tag="ul" className="justify-content-center">
+        <Row tag="ul" className="justify-content-center gy-4">
           {cards?.map((card, inx) => (
-            <Col
-              tag="li"
-              xs="12"
-              sm="6"
-              lg="4"
-              className="mb-5 d-flex align-items-stretch"
-              key={inx}
-            >
+            <Col tag="li" xs="12" sm="6" lg="4" className="d-flex align-items-stretch" key={inx}>
               <a href={card.link} className="card-wrapper">
                 <Card
                   imageUrl={card.image?.rendition && card.image.rendition.src}

--- a/src/components/contentblocks/CategoryListBlock.tsx
+++ b/src/components/contentblocks/CategoryListBlock.tsx
@@ -27,7 +27,7 @@ const getBackgroundColor = (theme: Theme) =>
 
 const CategoryListSection = styled.div`
   background-color: ${({ theme }) => getBackgroundColor(theme)};
-  padding: ${(props) => `${props.theme.spaces.s400} 0 ${props.theme.spaces.s100} 0`};
+  padding: var(--block-padding-top) 0 var(--block-padding-bottom) 0;
   color: ${({ theme }) => getColor(theme)};
 
   @media (min-width: ${(props) => props.theme.breakpointMd}) {
@@ -53,6 +53,7 @@ const CategoryListSection = styled.div`
 
   ul {
     padding: 0;
+    margin-bottom: 0;
   }
 
   .lead-text {
@@ -161,7 +162,7 @@ export default function CategoryListBlock(props: CategoryListBlockProps) {
       <Container>
         {heading ? <CategoryListHeader>{heading}</CategoryListHeader> : null}
         {lead ? <RichText html={lead} className="lead-text" /> : null}
-        <Row tag="ul" className="justify-content-center">
+        <Row tag="ul" className="justify-content-center gy-4">
           {categories
             ?.filter((cat) => cat?.categoryPage?.live)
             .map(
@@ -173,7 +174,7 @@ export default function CategoryListBlock(props: CategoryListBlockProps) {
                     sm="6"
                     lg="4"
                     key={cat.id}
-                    className="mb-5 d-flex align-items-stretch"
+                    className="d-flex align-items-stretch"
                   >
                     <Link href={cat.categoryPage.urlPath} className="card-wrapper">
                       <Card

--- a/src/components/contentblocks/DashboardRowBlock.tsx
+++ b/src/components/contentblocks/DashboardRowBlock.tsx
@@ -48,7 +48,7 @@ const isDashboardHeaderBlock = (
 ): block is DashboardBlock & DashboardHeaderBlock =>
   (block as { __typename?: string }).__typename === 'DashboardHeaderBlock';
 
-const isDashboardCardBlock = (block: DashboardBlock) => !isDashboardHeaderBlock(block);
+const isDashboardCardBlock = (block: DashboardBlock): boolean => !isDashboardHeaderBlock(block);
 
 interface DashboardRowBlockProps extends Omit<DashboardRowBlockFragment, 'rawValue'> {
   blocks: DashboardBlock[];

--- a/src/components/contentblocks/DashboardRowBlock.tsx
+++ b/src/components/contentblocks/DashboardRowBlock.tsx
@@ -10,21 +10,15 @@ import { IndicatorLink } from '@/common/links';
 import IndicatorVisualizationBlock from '@/components/indicators/IndicatorVisualizationBlock';
 
 import Card from '../common/Card';
-
 import { SectionHeader } from './ActionListBlock';
 import { getReadableThemeTextColor } from './colorUtils';
 
-const DashboardRowSection = styled.div<{
-  $topPadding?: boolean;
-  $bottomPadding?: boolean;
-}>`
+const DashboardRowSection = styled.div`
   background-color: ${(props) => props.theme.themeColors.light};
   color: ${(props) => props.theme.neutralDark};
   position: relative;
-  padding-top: ${(props) =>
-    props.$topPadding ? props.theme.spaces.s400 : props.theme.spaces.s100};
-  padding-bottom: ${(props) =>
-    props.$bottomPadding ? props.theme.spaces.s400 : props.theme.spaces.s100};
+  padding-top: var(--block-padding-top);
+  padding-bottom: var(--block-padding-bottom);
 `;
 
 const DashboardSectionHeader = styled(SectionHeader)`
@@ -57,8 +51,6 @@ const isDashboardHeaderBlock = (
 const isDashboardCardBlock = (block: DashboardBlock) => !isDashboardHeaderBlock(block);
 
 interface DashboardRowBlockProps extends Omit<DashboardRowBlockFragment, 'rawValue'> {
-  topPadding?: boolean;
-  bottomPadding?: boolean;
   blocks: DashboardBlock[];
 }
 
@@ -143,12 +135,7 @@ const DashboardCardContents = ({ block }: { block: DashboardBlock }) => {
   );
 };
 
-const DashboardRowBlock = ({
-  id,
-  blocks,
-  topPadding = true,
-  bottomPadding = true,
-}: DashboardRowBlockProps) => {
+const DashboardRowBlock = ({ id, blocks }: DashboardRowBlockProps) => {
   const t = useTranslations();
   const headerBlock = blocks.find(isDashboardHeaderBlock);
   const cardBlocks = blocks.filter(isDashboardCardBlock);
@@ -161,11 +148,7 @@ const DashboardRowBlock = ({
   ];
 
   return (
-    <DashboardRowSection
-      id={id ?? undefined}
-      $topPadding={topPadding}
-      $bottomPadding={bottomPadding}
-    >
+    <DashboardRowSection id={id ?? undefined}>
       <Container>
         {headerBlock?.text ? (
           <DashboardSectionHeader>{headerBlock.text}</DashboardSectionHeader>

--- a/src/components/contentblocks/IndicatorShowcaseBlock.tsx
+++ b/src/components/contentblocks/IndicatorShowcaseBlock.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
-import styled from '@emotion/styled';
 import { Paper } from '@mui/material';
+
+import styled from '@emotion/styled';
+
 import { useTranslations } from 'next-intl';
 import { Alert, Col, Container, Row } from 'reactstrap';
 
@@ -27,7 +29,7 @@ interface IndicatorShowcaseBlockProps {
 }
 
 const IndicatorShowcase = styled.div`
-  padding: ${(props) => props.theme.spaces.s400} 0;
+  padding: var(--block-padding-top) 0 var(--block-padding-bottom);
   background-color: ${({ theme }) => theme.section.indicatorShowcase.background};
   color: ${({ theme }) => theme.section.indicatorShowcase.color};
   text-align: center;

--- a/src/components/contentblocks/QuestionAnswerBlock.tsx
+++ b/src/components/contentblocks/QuestionAnswerBlock.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { type Theme, css } from '@emotion/react';
 import styled from '@emotion/styled';
+
 import { Col, type ColProps, Container, Row } from 'reactstrap';
 
 import Accordion from '@/components/common/Accordion';
@@ -25,7 +26,7 @@ const breakOutStyles = (theme: Theme) => css`
 
 const FaqSection = styled.section<{ $inline?: boolean }>`
   ${({ $inline, theme }) => ($inline ? inlineStyles(theme) : breakOutStyles(theme))};
-  padding: ${(props) => props.theme.spaces.s400} 0;
+  padding: var(--block-padding-top) 0 var(--block-padding-bottom);
 
   h2 {
     margin-bottom: ${(props) => props.theme.spaces.s300};

--- a/src/components/home/HeroFullImage.tsx
+++ b/src/components/home/HeroFullImage.tsx
@@ -78,13 +78,13 @@ const MainCard = styled(HeroCard, transientOptions)<{ $alignment: string }>`
   margin: -2rem auto 0;
 
   @media (min-width: ${(props) => props.theme.breakpointMd}) {
-    margin: 3rem
+    margin: var(--block-padding-top)
       ${(props) => {
         switch (props.$alignment) {
           case 'left':
-            return '0 2rem 0';
+            return '0 var(--block-padding-bottom) 0';
           case 'right':
-            return '0 2rem auto';
+            return '0 var(--block-padding-bottom) auto';
           case 'center':
             return 'auto';
           default:

--- a/src/components/home/HeroSmallImage.tsx
+++ b/src/components/home/HeroSmallImage.tsx
@@ -6,8 +6,6 @@ import { Container } from 'reactstrap';
 
 import { transientOptions } from '@common/themes/styles/styled';
 
-import { transientOptions } from '@common/themes/styles/styled';
-
 import RichText from '@/components/common/RichText';
 
 import { ImageCredit } from '../common/ImageCredit';
@@ -130,37 +128,6 @@ const MainCard = styled(HeroCard)`
 
 const StyledImageCredit = styled(ImageCredit)`
   border-top-right-radius: ${({ theme }) => theme.cardBorderRadius};
-`;
-
-const StyledContainer = styled(Container, transientOptions)<{
-  $backgroundColour?: string | null;
-}>`
-  --image-height: 70vh;
-
-  position: relative;
-  padding-top: ${(props) => props.theme.spaces.s100};
-  margin-bottom: ${(props) => props.theme.spaces.s300};
-
-  @media (min-width: ${(props) => props.theme.breakpointSm}) {
-    padding-top: ${(props) => props.theme.spaces.s300};
-  }
-
-  @media (min-height: 800px) {
-    --image-height: 60vh;
-  }
-
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 100vw;
-    height: calc(var(--image-height) / 2 + 50% + ${({ theme }) => theme.spaces.s150});
-    max-height: calc(100% - ${({ theme }) => theme.spaces.s150});
-    background-color: ${({ $backgroundColour, theme }) => $backgroundColour || theme.neutralLight};
-    z-index: -1;
-  }
 `;
 
 interface HeroSmallImageProps {

--- a/src/components/home/HeroSmallImage.tsx
+++ b/src/components/home/HeroSmallImage.tsx
@@ -18,7 +18,6 @@ const StyledContainer = styled(Container, transientOptions)<{
   $showImageAccent: boolean;
   $fullBackground: boolean | null;
 }>`
-  --block-margin: ${({ theme }) => theme.spaces.s300};
   --accent-bar-height: 0px;
   --image-top-padding: ${({ theme }) => theme.spaces.s100};
   --image-height: 70vh;
@@ -26,9 +25,7 @@ const StyledContainer = styled(Container, transientOptions)<{
   --bg-color: ${({ $backgroundColor, theme }) => $backgroundColor || theme.neutralLight};
 
   position: relative;
-  // TODO: If the previous block and this one are the same colour, this should be collapsed
   padding-top: var(--image-top-padding);
-  margin-bottom: var(--block-margin);
 
   &::before {
     content: '';
@@ -38,7 +35,7 @@ const StyledContainer = styled(Container, transientOptions)<{
     left: 50%;
     transform: translateX(-50%);
     width: 100vw;
-    height: calc(100% + var(--block-margin));
+    height: 100%;
     background-color: var(--bg-color);
     z-index: -1;
   }

--- a/src/components/home/HeroSmallImage.tsx
+++ b/src/components/home/HeroSmallImage.tsx
@@ -6,6 +6,8 @@ import { Container } from 'reactstrap';
 
 import { transientOptions } from '@common/themes/styles/styled';
 
+import { transientOptions } from '@common/themes/styles/styled';
+
 import RichText from '@/components/common/RichText';
 
 import { ImageCredit } from '../common/ImageCredit';
@@ -131,6 +133,37 @@ const MainCard = styled(HeroCard)`
 
 const StyledImageCredit = styled(ImageCredit)`
   border-top-right-radius: ${({ theme }) => theme.cardBorderRadius};
+`;
+
+const StyledContainer = styled(Container, transientOptions)<{
+  $backgroundColour?: string | null;
+}>`
+  --image-height: 70vh;
+
+  position: relative;
+  padding-top: ${(props) => props.theme.spaces.s100};
+  margin-bottom: ${(props) => props.theme.spaces.s300};
+
+  @media (min-width: ${(props) => props.theme.breakpointSm}) {
+    padding-top: ${(props) => props.theme.spaces.s300};
+  }
+
+  @media (min-height: 800px) {
+    --image-height: 60vh;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100vw;
+    height: calc(var(--image-height) / 2 + 50% + ${({ theme }) => theme.spaces.s150});
+    max-height: calc(100% - ${({ theme }) => theme.spaces.s150});
+    background-color: ${({ $backgroundColour, theme }) => $backgroundColour || theme.neutralLight};
+    z-index: -1;
+  }
 `;
 
 interface HeroSmallImageProps {


### PR DESCRIPTION
## Description

Standardise the spacing across all content blocks (eventually) using CSS variables based on the theme. Rather than referencing e.g. `theme.space.s400` a bunch of times, we'd use the CSS variables for consistency and easier visual changes/ refactors.

### Core system

- Adds `--block-gap`, `--block-padding-top/bottom`, `--block-header-margin-bottom` to the root [in the common repo](https://github.com/kausaltech/kausal-ui-common/pull/24)
- Doubles the block padding at larger breakpoints for desktop airiness 
- `BlockWrapper` figures out whether blocks should sit flush or have a gap based on their background colour (currently just a simple switch statement but perhaps we could actually check the background colour here, especially if we update all blocks to support custom background colours). This prevents a white line between some blocks.


### Other updates

- Removes the old `previousBlockType/nextBlockType` conditional padding from `RichTextSection` and `DashboardRowBlock`
- All coloured blocks (`CardListBlock`, `CategoryListBlock`, etc.) migrated from hardcoded `s400` to CSS variables
- `HeroFullImage` content card updated to have equal top and bottom padding
- Some improvements to the spacing of card grids to make vertical/ horizontal gaps equal (still using bootstrap classes, may want to remove them at some point)

## Requirements, dependencies and related PRs

https://github.com/kausaltech/kausal-ui-common/pull/24

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [x] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [x] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
