### PR TITLE
Do not pass Watch auth session to Paths data requests

### DIFF
--- a/src/components/providers/ApolloWrapper.tsx
+++ b/src/components/providers/ApolloWrapper.tsx
@@ -25,7 +25,13 @@ import {
   localeMiddleware,
 } from '../../utils/apollo.utils';
 
-const authMiddleware = setContext((_, { sessionToken, headers: initialHeaders = {} }) => {
+const authMiddleware = setContext((_, { uri, sessionToken, headers: initialHeaders = {} }) => {
+  // Operations that override the uri target the Paths API, which uses its own
+  // authentication; the Watch ID token must not be sent there.
+  if (uri) {
+    return { headers: initialHeaders };
+  }
+
   return {
     headers: {
       ...initialHeaders,

--- a/src/queries/paths/get-paths-instance.ts
+++ b/src/queries/paths/get-paths-instance.ts
@@ -4,6 +4,7 @@ import type {
   GetInstanceContextQuery,
   GetInstanceContextQueryVariables,
 } from '@/common/__generated__/paths/graphql';
+import { pathsGqlUrl } from '@/common/environment';
 import { getClient } from '@/utils/apollo-rsc-client';
 import { getHttpHeaders } from '@/utils/paths/paths.utils';
 
@@ -82,8 +83,6 @@ const GET_INSTANCE_CONTEXT = gql`
 
 export default GET_INSTANCE_CONTEXT;
 
-const gqlUrl = 'https://api.paths.kausal.dev/v1/graphql/';
-
 export const getPathsInstance = async (pathsInstance: string) =>
   await (
     await getClient()
@@ -92,7 +91,7 @@ export const getPathsInstance = async (pathsInstance: string) =>
     fetchPolicy: 'no-cache',
     variables: {},
     context: {
-      uri: gqlUrl,
+      uri: pathsGqlUrl,
       headers: getHttpHeaders({ instanceIdentifier: pathsInstance }),
     },
   });

--- a/src/utils/apollo-rsc-client.ts
+++ b/src/utils/apollo-rsc-client.ts
@@ -22,7 +22,13 @@ const rscErrorLink = createErrorLink(() => {
   );
 });
 
-const authMiddleware = setContext(async (_, { headers: initialHeaders = {} }) => {
+const authMiddleware = setContext(async (_, { uri, headers: initialHeaders = {} }) => {
+  // Operations that override the uri target the Paths API, which uses its own
+  // authentication; the Watch ID token must not be sent there.
+  if (uri) {
+    return { headers: initialHeaders };
+  }
+
   const session = await auth();
   const token = session?.idToken;
 


### PR DESCRIPTION
Paths data requests fail when Watch plan is behind auth. 
To fix this, do not pass Watch session to Paths data requests.