### PR TITLE
Capture more initial errors

### DIFF
--- a/src/app/root/[domain]/[lang]/[plan]/layout.tsx
+++ b/src/app/root/[domain]/[lang]/[plan]/layout.tsx
@@ -103,11 +103,12 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
 
 async function getPathsData(pathsInstance: string) {
   if (pathsInstance) {
-    const result = await tryRequest<GetInstanceContextQuery>(getPathsInstance(pathsInstance));
+    // Errors thrown by the query are captured to Sentry by tryRequest
+    const result = await tryRequest<GetInstanceContextQuery>(getPathsInstance(pathsInstance), {
+      pathsInstance,
+      context: 'getPathsData',
+    });
     if ('error' in result && result.error) {
-      captureException(result.error, {
-        extra: { pathsInstance, context: 'getPathsData' },
-      });
       return undefined;
     }
     const { data: pathsData, errors } = result as ApolloQueryResult<GetInstanceContextQuery>;
@@ -133,9 +134,18 @@ export default async function PlanLayout(props: Props) {
   Sentry.getIsolationScope().setTags({ 'plan.identifier': plan, 'plan.domain': domain });
   const cookieStore = await cookies();
   const origin = await getRequestOrigin();
-  const { data: planData } = await tryRequest(getPlan(domain, plan, origin));
+  const planResult = await tryRequest(getPlan(domain, plan, origin));
+  const planData = planResult.data;
 
   if (!planData?.plan) {
+    // The middleware resolved this plan for the hostname moments ago, so a
+    // missing plan here is a backend inconsistency rather than a bad URL.
+    // Query errors are already captured to Sentry by tryRequest.
+    if (!('error' in planResult) || !planResult.error) {
+      captureException(new Error(`GetPlanContext returned no plan before 404`), {
+        extra: { domain, plan, context: 'PlanLayout' },
+      });
+    }
     notFound();
   }
 

--- a/src/utils/api.utils.ts
+++ b/src/utils/api.utils.ts
@@ -1,4 +1,5 @@
 import type { ApolloClient } from '@apollo/client';
+import { captureException } from '@sentry/nextjs';
 
 type FailedRequest = {
   error: Error;
@@ -7,23 +8,26 @@ type FailedRequest = {
 
 /**
  * Simple wrapper to wrap queries in a try/catch block and return errors
- * which conform with Apollo query response.
+ * which conform with Apollo query response. Thrown errors are captured to
+ * Sentry, since callers typically convert failures into a 404 and would
+ * otherwise leave no trace of the underlying error.
  */
 export async function tryRequest<T>(
-  request: Promise<ApolloClient.QueryResult<T>>
+  request: Promise<ApolloClient.QueryResult<T>>,
+  errorContext?: Record<string, unknown>
 ): Promise<ApolloClient.QueryResult<T> | FailedRequest> {
   try {
     const response = await request;
 
     return response;
   } catch (error: unknown) {
-    if (error instanceof Error) {
-      return { error, data: undefined };
-    }
+    const wrappedError =
+      error instanceof Error
+        ? error
+        : new Error(typeof error === 'string' ? error : 'Unknown error occurred');
 
-    return {
-      error: new Error(typeof error === 'string' ? error : 'Unknown error occurred'),
-      data: undefined,
-    };
+    captureException(wrappedError, errorContext ? { extra: errorContext } : undefined);
+
+    return { error: wrappedError, data: undefined };
   }
 }


### PR DESCRIPTION
Make sure the errors on initial server side requests are captured on Sentry