### PR TITLE
Make action cards centre aligned when smaller than a row's width

### DIFF
--- a/src/components/actions/ActionCardList.tsx
+++ b/src/components/actions/ActionCardList.tsx
@@ -44,6 +44,21 @@ const ActionGroup = styled(Row)`
 const ActionGroupList = styled(Row)`
   padding: 0;
 `;
+
+// Centre the cards when there are fewer cards that fit into a row
+// to avoid a center aligned title and a few cards dangling off to the left.
+// Use this rather than justify-content: center; so that the action cards on
+// multiple rows are still left aligned for consistency with the action grid.
+const ActionCol = styled(Col)`
+  &:first-child {
+    margin-left: auto;
+  }
+
+  &:last-child {
+    margin-right: auto;
+  }
+`;
+
 const OTHER_GROUP_ID = 'other';
 
 type ActionGroup<T extends ActionListAction | ActionCardFragment> = {
@@ -176,7 +191,7 @@ function ActionCardList<ActionT extends ActionListAction | ActionCardFragment>({
           <Col xs="12">
             <ActionGroupList tag="ul">
               {group.elements.map((item) => (
-                <Col
+                <ActionCol
                   tag="li"
                   xs="6"
                   sm="4"
@@ -192,7 +207,7 @@ function ActionCardList<ActionT extends ActionListAction | ActionCardFragment>({
                     size="xs"
                     getFullAction={getFullAction}
                   />
-                </Col>
+                </ActionCol>
               ))}
             </ActionGroupList>
           </Col>

--- a/src/components/common/StreamField.tsx
+++ b/src/components/common/StreamField.tsx
@@ -473,8 +473,6 @@ function StreamFieldBlock(props: StreamFieldBlockProps) {
             }
           : undefined;
 
-      console.log('additionalSettings', additionalSettings);
-
       return (
         <FrontPageHeroBlock
           id={id}


### PR DESCRIPTION
## Description

Small visual update to centre align action cards when there are too few to fit in a single row. This caused the cards to sit off to the left which looked odd against the centre aligned title. I used auto margins rather than flex centre aligning so that when on multiple rows, the cards are still left aligned, which is better for readability of these smaller action cards and is consistent with the action page.

## Screenshots/Videos (if applicable)

### Before
<img width="1512" height="631" alt="image" src="https://github.com/user-attachments/assets/d4aaec01-34fe-4b13-9858-f37eec9ddbdd" />

### After
<img width="3024" height="1128" alt="Screenshot 2026-07-22 at 14 51 23" src="https://github.com/user-attachments/assets/236078fe-13c4-46da-99af-4b1e47ffe641" />

<img width="400" alt="Screenshot 2026-07-22 at 14 51 35" src="https://github.com/user-attachments/assets/311ebadb-cf55-4784-8f8a-158573cad5a9" />

## Related issue

[Discussion in Slack](https://kausaltech.slack.com/archives/C029WNCMF0T/p1784547159807709)

---

## ✅ Pre-Merge Checklist

### Type of Change

- [x] Set the PR's label to match the nature of this change

### Testing

- [-] **Built E2E tests** (if applicable. E2E tests added/updated)
- [x] **Mobile screen widths** tested for responsiveness
- [x] **Manually tested locally** (functionality verified)
  ##### Manual testing instructions
  If feature requires manual testing by reviewer, you can provide instructions here.

### Internationalization & Accessibility

- [-] **New strings are translatable** (all user-facing text uses i18n)
- [x] **Accessibility** standards met (WCAG compliance, screen reader support)

### Dependencies

- [x] **Dependencies are merged** (if applicable. If the change depends on other PRs e.g. kausal_common)
