### PR TITLE
Fix center aligned action cards on actions list

### DIFF
--- a/src/components/actions/ActionCardList.tsx
+++ b/src/components/actions/ActionCardList.tsx
@@ -7,6 +7,8 @@ import type { Theme } from '@kausal/themes/types';
 import { useTranslations } from 'next-intl';
 import { Col, Row } from 'reactstrap';
 
+import { transientOptions } from '@common/themes/styles/styled';
+
 import type { ActionCardFragment } from '@/common/__generated__/graphql';
 import type { TFunction } from '@/common/i18n';
 
@@ -49,14 +51,19 @@ const ActionGroupList = styled(Row)`
 // to avoid a center aligned title and a few cards dangling off to the left.
 // Use this rather than justify-content: center; so that the action cards on
 // multiple rows are still left aligned for consistency with the action grid.
-const ActionCol = styled(Col)`
-  &:first-child {
-    margin-left: auto;
-  }
+const ActionCol = styled(Col, transientOptions)<{ $centerAlignOnSingleRow: boolean }>`
+  ${({ $centerAlignOnSingleRow }) =>
+    $centerAlignOnSingleRow
+      ? `
+        &:first-child {
+          margin-left: auto;
+        }
 
-  &:last-child {
-    margin-right: auto;
-  }
+        &:last-child {
+          margin-right: auto;
+        }
+        `
+      : undefined}
 `;
 
 const OTHER_GROUP_ID = 'other';
@@ -152,6 +159,7 @@ type ActionCardListProps<ActionT extends ActionListAction | ActionCardFragment> 
   includeRelatedPlans: boolean;
   showOtherCategory?: boolean;
   compactTopMargin?: boolean;
+  centerAlignOnSingleRow?: boolean;
 };
 
 function ActionCardList<ActionT extends ActionListAction | ActionCardFragment>({
@@ -161,6 +169,7 @@ function ActionCardList<ActionT extends ActionListAction | ActionCardFragment>({
   includeRelatedPlans,
   showOtherCategory = true,
   compactTopMargin = false,
+  centerAlignOnSingleRow = false,
 }: ActionCardListProps<ActionT>) {
   const theme = useTheme();
   const t = useTranslations();
@@ -200,6 +209,8 @@ function ActionCardList<ActionT extends ActionListAction | ActionCardFragment>({
                   key={item.id}
                   className="mb-4 d-flex align-items-stretch"
                   style={{ transition: 'all 0.5s ease' }}
+                  // When grouped, keep action cards left aligned to align with the group title and hr
+                  $centerAlignOnSingleRow={centerAlignOnSingleRow && groups.length < 2}
                 >
                   <ActionCard
                     action={item as ActionCardFragment}

--- a/src/components/actions/ActionHighlightsList.tsx
+++ b/src/components/actions/ActionHighlightsList.tsx
@@ -124,13 +124,13 @@ export type ActionHighlightListAction = NonNullable<
   NonNullable<ActionHightlightListQuery['planActions']>[number]
 >;
 
-type ActionCardListProps = {
+type ActionHighlightsCardListProps = {
   actions: ActionHighlightListAction[];
   plan: PlanContextFragment;
   displayHeader?: boolean;
 };
 
-function ActionCardList(props: ActionCardListProps) {
+function ActionHighlightsCardList(props: ActionHighlightsCardListProps) {
   const t = useTranslations();
   const { actions, plan, displayHeader } = props;
   // Components which use the EmbedContext support embedding
@@ -204,7 +204,11 @@ function ActionHighlightsList(props: ActionHighlightsListProps) {
     );
 
   return (
-    <ActionCardList actions={data.planActions} plan={plan} displayHeader={displayHeader ?? true} />
+    <ActionHighlightsCardList
+      actions={data.planActions}
+      plan={plan}
+      displayHeader={displayHeader ?? true}
+    />
   );
 }
 

--- a/src/components/contentblocks/ActionListBlock.tsx
+++ b/src/components/contentblocks/ActionListBlock.tsx
@@ -289,6 +289,7 @@ const ActionListBlock = (props: ActionListBlockProps) => {
             includeRelatedPlans={false}
             showOtherCategory={false}
             compactTopMargin={false}
+            centerAlignOnSingleRow
           />
         ) : groups.mode === 'oneLevel' ? (
           <>


### PR DESCRIPTION
## Description

Fixes a regression I introduced in https://github.com/kausaltech/kausal-watch-ui/pull/791. Action cards should remain left aligned on the action list page and when categorised by a group.

## Screenshots/Videos (if applicable)

### Action list page

<img width="3248" height="2112" alt="Screenshot 2026-07-30 at 14 19 48" src="https://github.com/user-attachments/assets/f55c1093-30ae-44be-bf0e-89fd781d3768" />

### Category page

<img width="3248" height="2112" alt="Screenshot 2026-07-30 at 14 19 29" src="https://github.com/user-attachments/assets/54a336f1-4e86-4782-8f8e-8f5e7246193d" />
<img width="3248" height="2112" alt="Screenshot 2026-07-30 at 14 19 19" src="https://github.com/user-attachments/assets/24644bdf-af38-4c25-8207-702ba4287248" />

<img width="3248" height="2112" alt="Screenshot 2026-07-30 at 14 19 39" src="https://github.com/user-attachments/assets/ce79be84-ff5b-43bf-bac7-27d9d3838368" />
