### PR TITLE
Fix hydration mismatches from unpinned time rendering

### DIFF
--- a/src/app/root/[domain]/[lang]/[plan]/layout.tsx
+++ b/src/app/root/[domain]/[lang]/[plan]/layout.tsx
@@ -22,6 +22,7 @@ import GlobalIndicatorModalWrapper from '@/components/indicators/GlobalIndicator
 import PathsProvider from '@/components/providers/PathsProvider';
 import PlanProvider from '@/components/providers/PlanProvider';
 import ThemeProvider from '@/components/providers/ThemeProvider';
+import TimeZoneProvider from '@/components/providers/TimeZoneProvider';
 import { SELECTED_WORKFLOW_COOKIE_KEY } from '@/constants/workflow';
 import { PrintProvider } from '@/context/print';
 import { WorkflowProvider } from '@/context/workflow-selector';
@@ -162,22 +163,24 @@ export default async function PlanLayout(props: Props) {
       )}
 
       {!!matomoAnalyticsUrl && <MatomoAnalytics matomoAnalyticsUrl={matomoAnalyticsUrl} />}
-      <ThemeProvider theme={theme}>
-        <ThemedGlobalStyles />
-        <SharedIcons />
-        {theme.introModal?.videoUrls && <IntroModal videoUrls={theme.introModal.videoUrls} />}
-        <PlanProvider plan={planData.plan}>
-          <GlobalIndicatorModalWrapper />
-          <PathsProvider instance={pathsData}>
-            <WorkflowProvider
-              initialWorkflow={selectedWorkflow?.value as WorkflowState | undefined}
-              workflowStates={planData.workflowStates}
-            >
-              <PrintProvider>{children}</PrintProvider>
-            </WorkflowProvider>
-          </PathsProvider>
-        </PlanProvider>
-      </ThemeProvider>
+      <TimeZoneProvider locale={params.lang} timeZone={planData.plan.timezone}>
+        <ThemeProvider theme={theme}>
+          <ThemedGlobalStyles />
+          <SharedIcons />
+          {theme.introModal?.videoUrls && <IntroModal videoUrls={theme.introModal.videoUrls} />}
+          <PlanProvider plan={planData.plan}>
+            <GlobalIndicatorModalWrapper />
+            <PathsProvider instance={pathsData}>
+              <WorkflowProvider
+                initialWorkflow={selectedWorkflow?.value as WorkflowState | undefined}
+                workflowStates={planData.workflowStates}
+              >
+                <PrintProvider>{children}</PrintProvider>
+              </WorkflowProvider>
+            </PathsProvider>
+          </PlanProvider>
+        </ThemeProvider>
+      </TimeZoneProvider>
     </>
   );
 }

--- a/src/common/dayjs.ts
+++ b/src/common/dayjs.ts
@@ -18,12 +18,17 @@ import 'dayjs/locale/sv-fi';
 import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 
 dayjs.extend(isSameOrAfter);
 dayjs.extend(localizedFormat);
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
+// `timezone` (depends on `utc`) lets us format dates in the plan's time zone so
+// that the server and client agree, avoiding hydration mismatches for users
+// whose local zone differs from the server's.
+dayjs.extend(timezone);
 
 export function DayjsLocaleProvider({ locale, children }: { locale: string; children: ReactNode }) {
   dayjs.locale(locale);

--- a/src/components/common/ChangeHistory.tsx
+++ b/src/components/common/ChangeHistory.tsx
@@ -8,6 +8,7 @@ import { useTranslations } from 'next-intl';
 
 import dayjs from '@/common/dayjs';
 import Icon from '@/components/common/Icon';
+import { usePlan } from '@/context/plan';
 
 export type EntityType = 'action' | 'indicator' | 'page';
 
@@ -157,10 +158,12 @@ const ChangeHistory: React.FC<ChangeHistoryProps> = ({
   fieldHelpText,
 }) => {
   const t = useTranslations();
+  const plan = usePlan();
   const [isOpen, setIsOpen] = useState(false);
   if (!entry) return null;
 
-  const formattedDate = dayjs(entry.updatedAt).format('L');
+  // Format in the plan's time zone so the server and client agree.
+  const formattedDate = dayjs(entry.updatedAt).tz(plan.timezone).format('L');
 
   const modalTitle = fieldLabel?.trim() || t('change-history.modal-title');
   const descriptionLabel = fieldHelpText?.trim() || t('change-history.description-label');

--- a/src/components/common/GlobalNav.tsx
+++ b/src/components/common/GlobalNav.tsx
@@ -24,7 +24,6 @@ import {
 import { transientOptions } from '@common/themes/styles/styled';
 import { getThemeStaticURL } from '@common/themes/theme';
 
-import { isServer } from '@/common/environment';
 import { Link, NavigationLink } from '@/common/links';
 import PlanSelector from '@/components/plans/PlanSelector';
 import PlanVersionSelector from '@/components/versioning/PlanVersionSelector';
@@ -518,7 +517,11 @@ const getIsPrimaryNavSticky = (theme: Theme, width: number) => width < parseInt(
 const useStickyNavigation = (isStickyEnabled: boolean = false) => {
   const primaryNavRef = useRef<HTMLDivElement>(null);
   const secondaryNavRef = useRef<HTMLDivElement>(null);
-  const [width, setWidth] = useState(!isServer ? window.innerWidth : 0);
+  // Start at 0 on both server and client to keep the first client render
+  // identical to the SSR output; the real width is set in the effect below
+  // after mount. Reading `window.innerWidth` in the initializer would diverge
+  // between server and client and cause a hydration mismatch.
+  const [width, setWidth] = useState(0);
   const [isNavFixed, setIsNavFixed] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [navHeight, setNavHeight] = useState<number>();
@@ -527,6 +530,9 @@ const useStickyNavigation = (isStickyEnabled: boolean = false) => {
   const isPrimaryNavSticky = getIsPrimaryNavSticky(theme, width);
 
   useEffect(() => {
+    // Capture the real viewport width after mount (see the `width` initializer).
+    setWidth(window.innerWidth);
+
     if (!isStickyEnabled) {
       return;
     }

--- a/src/components/dashboard/cells/DateCell.tsx
+++ b/src/components/dashboard/cells/DateCell.tsx
@@ -15,6 +15,10 @@ const Wrapper = styled.span`
 `;
 
 const DateCell = ({ date }: Props) => {
+  // These are date-only calendar values (an action's start/end date), which
+  // have no time zone. Formatting them directly is deterministic across the
+  // server and client; applying `.tz()` here would instead re-parse the date
+  // in the local zone first and could shift it by a day, causing a mismatch.
   const formattedDate = date ? dayjs(date).format('L') : null;
   return <Wrapper>{formattedDate}</Wrapper>;
 };

--- a/src/components/dashboard/cells/UpdatedAtCell.tsx
+++ b/src/components/dashboard/cells/UpdatedAtCell.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
 import styled from '@emotion/styled';
 
 import dayjs from '@/common/dayjs';
@@ -17,13 +21,28 @@ const Wrapper = styled.div`
   padding: ${(props) => props.theme.spaces.s050};
 `;
 
-// `fromNow()` is computed relative to the current time, so the value produced
-// during SSR can differ from the one produced at hydration (the clocks differ
-// by the render-to-hydrate gap, and can straddle a rounding boundary).
-// `suppressHydrationWarning` tells React to accept this expected text
-// difference instead of reporting a hydration error.
-const UpdatedAtCell = ({ action }: Props) => (
-  <Wrapper suppressHydrationWarning>{dayjs(action.updatedAt).fromNow(false)}</Wrapper>
-);
+// Keep the relative timestamp reasonably current without a per-second timer.
+const REFRESH_INTERVAL_MS = 60 * 1000;
+
+const UpdatedAtCell = ({ action }: Props) => {
+  // `fromNow()` is computed relative to the current time, so the value produced
+  // during SSR can differ from the one produced at hydration (the clocks differ
+  // by the render-to-hydrate gap, and can straddle a rounding boundary). We seed
+  // state with the value for the current render — `suppressHydrationWarning`
+  // tells React to accept the server text instead of reporting a hydration
+  // error — and then recompute after mount so any stale server value is
+  // reconciled to the client's clock. Without this, `suppressHydrationWarning`
+  // would leave the server-rendered text in place indefinitely.
+  const [relative, setRelative] = useState(() => dayjs(action.updatedAt).fromNow(false));
+
+  useEffect(() => {
+    const update = () => setRelative(dayjs(action.updatedAt).fromNow(false));
+    update();
+    const id = setInterval(update, REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [action.updatedAt]);
+
+  return <Wrapper suppressHydrationWarning>{relative}</Wrapper>;
+};
 
 export default UpdatedAtCell;

--- a/src/components/dashboard/cells/UpdatedAtCell.tsx
+++ b/src/components/dashboard/cells/UpdatedAtCell.tsx
@@ -17,8 +17,13 @@ const Wrapper = styled.div`
   padding: ${(props) => props.theme.spaces.s050};
 `;
 
+// `fromNow()` is computed relative to the current time, so the value produced
+// during SSR can differ from the one produced at hydration (the clocks differ
+// by the render-to-hydrate gap, and can straddle a rounding boundary).
+// `suppressHydrationWarning` tells React to accept this expected text
+// difference instead of reporting a hydration error.
 const UpdatedAtCell = ({ action }: Props) => (
-  <Wrapper>{dayjs(action.updatedAt).fromNow(false)}</Wrapper>
+  <Wrapper suppressHydrationWarning>{dayjs(action.updatedAt).fromNow(false)}</Wrapper>
 );
 
 export default UpdatedAtCell;

--- a/src/components/providers/TimeZoneProvider.tsx
+++ b/src/components/providers/TimeZoneProvider.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { NextIntlClientProvider } from 'next-intl';
+
+type Props = {
+  locale: string;
+  timeZone: string;
+  children: ReactNode;
+};
+
+/**
+ * Pins next-intl date/number formatting to the plan's time zone.
+ *
+ * Without an explicit time zone, next-intl formats using the server's zone
+ * during SSR and the browser's zone on the client, which causes hydration
+ * mismatches for users outside the server's zone. The plan's time zone is only
+ * known below the root layout, so we override it here.
+ *
+ * This is a Client Component on purpose: it renders the client variant of
+ * `NextIntlClientProvider`, which inherits `messages`/`formats` from the parent
+ * provider's context instead of re-serializing the whole message payload into
+ * the response (which the Server Component variant would do).
+ */
+export default function TimeZoneProvider({ locale, timeZone, children }: Props) {
+  return (
+    <NextIntlClientProvider locale={locale} timeZone={timeZone}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}


### PR DESCRIPTION
Hydration errors were firing across many tenants and page types (WATCH-UI-3Q6), because time was rendered during SSR in ways the client couldn't reproduce:

- Relative time (`dayjs(...).fromNow()`) depends on the current time, so the value computed at SSR could differ from the one at hydration. This drove the bulk of the occurrences via the actions-list "updated at" cell.
- No global time zone was configured, so next-intl and dayjs formatted timestamps in the server's zone during SSR and the browser's zone on the client, mismatching for users outside the server's zone.

Changes:
- Add a `TimeZoneProvider` client wrapper that pins next-intl's `timeZone` to the plan's zone. It renders the client variant of NextIntlClientProvider so it inherits messages/formats from the parent instead of re-serializing them.
- Format the ChangeHistory timestamp in the plan's time zone (it's an absolute instant, so `.tz()` is deterministic across the server and client).
- Load the dayjs `timezone` plugin.
- Suppress the hydration warning on the relative-time UpdatedAtCell (the text difference is expected and unavoidable).
- Stop reading `window.innerWidth` in a render-time useState initializer in GlobalNav; initialize to 0 and set the real width in the existing effect.

Note: DateCell renders date-only calendar values (action start/end dates), which have no time zone. Those are formatted directly with `dayjs(date).format('L')`, which is already deterministic across environments; applying `.tz()` there would re-parse in the local zone and could shift the day.

Fixes WATCH-UI-3Q6