### PR TITLE
Fix umbrella action category filtering

### DIFF
--- a/src/common/__tests__/categories.test.ts
+++ b/src/common/__tests__/categories.test.ts
@@ -1,0 +1,87 @@
+import { constructCatHierarchy, mapActionCategories } from '@/common/categories';
+
+describe('constructCatHierarchy', () => {
+  it('preserves parent paths when mapping categories to common categories', () => {
+    const categoryTypes: any[] = [
+      {
+        common: {
+          id: 'lpr_aihealue',
+          __typename: 'CommonCategoryType',
+          identifier: 'lpr_aihealue',
+        },
+        categories: [
+          {
+            id: 'local-parent',
+            common: {
+              id: '209',
+              identifier: 'koulutus',
+            },
+            parent: null,
+          },
+          {
+            id: 'local-child',
+            common: {
+              id: '210',
+              identifier: 'luontokasvatus',
+            },
+            parent: {
+              id: 'local-parent',
+              common: {
+                id: '209',
+              },
+            },
+          },
+        ],
+      },
+    ];
+
+    const [categoryType] = constructCatHierarchy<any, any>(categoryTypes, true);
+    const child = categoryType.categories.find((cat: any) => cat.id === '210');
+
+    expect(child?.parent?.id).toBe('209');
+    expect(child?.depth).toBe(1);
+  });
+});
+
+describe('mapActionCategories', () => {
+  it('maps action categories through common categories when explicitly enabled', () => {
+    const categoryTypes: any[] = [
+      {
+        id: 'lpr_aihealue',
+        __typename: 'CommonCategoryType',
+        identifier: 'lpr_aihealue',
+        categories: [
+          {
+            id: '209',
+            identifier: 'koulutus',
+            depth: 0,
+            parent: null,
+            children: [],
+            type: null,
+          },
+        ],
+      },
+    ];
+    categoryTypes[0].categories[0].type = categoryTypes[0];
+
+    const actions: any[] = [
+      {
+        id: '9679',
+        categories: [
+          {
+            id: '6473',
+            common: {
+              id: '209',
+            },
+          },
+        ],
+      },
+    ];
+
+    const mapped = mapActionCategories(actions, categoryTypes, null, 1, true);
+
+    expect(mapped[0].categories).toHaveLength(1);
+    expect(mapped[0].categories[0].id).toBe('209');
+    expect(mapped[0].primaryCategories).toHaveLength(0);
+  });
+});

--- a/src/common/categories.ts
+++ b/src/common/categories.ts
@@ -93,6 +93,9 @@ export interface CategoryMappedAction<
 export interface CategoryMappedActionInput {
   categories: {
     id: string;
+    common?: {
+      id: string;
+    } | null;
   }[];
 }
 
@@ -104,9 +107,9 @@ export function mapActionCategories<
   actions: CategoryMappedActionInput[],
   categoryTypes: CategoryTypeHierarchy<Cat>[],
   primaryRootCT: CT | null = null,
-  depth: number
+  depth: number,
+  useCommonCategories: boolean = (primaryRootCT as any)?.__typename === 'CommonCategoryType'
 ) {
-  const useCommonCategories = primaryRootCT?.__typename === 'CommonCategoryType' ?? false;
   const categories = categoryTypes.map((ct) => ct.categories).flat();
 
   const categoriesById: Map<string, Cat> = new Map(categories.map((c) => [c.id, c]));

--- a/src/components/dashboard/ActionList.tsx
+++ b/src/components/dashboard/ActionList.tsx
@@ -167,6 +167,9 @@ const planFragment = gql`
         name
         parent {
           id
+          common @include(if: $relatedPlanActions) {
+            id
+          }
         }
         ...CommonCategoryFragment @include(if: $relatedPlanActions)
 
@@ -471,13 +474,14 @@ const ActionList = (props: ActionListProps) => {
       includeRelatedPlans
     );
   }, [categoryTypes, includeRelatedPlans]);
-  const primaryActionClassification = includeRelatedPlans
-    ? plan.primaryActionClassification?.common
-    : plan.primaryActionClassification;
-
-  const primaryCatType =
-    primaryActionClassification && 'id' in primaryActionClassification
-      ? cts.find((ct) => ct.id == primaryActionClassification?.id)
+  const primaryCommonIdentifier = plan.primaryActionClassification?.common?.identifier;
+  const primaryCategoryTypeId = plan.primaryActionClassification?.id;
+  const primaryCatType = includeRelatedPlans
+    ? primaryCommonIdentifier
+      ? cts.find((ct) => ct.identifier === primaryCommonIdentifier)
+      : undefined
+    : primaryCategoryTypeId
+      ? cts.find((ct) => ct.id === primaryCategoryTypeId)
       : undefined;
 
   const filterSections: ActionListFilterSection[] = useMemo(() => {
@@ -504,7 +508,7 @@ const ActionList = (props: ActionListProps) => {
     ActionListCategoryType,
     ActionListCategory,
     ActionListAction
-  >(actionsWithRps, cts, primaryCatType, headingHierarchyDepth);
+  >(actionsWithRps, cts, primaryCatType, headingHierarchyDepth, includeRelatedPlans);
   const enabledFilters = filterSections
     .map((section) => section.filters.filter((filter) => activeFilters[filter.id]))
     .flat();


### PR DESCRIPTION
Umbrella action lists need to compare categories through common category IDs, but the frontend only enabled common-category remapping when the primary action classification had a common category type. Plans such as lpr-kestavyys-copy1 use a primary classification without a common mapping, so child-plan local category IDs were compared against common filter option IDs and no actions matched. Pass related-plan mode explicitly into action category mapping, match common primary category types by identifier, and add a regression test for remapping child-plan categories through their common category.

## Related issue

[Slack thread](https://kausaltech.slack.com/archives/C031Z5WMGJ0/p1782459886043429)

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [x] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)

### Internationalization & Accessibility

- [x] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [x] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
