### PR TITLE
Fix RangeError from maximumFractionDigits: 100 in ActionAttribute

### DIFF
--- a/src/components/common/ActionAttribute.tsx
+++ b/src/components/common/ActionAttribute.tsx
@@ -1,6 +1,7 @@
 import React, { type ReactElement } from 'react';
 
 import styled from '@emotion/styled';
+
 import { readableColor } from 'polished';
 
 import { transientOptions } from '@common/themes/styles/styled';
@@ -136,7 +137,7 @@ type AttributeContentNestedTypeProps = {
 };
 
 const ActionAttribute = (props: AttributeContentProps | AttributeContentNestedTypeProps) => {
-  const formatNumber = useNumberFormatter({ maximumFractionDigits: 100 });
+  const formatNumber = useNumberFormatter({ maximumFractionDigits: 20 });
   const { attribute, attributeType, fontSize, notitle = false, variant = 'default' } = props;
   const type = attributeType ?? attribute.type;
   const isMinimized = variant === 'minimized';


### PR DESCRIPTION
ActionAttribute requested maximumFractionDigits: 100, which older JS engines reject with a RangeError (crashing the render for affected users). Pass 20 instead, and bump kausal_common to the commit that caps the value centrally in makeFormatter.

Fixes Sentry WATCH-UI-7MP, WATCH-UI-CGR.

Depends on https://github.com/kausaltech/kausal-ui-common/pull/28