### PR TITLE
Fix removed padding around rich text

### DIFF
--- a/src/components/common/RichText.tsx
+++ b/src/components/common/RichText.tsx
@@ -96,6 +96,14 @@ const StyledRichText = styled.div`
     width: 100%;
     height: 100%;
   }
+
+  > *:first-child {
+    margin-top: 0;
+  }
+
+  > *:last-child {
+    margin-bottom: 0;
+  }
 `;
 
 //Fallback collapse based on height. Only used when the safe breakpoint not found.

--- a/src/components/common/StreamField.tsx
+++ b/src/components/common/StreamField.tsx
@@ -227,7 +227,7 @@ const RichTextContainer = styled.div`
   display: flex;
   justify-content: center;
   background-color: ${({ theme }) => theme.themeColors.white};
-  padding: 0 ${({ theme }) => theme.spaces.s200};
+  padding: var(--inner-block-padding-y) var(--inner-block-padding-x);
 
   > div {
     flex: 0 1 800px;

--- a/src/components/home/heroStyles.ts
+++ b/src/components/home/heroStyles.ts
@@ -4,8 +4,7 @@ import { transientOptions } from '@common/themes/styles/styled';
 
 export const HeroCard = styled('div', transientOptions)<{ $cardColor: string }>`
   position: relative;
-  padding: ${(props) =>
-    `${props.theme.spaces.s200} ${props.theme.spaces.s200} ${props.theme.spaces.s100}`};
+  padding: var(--inner-block-padding-y) var(--inner-block-padding-x);
   border-radius: ${(props) => props.theme.cardBorderRadius};
   background-color: ${(props) =>
     props.$cardColor === 'dark' ? props.theme.brandDark : props.theme.cardBackground.primary};


### PR DESCRIPTION
## Description

Fixes a regression introduced with the spacing updates where the vertical padding around rich text was removed. This was visible when rich text blocks (all of which have a white background) were positioned on top of non-white backgrounds.

## Screenshots/Videos (if applicable)
<img width="3024" height="1894" alt="Screenshot 2026-07-02 at 18 19 37" src="https://github.com/user-attachments/assets/9ed2973c-7940-43f8-875e-58415290fa76" />
<img width="3024" height="1896" alt="Screenshot 2026-07-02 at 18 19 17" src="https://github.com/user-attachments/assets/4fc18add-abac-4a49-bd3e-cc20373d18ba" />
