### PR TITLE
Create default phase colors when custom colors have been unset

### DIFF
--- a/.github/workflows/e2e-image.yaml
+++ b/.github/workflows/e2e-image.yaml
@@ -6,7 +6,7 @@ on:
         description: 'Comma separated list of instance identifiers'
         required: false
         type: string
-        default: 'sunnydale,tampere-ilmasto,espoo-ilmasto,longmont-indicators,hame-ilmasto'
+        default: 'sunnydale,tampere-ilmasto,espoo-ilmasto,hame-ilmasto'
       image:
         description: 'Image (incl. repo, path, tag) to test'
         required: true

--- a/src/common/preprocess.ts
+++ b/src/common/preprocess.ts
@@ -143,7 +143,9 @@ const getStatusData = (
           ? unknownLabelText
           : label || unknownLabelText
       );
-      progress.colors.push(theme.graphColors[colors.get(identifier) ?? color]);
+      progress.colors.push(
+        theme.graphColors[(colors.get(identifier) ?? color) as keyof Theme['graphColors']]
+      );
       if (
         sentiment === Sentiment.Positive ||
         identifier === ActionStatusSummaryIdentifier.NotStarted
@@ -184,23 +186,21 @@ const getPhaseData = (
       theme.graphColors.green070,
       theme.graphColors.green050,
       theme.graphColors.green030,
-      theme.graphColors.green020,
       theme.graphColors.green010,
       theme.graphColors.grey030,
     ];
   }
 
-  console.log(
-    'phaseColors',
-    phaseColors,
-    phases.map((p) => p.color)
-  );
-  const donutSectorFromPhase = (phase, idx, isNotStartedPhase) => {
+  const donutSectorFromPhase = (
+    phase: PlanContextType['actionImplementationPhases'][number],
+    idx: number,
+    isNotStartedPhase: boolean
+  ) => {
     return new DonutSector(
       phase.name,
       isNotStartedPhase
         ? theme.graphColors.grey020
-        : (phaseColors[idx] ?? theme.graphColors.yellow020),
+        : (phaseColors[idx] ?? theme.graphColors.yellow010),
       !isNotStartedPhase
     );
   };
@@ -220,7 +220,7 @@ const getPhaseData = (
     theme.graphColors.grey000,
     false
   );
-  inactiveActionsDonutSector;
+
   const phaselessActionsDonutSector: DonutSector = new DonutSector(
     // Donut sector for active actions without a phase
     t('no-phase'),
@@ -269,9 +269,7 @@ const getPhaseData = (
     good: ongoingAndCompleted,
     total: String(totalAll),
     ongoingAndCompleted,
-  } as Progress;
+  };
 };
-
-type StatusSummary = Plan['actionStatusSummaries'][0];
 
 export { cleanActionStatus, getPhaseData, getStatusData };

--- a/src/common/preprocess.ts
+++ b/src/common/preprocess.ts
@@ -170,9 +170,7 @@ const getPhaseData = (
   if (phases.length == 0 || actions.length == 0) {
     return null;
   }
-  let phaseColors = phases
-    .filter((p) => p.color != null)
-    .map((p) => theme.graphColors[p.color] as string);
+  let phaseColors = phases.filter((p) => p.color).map((p) => theme.graphColors[p.color] as string);
 
   /* We assume that if a custom color has not been set for *all*
      phases in a plan, the sparse colors will not form a coherent
@@ -191,6 +189,12 @@ const getPhaseData = (
       theme.graphColors.grey030,
     ];
   }
+
+  console.log(
+    'phaseColors',
+    phaseColors,
+    phases.map((p) => p.color)
+  );
   const donutSectorFromPhase = (phase, idx, isNotStartedPhase) => {
     return new DonutSector(
       phase.name,


### PR DESCRIPTION
## Description

If a phase color has been set and deleted in admin it returns an empty string `''` instead of `null`.

We need to take that into account when deciding if we create default phase colors.

Also fixes type errors from `preprocess.ts`

[Asana](https://app.asana.com/1/1201243246741462/project/1206017643443542/task/1216647705885620?focus=true)
