### PR TITLE
Use plan.name as fallback if plan.shortName is missing

### DIFF
--- a/src/common/__generated__/graphql.ts
+++ b/src/common/__generated__/graphql.ts
@@ -1619,8 +1619,8 @@ export type GetActionListQuery = (
       ) | null }
       & { __typename: 'Organization' }
     ) | null, mergedWith: (
-      { id: string, identifier: string, plan: (
-        { id: string, shortName: string | null, versionName: string, viewUrl: string | null }
+      { id: string, identifier: string, viewUrl: string, plan: (
+        { id: string, shortName: string | null, name: string, versionName: string, viewUrl: string | null }
         & { __typename: 'Plan' }
       ) }
       & { __typename: 'Action' }
@@ -1982,8 +1982,8 @@ export type GetActionListForBlockQuery = (
       ) | null }
       & { __typename: 'Organization' }
     ) | null, mergedWith: (
-      { id: string, identifier: string, plan: (
-        { id: string, shortName: string | null, versionName: string, viewUrl: string | null }
+      { id: string, identifier: string, viewUrl: string, plan: (
+        { id: string, shortName: string | null, name: string, versionName: string, viewUrl: string | null }
         & { __typename: 'Plan' }
       ) }
       & { __typename: 'Action' }
@@ -3585,8 +3585,8 @@ export type ActionCardFragment = (
     ) | null }
     & { __typename: 'Organization' }
   ) | null, mergedWith: (
-    { id: string, identifier: string, plan: (
-      { id: string, shortName: string | null, versionName: string, viewUrl: string | null }
+    { id: string, identifier: string, viewUrl: string, plan: (
+      { id: string, shortName: string | null, name: string, versionName: string, viewUrl: string | null }
       & { __typename: 'Plan' }
     ) }
     & { __typename: 'Action' }
@@ -6961,8 +6961,8 @@ export type GetActionDetailsQuery = (
         ) | null }
         & { __typename: 'Organization' }
       ) | null, mergedWith: (
-        { id: string, identifier: string, plan: (
-          { id: string, shortName: string | null, versionName: string, viewUrl: string | null }
+        { id: string, identifier: string, viewUrl: string, plan: (
+          { id: string, shortName: string | null, name: string, versionName: string, viewUrl: string | null }
           & { __typename: 'Plan' }
         ) }
         & { __typename: 'Action' }
@@ -7243,8 +7243,8 @@ export type GetActionDetailsQuery = (
         ) | null }
         & { __typename: 'Organization' }
       ) | null, mergedWith: (
-        { id: string, identifier: string, plan: (
-          { id: string, shortName: string | null, versionName: string, viewUrl: string | null }
+        { id: string, identifier: string, viewUrl: string, plan: (
+          { id: string, shortName: string | null, name: string, versionName: string, viewUrl: string | null }
           & { __typename: 'Plan' }
         ) }
         & { __typename: 'Action' }
@@ -7519,8 +7519,8 @@ export type GetActionDetailsQuery = (
         ) | null }
         & { __typename: 'Organization' }
       ) | null, mergedWith: (
-        { id: string, identifier: string, plan: (
-          { id: string, shortName: string | null, versionName: string, viewUrl: string | null }
+        { id: string, identifier: string, viewUrl: string, plan: (
+          { id: string, shortName: string | null, name: string, versionName: string, viewUrl: string | null }
           & { __typename: 'Plan' }
         ) }
         & { __typename: 'Action' }
@@ -8441,8 +8441,8 @@ export type GetActionDetailsQuery = (
           ) | null }
           & { __typename: 'Organization' }
         ) | null, mergedWith: (
-          { id: string, identifier: string, plan: (
-            { id: string, shortName: string | null, versionName: string, viewUrl: string | null }
+          { id: string, identifier: string, viewUrl: string, plan: (
+            { id: string, shortName: string | null, name: string, versionName: string, viewUrl: string | null }
             & { __typename: 'Plan' }
           ) }
           & { __typename: 'Action' }
@@ -8720,8 +8720,8 @@ export type GetActionDetailsQuery = (
           ) | null }
           & { __typename: 'Organization' }
         ) | null, mergedWith: (
-          { id: string, identifier: string, plan: (
-            { id: string, shortName: string | null, versionName: string, viewUrl: string | null }
+          { id: string, identifier: string, viewUrl: string, plan: (
+            { id: string, shortName: string | null, name: string, versionName: string, viewUrl: string | null }
             & { __typename: 'Plan' }
           ) }
           & { __typename: 'Action' }
@@ -10536,8 +10536,8 @@ export type ActionDependenciesFragment = (
         ) | null }
         & { __typename: 'Organization' }
       ) | null, mergedWith: (
-        { id: string, identifier: string, plan: (
-          { id: string, shortName: string | null, versionName: string, viewUrl: string | null }
+        { id: string, identifier: string, viewUrl: string, plan: (
+          { id: string, shortName: string | null, name: string, versionName: string, viewUrl: string | null }
           & { __typename: 'Plan' }
         ) }
         & { __typename: 'Action' }
@@ -10815,8 +10815,8 @@ export type ActionDependenciesFragment = (
         ) | null }
         & { __typename: 'Organization' }
       ) | null, mergedWith: (
-        { id: string, identifier: string, plan: (
-          { id: string, shortName: string | null, versionName: string, viewUrl: string | null }
+        { id: string, identifier: string, viewUrl: string, plan: (
+          { id: string, shortName: string | null, name: string, versionName: string, viewUrl: string | null }
           & { __typename: 'Plan' }
         ) }
         & { __typename: 'Action' }
@@ -12212,8 +12212,8 @@ export type ActionCardWithDependencyRoleFragment = (
     ) | null }
     & { __typename: 'Organization' }
   ) | null, mergedWith: (
-    { id: string, identifier: string, plan: (
-      { id: string, shortName: string | null, versionName: string, viewUrl: string | null }
+    { id: string, identifier: string, viewUrl: string, plan: (
+      { id: string, shortName: string | null, name: string, versionName: string, viewUrl: string | null }
       & { __typename: 'Plan' }
     ) }
     & { __typename: 'Action' }

--- a/src/components/actions/ActionCard.tsx
+++ b/src/components/actions/ActionCard.tsx
@@ -2,6 +2,7 @@ import React, { Suspense, useState } from 'react';
 
 import { css, useTheme } from '@emotion/react';
 import styled from '@emotion/styled';
+
 import { captureException } from '@sentry/nextjs';
 import { useTranslations } from 'next-intl';
 import { readableColor, transparentize } from 'polished';
@@ -23,6 +24,7 @@ import { cleanActionStatus } from '@/common/preprocess';
 import PlanChip from '@/components/plans/PlanChip';
 import { usePlan } from '@/context/plan';
 import { ACTION_CARD_FRAGMENT } from '@/fragments/action-card.fragment';
+import { getMergedName } from '@/utils/action.utils';
 
 import Icon from '../common/Icon';
 import { ActionDependenciesBlock } from './blocks/action-dependencies/ActionDependenciesBlock';
@@ -348,11 +350,6 @@ function ActionCard({
     return undefined;
   };
 
-  const getMergedName = (mergedWith, planId) => {
-    if (mergedWith.plan.id !== planId)
-      return `${mergedWith.plan.shortName} ${mergedWith.identifier}`;
-    else return mergedWith.identifier;
-  };
   const primaryRootCategory = action.primaryCategories ? action.primaryCategories[0] : null;
 
   function getidentifierPosition(

--- a/src/fragments/action-card.fragment.ts
+++ b/src/fragments/action-card.fragment.ts
@@ -41,9 +41,11 @@ export const ACTION_CARD_FRAGMENT = gql`
     mergedWith {
       id
       identifier
+      viewUrl
       plan {
         id
         shortName
+        name
         versionName
         viewUrl(clientUrl: $clientUrl)
       }

--- a/src/utils/__tests__/action.utils.test.ts
+++ b/src/utils/__tests__/action.utils.test.ts
@@ -1,0 +1,40 @@
+import { getMergedName } from '@/utils/action.utils';
+
+const otherPlan = (overrides: { shortName?: string | null; name?: string }) => ({
+  identifier: '1',
+  plan: {
+    id: '42',
+    shortName: null,
+    name: 'Other Plan',
+    ...overrides,
+  },
+});
+
+describe('getMergedName', () => {
+  it('returns just the identifier when merged within the same plan', () => {
+    const mergedWith = {
+      identifier: '7',
+      plan: { id: '1', shortName: 'SP', name: 'Same Plan' },
+    };
+
+    expect(getMergedName(mergedWith, '1')).toBe('7');
+  });
+
+  it('prefixes the shortName when merged with an action in another plan', () => {
+    const mergedWith = otherPlan({ shortName: 'OP' });
+
+    expect(getMergedName(mergedWith, '1')).toBe('OP 1');
+  });
+
+  it('falls back to the plan name when the other plan has no shortName', () => {
+    const mergedWith = otherPlan({ shortName: null });
+
+    expect(getMergedName(mergedWith, '1')).toBe('Other Plan 1');
+  });
+
+  it('falls back to the plan name when shortName is an empty string', () => {
+    const mergedWith = otherPlan({ shortName: '' });
+
+    expect(getMergedName(mergedWith, '1')).toBe('Other Plan 1');
+  });
+});

--- a/src/utils/action.utils.ts
+++ b/src/utils/action.utils.ts
@@ -1,0 +1,18 @@
+interface MergedWithLike {
+  identifier: string;
+  plan: {
+    id: string;
+    shortName?: string | null;
+    name?: string | null;
+  };
+}
+
+export function getMergedName(mergedWith: MergedWithLike, planId: string): string {
+  if (mergedWith.plan.id === planId) {
+    return mergedWith.identifier;
+  }
+
+  const planLabel = mergedWith.plan.shortName || mergedWith.plan.name;
+
+  return planLabel ? `${planLabel} ${mergedWith.identifier}` : mergedWith.identifier;
+}


### PR DESCRIPTION
Applies to merged actions if they are from another plan and that plan has no short name.

## Description

Use plan.name as fallback if plan.shortName is missing

## Screenshots/Videos (if applicable)

Before:

<img width="332" height="297" alt="image" src="https://github.com/user-attachments/assets/31d7dc31-74ae-4bb4-98e7-be352a40b21e" />

After:
"null" is replaced with plan name.

## Related issue

https://app.asana.com/1/1201243246741462/project/1210042120863961/task/1215962515384079?focus=true

## Requirements, dependencies and related PRs

-

## Additional Notes

The viewUrl is there to fix a pre-existing type error which now surfaced from baseline due to suffling some types/fields around.

---

## ✅ Pre-Merge Checklist

### Type of Change

- [X] Set the PR's label to match the nature of this change

### Testing

- [ ] **Built E2E tests** (if applicable. E2E tests added/updated)
- [ ] **Mobile screen widths** tested for responsiveness
- [X] **Unit tested**
- [X] **Manually tested locally** (functionality verified)


### Internationalization & Accessibility

- [X] **New strings are translatable** (all user-facing text uses i18n)
- [X] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [X] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
